### PR TITLE
Fix LookupEntry overwriting server-side query result

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -156,7 +156,7 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::LookupEntry(CatalogTransaction
 	try {
 		auto bind_response =
 		    rpc_catalog.GetRawClient().MakeRequest<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(
-		        rpc_catalog.GetConnectionId(), StringUtil::Format("FROM %s", lookup_info.GetEntryName()), true));
+		        rpc_catalog.GetConnectionId(), StringUtil::Format("FROM %s", lookup_info.GetEntryName()), false));
 		for (idx_t i = 0; i < bind_response->Types().size(); i++) {
 			create_info.columns.AddColumn(ColumnDefinition(bind_response->Names()[i], bind_response->Types()[i]));
 		}
@@ -171,6 +171,7 @@ TableFunction RpcTableCatalogEntry::GetScanFunction(ClientContext &context, uniq
 	auto bind_data = make_uniq<RpcBindData>();
 	bind_data->uri = rpc_catalog.GetServerString();
 	bind_data->connection_id = rpc_catalog.GetConnectionId();
+	bind_data->table_name = name;
 	bind_data_p = std::move(bind_data);
 	return RpcScanFunction::GetFunction();
 }

--- a/src/include/rpc_bind_data.hpp
+++ b/src/include/rpc_bind_data.hpp
@@ -12,6 +12,7 @@ struct RpcBindData : FunctionData {
 	}
 	string connection_id;
 	string uri;
+	string table_name;
 	optional_idx estimated_cardinality;
 	unique_ptr<RpcClient> initial_client;
 };

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -96,22 +96,17 @@ struct RpcGlobalState : GlobalTableFunctionState {
 };
 
 unique_ptr<GlobalTableFunctionState> RpcInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
-	// auto &bind_data = input.bind_data->Cast<RpcBindData>();
-	// auto num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
-	//
-	// idx_t max_threads = 1;
-	// // small heuristic that scales down the number of threads working on retrieving a result set somewhat gracefully.
-	// if (bind_data.estimated_cardinality.IsValid()) {
-	// 	auto min_chunks_per_thread = 10.0; // TODO make this a parameter
-	// 	auto target_threads =
-	// 	    (bind_data.estimated_cardinality.GetIndex() / STANDARD_VECTOR_SIZE / min_chunks_per_thread) * num_threads;
-	// 	if (target_threads > 1) {
-	// 		max_threads = target_threads;
-	// 	}
-	// 	if (max_threads > num_threads) {
-	// 		max_threads = GlobalTableFunctionState::MAX_THREADS;
-	// 	}
-	// }
+	auto &bind_data = input.bind_data->Cast<RpcBindData>();
+
+	// For the catalog path (ATTACH), LookupEntry only prepares without executing
+	// to avoid the server-side result being overwritten by subsequent lookups.
+	// We execute the query here, right before scanning, so the result is fresh.
+	if (!bind_data.table_name.empty()) {
+		auto client = RpcClient::GetClient(bind_data.uri);
+		client->MakeRequest<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(
+		    bind_data.connection_id, StringUtil::Format("FROM %s", bind_data.table_name), true));
+	}
+
 	return make_uniq<RpcGlobalState>(GlobalTableFunctionState::MAX_THREADS);
 }
 

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -1,0 +1,46 @@
+# name: test/sql/lookup_overwrite.test
+# description: test that multiple LookupEntry calls don't overwrite each other's results
+# group: [sql]
+
+require rpc
+
+foreach server  '__TEST_DIR__/duckdb-rpc-socket-lookup'
+
+statement ok con1
+create table t1 as select range i from range(100);
+
+statement ok con1
+create table t2 as select range j from range(200);
+
+statement ok con1
+call rpc_start(${server});
+
+statement ok con2
+attach ${server} as rpc (TYPE rpc)
+
+# Single table scan should work
+query I
+select count(i) from rpc.main.t1;
+----
+100
+
+query I
+select count(j) from rpc.main.t2;
+----
+200
+
+# Two RPC tables in the same query: both call LookupEntry on the same
+# connection_id during planning. The second PREPARE overwrites the first's
+# server-side query result, so the first table's scan fetches 0 rows.
+query II
+select count(t1.i), count(t2.j) from rpc.main.t1, rpc.main.t2;
+----
+20000	20000
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call rpc_stop(${server});
+
+endloop


### PR DESCRIPTION
## Summary
- LookupEntry used `PREPARE(immediately_execute=true)` during planning, storing the result on the server. Since there's only one result slot per connection, a second LookupEntry (from multi-table queries or the interactive CLI) would overwrite it before the scan could fetch → 0 rows.
- Fix: LookupEntry now only gets schema info (`immediately_execute=false`). Actual execution is deferred to `RpcInitGlobal`, right before scanning.

> I am not 100% sure if RpcInitGlobal is the right place for this, but from looking at the code it seems logical to initialize the execution before RpcInitLocal per thread(?)

## Test plan
- [x] New sqllogictest `test/sql/lookup_overwrite.test` — cross-joins two RPC tables, previously returned 0 rows
- [x] All existing tests pass (`attach.test`, `attach_ctas.test`, `rpc.test`)