### PR TITLE
Feature/pushdown support

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -181,6 +181,10 @@ TableFunction RpcTableCatalogEntry::GetScanFunction(ClientContext &context, uniq
 	bind_data->uri = rpc_catalog.GetServerString();
 	bind_data->connection_id = rpc_catalog.GetConnectionId();
 	bind_data->table_name = name;
+	for (auto &col : GetColumns().Physical()) {
+		bind_data->column_names.push_back(col.Name());
+		bind_data->column_types.push_back(col.Type());
+	}
 	bind_data_p = std::move(bind_data);
 	return RpcScanFunction::GetFunction();
 }

--- a/src/include/rpc_bind_data.hpp
+++ b/src/include/rpc_bind_data.hpp
@@ -15,5 +15,7 @@ struct RpcBindData : FunctionData {
 	string table_name;
 	optional_idx estimated_cardinality;
 	unique_ptr<RpcClient> initial_client;
+	vector<string> column_names;
+	vector<LogicalType> column_types;
 };
 } // namespace duckdb

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -6,6 +6,12 @@
 #include "rpc_bind_data.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/in_filter.hpp"
 
 using namespace duckdb;
 
@@ -106,6 +112,92 @@ struct RpcGlobalState : GlobalTableFunctionState {
 	atomic<bool> done;
 };
 
+static bool CanPushdownFilter(const TableFilter &filter) {
+	switch (filter.filter_type) {
+	case TableFilterType::CONSTANT_COMPARISON:
+	case TableFilterType::IS_NULL:
+	case TableFilterType::IS_NOT_NULL:
+	case TableFilterType::IN_FILTER:
+		return true;
+	case TableFilterType::CONJUNCTION_AND: {
+		auto &conjunction = filter.Cast<ConjunctionAndFilter>();
+		for (auto &child : conjunction.child_filters) {
+			if (!CanPushdownFilter(*child)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	case TableFilterType::CONJUNCTION_OR: {
+		auto &conjunction = filter.Cast<ConjunctionOrFilter>();
+		for (auto &child : conjunction.child_filters) {
+			if (!CanPushdownFilter(*child)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	default:
+		return false;
+	}
+}
+
+static string BuildPushdownQuery(const RpcBindData &bind_data, const TableFunctionInitInput &input) {
+	string query;
+
+	// Projection: select only the columns DuckDB actually needs in the output.
+	// With filter_prune, projection_ids indexes into column_ids for output columns only.
+	// Filter-only columns are in column_ids but NOT in projection_ids — they go in WHERE, not SELECT.
+	if (!input.column_ids.empty() && !bind_data.column_names.empty()) {
+		vector<string> selected_columns;
+		if (!input.projection_ids.empty()) {
+			for (auto &proj_id : input.projection_ids) {
+				auto col_id = input.column_ids[proj_id];
+				if (IsRowIdColumnId(col_id) || col_id >= bind_data.column_names.size()) {
+					continue;
+				}
+				selected_columns.push_back(KeywordHelper::WriteOptionallyQuoted(bind_data.column_names[col_id]));
+			}
+		} else {
+			for (auto &col_id : input.column_ids) {
+				if (IsRowIdColumnId(col_id) || col_id >= bind_data.column_names.size()) {
+					continue;
+				}
+				selected_columns.push_back(KeywordHelper::WriteOptionallyQuoted(bind_data.column_names[col_id]));
+			}
+		}
+		if (!selected_columns.empty()) {
+			query = "SELECT " + StringUtil::Join(selected_columns, ", ");
+		}
+	}
+	if (query.empty()) {
+		query = "SELECT *";
+	}
+	query += StringUtil::Format(" FROM %s", bind_data.table_name);
+
+	// Filters: build WHERE clause from pushable filters
+	if (input.filters) {
+		vector<string> where_clauses;
+		for (auto &entry : *input.filters) {
+			auto col_idx = entry.GetIndex().GetIndex();
+			if (col_idx >= bind_data.column_names.size()) {
+				continue;
+			}
+			auto &filter = entry.Filter();
+			if (!CanPushdownFilter(filter)) {
+				continue;
+			}
+			auto col_name = KeywordHelper::WriteOptionallyQuoted(bind_data.column_names[col_idx]);
+			where_clauses.push_back(filter.ToString(col_name));
+		}
+		if (!where_clauses.empty()) {
+			query += " WHERE " + StringUtil::Join(where_clauses, " AND ");
+		}
+	}
+
+	return query;
+}
+
 unique_ptr<GlobalTableFunctionState> RpcInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->Cast<RpcBindData>();
 
@@ -113,9 +205,10 @@ unique_ptr<GlobalTableFunctionState> RpcInitGlobal(ClientContext &context, Table
 	// to avoid the server-side result being overwritten by subsequent lookups.
 	// We execute the query here, right before scanning, so the result is fresh.
 	if (!bind_data.table_name.empty()) {
+		auto query = BuildPushdownQuery(bind_data, input);
 		auto client = RpcClient::GetClient(bind_data.uri);
-		client->MakeRequest<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(
-		    bind_data.connection_id, StringUtil::Format("FROM %s", bind_data.table_name), true));
+		client->MakeRequest<PrepareResponseMessage>(
+		    make_uniq<PrepareRequestMessage>(bind_data.connection_id, query, true));
 	}
 
 	return make_uniq<RpcGlobalState>(GlobalTableFunctionState::MAX_THREADS);
@@ -170,6 +263,9 @@ TableFunction RpcScanFunction::GetFunction() {
 	auto fun = TableFunction("rpc_call", {LogicalType::VARCHAR, LogicalType::VARCHAR}, RpcScan, RpcBind, RpcInitGlobal,
 	                         RpcInitLocal);
 	fun.cardinality = RpcCardinality;
+	fun.projection_pushdown = true;
+	fun.filter_pushdown = true;
+	fun.filter_prune = true;
 	return fun;
 }
 
@@ -177,5 +273,8 @@ TableFunction RpcScanByNameFunction::GetFunction() {
 	auto fun = TableFunction("rpc_call_by_name", {LogicalType::VARCHAR, LogicalType::VARCHAR}, RpcScan,
 	                         RpcBindCatalogName, RpcInitGlobal, RpcInitLocal);
 	fun.cardinality = RpcCardinality;
+	fun.projection_pushdown = true;
+	fun.filter_pushdown = true;
+	fun.filter_prune = true;
 	return fun;
 }

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -247,8 +247,17 @@ static void RpcScan(ClientContext &context, TableFunctionInput &input, DataChunk
 		return;
 	}
 
-	output.Reference(*fetch_response->ResponseData());
-	output.SetCardinality(fetch_response->ResponseData()->size());
+	auto &response_chunk = *fetch_response->ResponseData();
+	if (response_chunk.ColumnCount() == output.ColumnCount()) {
+		output.Reference(response_chunk);
+	} else {
+		// Server returned more columns than needed (e.g. rpc_call with projection pushdown).
+		// Copy only the columns DuckDB expects.
+		for (idx_t i = 0; i < output.ColumnCount(); i++) {
+			output.data[i].Reference(response_chunk.data[i]);
+		}
+	}
+	output.SetCardinality(response_chunk.size());
 }
 
 static unique_ptr<NodeStatistics> RpcCardinality(ClientContext &context, const FunctionData *bind_data_p) {

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -1,0 +1,96 @@
+# name: test/sql/pushdown.test
+# description: test filter and projection pushdown for RPC catalog scans
+# group: [sql]
+
+require rpc
+
+foreach server  '__TEST_DIR__/duckdb-rpc-socket-pushdown'
+
+statement ok con1
+create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
+
+statement ok con1
+call rpc_start(${server});
+
+statement ok con2
+attach ${server} as rpc (TYPE rpc)
+
+# Verify projection pushdown: selecting one column should only project that column
+query II
+EXPLAIN SELECT i FROM rpc.main.test_data;
+----
+physical_plan	<REGEX>:.*Projections: i.*
+
+# Verify projection pushdown: selecting two columns
+query II
+EXPLAIN SELECT i, name FROM rpc.main.test_data;
+----
+physical_plan	<REGEX>:.*Projections:.*i.*name.*
+
+# Verify filter pushdown appears in the physical plan
+query II
+EXPLAIN SELECT i FROM rpc.main.test_data WHERE i = 42;
+----
+physical_plan	<REGEX>:.*Filters:.*i=42.*
+
+# Verify range filter pushdown
+query II
+EXPLAIN SELECT i FROM rpc.main.test_data WHERE i > 9990;
+----
+physical_plan	<REGEX>:.*Filters:.*i>9990.*
+
+# Verify multiple filters (AND)
+query II
+EXPLAIN SELECT i FROM rpc.main.test_data WHERE i >= 100 AND i < 200;
+----
+physical_plan	<REGEX>:.*Filters:.*i>=100.*i<200.*
+
+# Verify combined filter + projection pushdown
+query II
+EXPLAIN SELECT name FROM rpc.main.test_data WHERE i = 100;
+----
+physical_plan	<REGEX>:.*Projections:.*name.*
+
+# Correctness: filter pushdown returns correct results
+query I
+select i from rpc.main.test_data where i = 42;
+----
+42
+
+# Correctness: range filter
+query I
+select count(i) from rpc.main.test_data where i > 9990;
+----
+9
+
+# Correctness: combined filter and projection
+query I
+select name from rpc.main.test_data where i = 100;
+----
+name_100
+
+# Correctness: multiple conditions
+query I
+select count(i) from rpc.main.test_data where i >= 100 and i < 200;
+----
+100
+
+# Correctness: empty result
+query I
+select count(i) from rpc.main.test_data where i > 99999;
+----
+0
+
+# Correctness: no filter (full scan still works)
+query I
+select max(i) from rpc.main.test_data;
+----
+9999
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call rpc_stop(${server});
+
+endloop


### PR DESCRIPTION
## Filter & Projection Pushdown for ATTACH Scans

When using `ATTACH` with the RPC extension, queries like `SELECT name FROM remote.test WHERE i > 5` did not pushdown projections or filters to the server.

### Solution

Build SQL on the client side instead of always sending `FROM tablename`. The server already accepts arbitrary SQL via `PREPARE_REQUEST`, so no protocol changes were needed.

For `SELECT name FROM rpc.main.test_data WHERE i > 100`, the client now sends:
```sql
SELECT name FROM test_data WHERE i>100
```
instead of:
```sql
FROM test_data
```

### Implementation

1. **`RpcBindData`** now carries column names/types from the catalog, so the scan phase knows column names to build SQL
2. **`BuildPushdownQuery()`** constructs the SQL at scan init time using DuckDB's `TableFunctionInitInput`:
   - **Projection**: `input.projection_ids` → `SELECT col1, col3` (only output columns, not filter-only columns)
   - **Filters**: `input.filters` → `WHERE col1>100 AND col2='foo'` — uses DuckDB's built-in `TableFilter::ToString()` which already produces valid SQL for constant comparisons, IS NULL/NOT NULL, IN lists, and AND/OR conjunctions
3. **`CanPushdownFilter()`** checks filter types before converting — unsupported types (bloom filters, dynamic filters, etc.) are left for DuckDB to handle locally

### rpc_call and the projection mismatch

Both `rpc_call('uri', 'SQL')` and the ATTACH catalog path share the same `TableFunction` (same pattern as `duckdb-postgres` where `postgres_query` reuses `postgres_scan`'s init/scan functions). Pushdown flags are enabled on both because the catalog path needs them.

This creates a subtlety: for `SELECT a FROM rpc_call('uri', 'SELECT a, b FROM t')`, DuckDB sees `projection_pushdown = true` and creates a 1-column output chunk expecting just `a`. But the server returns 2 columns (`a, b`) because `rpc_call` sends the user's SQL verbatim.

`RpcScan` handles this by checking if the response has more columns than the output expects, and referencing only the needed columns. For the ATTACH path this never triggers because `BuildPushdownQuery` already sends the right projection in the SQL.

### Supported filter types

| Filter | Example SQL |
|--------|------------|
| Constant comparison | `col >= 100`, `col = 'foo'` |
| IS NULL / IS NOT NULL | `col IS NULL` |
| IN list | `col IN (1, 2, 3)` |
| AND / OR conjunctions | `col > 5 AND col < 10` |

### Tests

New `test/sql/pushdown.test` verifies pushdown via `EXPLAIN` plan assertions:
- `Projections: i` appears in the scan node (projection pushdown)
- `Filters: i=42` appears in the scan node (filter pushdown)
- Correctness checks for filtered/projected results
