### PR TITLE
Add logging to duckdb-remote

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(${TARGET_NAME})
 
 include_directories(src/include duckdb/third_party/httplib duckdb/extension/autocomplete/include)
 
-set(EXTENSION_SOURCES src/rpc_extension.cpp src/rpc_server.cpp src/https_rpc_server.cpp src/message.cpp src/client.cpp src/rpc_scan_function.cpp src/rpc_start_function.cpp src/rpc_storage_extension.cpp src/ssl_key_generator.cpp src/catalog.cpp  src/rpc_insert.cpp)
+set(EXTENSION_SOURCES src/rpc_extension.cpp src/rpc_server.cpp src/https_rpc_server.cpp src/message.cpp src/client.cpp src/rpc_scan_function.cpp src/rpc_start_function.cpp src/rpc_storage_extension.cpp src/ssl_key_generator.cpp src/catalog.cpp src/rpc_insert.cpp src/rpc_log_type.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -71,8 +71,10 @@ void RpcTransactionManager::Checkpoint(ClientContext &context, bool force) {
 	throw NotImplementedException("Checkpoint not implemented yet");
 }
 
-RpcCatalog::RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p)
+RpcCatalog::RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p, ClientContext &context)
     : Catalog(db_p), server_uri(server_uri_p), client(RpcClient::GetClient(server_uri)) {
+	client->SetContext(&context);
+
 	// evil copy paste
 	Value default_token_val;
 	auto &config = DBConfig::GetConfig(db_p.GetDatabase());

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -31,8 +31,46 @@ HttpsRpcClient::~HttpsRpcClient() {
 unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolMessage> request_message) {
 	D_ASSERT(request_message);
 	request_message->ToMemoryStream(write_stream);
+
+	int64_t start_time = 0;
+	bool should_log_http = context && Logger::Get(*context).ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
+	if (should_log_http) {
+		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+		                 .time_since_epoch()
+		                 .count();
+	}
+
 	auto https_result = https_client->Post("/rpc", (const char *)write_stream.GetData(), write_stream.GetPosition(),
 	                                       "application/duckdb");
+
+	if (should_log_http) {
+		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+		                       .time_since_epoch()
+		                       .count();
+		int64_t duration_ms = end_time - start_time;
+		int status = https_result ? https_result->status : -1;
+
+		child_list_t<Value> request_child_list = {
+		    {"type", Value("POST")},
+		    {"url", Value(uri.Http() + "/rpc")},
+		    {"start_time", Value()},
+		    {"duration_ms", Value::BIGINT(duration_ms)},
+		    {"headers", Value()},
+		};
+		auto request_value = Value::STRUCT(request_child_list);
+
+		child_list_t<Value> response_child_list = {
+		    {"status", Value(to_string(status))},
+		    {"reason", https_result ? Value(https_result->reason) : Value()},
+		    {"headers", Value()},
+		};
+		auto response_value = Value::STRUCT(response_child_list);
+
+		child_list_t<Value> child_list = {{"request", request_value}, {"response", response_value}};
+		auto msg = Value::STRUCT(child_list).ToString();
+		Logger::Get(*context).WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, msg);
+	}
+
 	if (!https_result) {
 		throw IOException("Failed to send message %s ", to_string(https_result.error()));
 	}

--- a/src/include/catalog.hpp
+++ b/src/include/catalog.hpp
@@ -104,7 +104,7 @@ private:
 
 class RpcCatalog : public Catalog {
 public:
-	explicit RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p);
+	explicit RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p, ClientContext &context);
 	~RpcCatalog();
 
 public:

--- a/src/include/client.hpp
+++ b/src/include/client.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "message.hpp"
+#include "rpc_log_type.hpp"
 #include "rpc_uri.hpp"
+
+#include "duckdb/logging/logger.hpp"
 
 namespace duckdb_httplib_openssl {
 class Client;
@@ -13,10 +16,63 @@ class RpcClient {
 public:
 	explicit RpcClient(const RpcUri &uri_p) : uri(uri_p) {};
 
+	void SetContext(optional_ptr<ClientContext> context_p) {
+		context = context_p;
+	}
+
 	template <class TARGET>
 	unique_ptr<TARGET> Request(unique_ptr<ProtocolMessage> request_message) {
 		lock_guard<mutex> guard(request_mutex);
+
+		// Extract metadata before move
+		auto request_type = request_message->Type();
+		string rpc_connection_id;
+		string query;
+		switch (request_type) {
+		case MessageType::PREPARE_REQUEST: {
+			auto &msg = request_message->Cast<PrepareRequestMessage>();
+			rpc_connection_id = msg.ConnectionId();
+			query = msg.Query();
+			break;
+		}
+		case MessageType::FETCH_REQUEST:
+			rpc_connection_id = request_message->Cast<FetchRequestMessage>().ConnectionId();
+			break;
+		case MessageType::CATALOG_REQUEST:
+			rpc_connection_id = request_message->Cast<CatalogRequestMessage>().ConnectionId();
+			break;
+		case MessageType::APPEND_REQUEST:
+			rpc_connection_id = request_message->Cast<AppendRequestMessage>().ConnectionId();
+			break;
+		default:
+			break;
+		}
+
+		// Time the request
+		int64_t start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+		                         .time_since_epoch()
+		                         .count();
+
 		auto response_message = RequestInternal(std::move(request_message)).release();
+
+		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+		                       .time_since_epoch()
+		                       .count();
+
+		// Log RPC message
+		if (context) {
+			auto &logger = Logger::Get(*context);
+			if (logger.ShouldLog(RPCLogType::NAME, RPCLogType::LEVEL)) {
+				string error;
+				if (response_message->Type() == MessageType::ERROR) {
+					error = response_message->Cast<ErrorMessage>().Error();
+				}
+				auto msg = RPCLogType::ConstructLogMessage(request_type, rpc_connection_id, query, uri.Http(),
+				                                           end_time - start_time, response_message->Type(), error);
+				logger.WriteLog(RPCLogType::NAME, RPCLogType::LEVEL, msg);
+			}
+		}
+
 		if (response_message->Type() != TARGET::TYPE) {
 			if (response_message->Type() == MessageType::ERROR) {
 				throw IOException("Expected %s message, got error message instead: %s",
@@ -37,6 +93,7 @@ protected:
 	mutex request_mutex;
 	MemoryStream read_stream, write_stream;
 	RpcUri uri;
+	optional_ptr<ClientContext> context;
 
 private:
 	virtual unique_ptr<ProtocolMessage> RequestInternal(unique_ptr<ProtocolMessage> request_message) = 0;

--- a/src/include/client.hpp
+++ b/src/include/client.hpp
@@ -28,6 +28,7 @@ public:
 		auto request_type = request_message->Type();
 		string rpc_connection_id;
 		string query;
+		optional_idx client_query_id;
 		switch (request_type) {
 		case MessageType::PREPARE_REQUEST: {
 			auto &msg = request_message->Cast<PrepareRequestMessage>();
@@ -46,6 +47,12 @@ public:
 			break;
 		default:
 			break;
+		}
+
+		// Inject client_query_id from context into the message before sending
+		if (context) {
+			client_query_id = context->transaction.GetActiveQuery();
+			request_message->SetClientQueryId(client_query_id);
 		}
 
 		// Time the request
@@ -67,8 +74,9 @@ public:
 				if (response_message->Type() == MessageType::ERROR) {
 					error = response_message->Cast<ErrorMessage>().Error();
 				}
-				auto msg = RPCLogType::ConstructLogMessage(request_type, rpc_connection_id, query, uri.Http(),
-				                                           end_time - start_time, response_message->Type(), error);
+				auto msg = RPCLogType::ConstructLogMessage(request_type, rpc_connection_id, client_query_id, query,
+				                                           uri.Http(), end_time - start_time,
+				                                           response_message->Type(), error);
 				logger.WriteLog(RPCLogType::NAME, RPCLogType::LEVEL, msg);
 			}
 		}

--- a/src/include/message.hpp
+++ b/src/include/message.hpp
@@ -56,6 +56,14 @@ public:
 		return message_type;
 	}
 
+	optional_idx ClientQueryId() const {
+		return client_query_id;
+	}
+
+	void SetClientQueryId(optional_idx query_id) {
+		client_query_id = query_id;
+	}
+
 	virtual ~ProtocolMessage() {
 	}
 
@@ -63,6 +71,7 @@ protected:
 	explicit ProtocolMessage(MessageType type) : message_type(type) {
 	}
 	MessageType message_type = MessageType::INVALID;
+	optional_idx client_query_id;
 };
 
 class PrepareRequestMessage : public ProtocolMessage {

--- a/src/include/rpc_log_type.hpp
+++ b/src/include/rpc_log_type.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "duckdb/logging/log_type.hpp"
+#include "message.hpp"
+
+namespace duckdb {
+
+class RPCLogType : public LogType {
+public:
+	static constexpr const char *NAME = "RPC";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
+
+	RPCLogType();
+
+	static LogicalType GetLogType();
+	static string ConstructLogMessage(MessageType request_type, const string &rpc_connection_id, const string &query,
+	                                  const string &server_uri, int64_t duration_ms, MessageType response_type,
+	                                  const string &error);
+};
+
+} // namespace duckdb

--- a/src/include/rpc_log_type.hpp
+++ b/src/include/rpc_log_type.hpp
@@ -13,9 +13,9 @@ public:
 	RPCLogType();
 
 	static LogicalType GetLogType();
-	static string ConstructLogMessage(MessageType request_type, const string &rpc_connection_id, const string &query,
-	                                  const string &server_uri, int64_t duration_ms, MessageType response_type,
-	                                  const string &error);
+	static string ConstructLogMessage(MessageType request_type, const string &rpc_connection_id,
+	                                  optional_idx client_query_id, const string &query, const string &server_uri,
+	                                  int64_t duration_ms, MessageType response_type, const string &error);
 };
 
 } // namespace duckdb

--- a/src/include/rpc_server.hpp
+++ b/src/include/rpc_server.hpp
@@ -52,6 +52,7 @@ public:
 
 protected:
 	unique_ptr<ProtocolMessage> HandleMessage(ProtocolMessage &received_message);
+	unique_ptr<ProtocolMessage> HandleMessageInternal(ProtocolMessage &received_message);
 
 protected:
 	std::vector<std::thread> listen_threads;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -140,15 +140,19 @@ unique_ptr<ProtocolMessage> ConnectionResponseMessage::Deserialize(Deserializer 
 void PrepareRequestMessage::Serialize(Serializer &serializer) const {
 	ProtocolMessage::Serialize(serializer);
 	serializer.WriteProperty<string>(98, "connection_id", connection_id);
+	serializer.WriteProperty<optional_idx>(99, "client_query_id", client_query_id);
 	serializer.WriteProperty<string>(200, "sql_query", sql_query);
 	serializer.WriteProperty<bool>(201, "immediately_execute", immediately_execute);
 }
 
 unique_ptr<ProtocolMessage> PrepareRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto connection_id = deserializer.ReadProperty<string>(98, "connection_id");
+	auto cqid = deserializer.ReadProperty<optional_idx>(99, "client_query_id");
 	auto sql_query = deserializer.ReadProperty<string>(200, "sql_query");
 	auto immediately_execute = deserializer.ReadProperty<bool>(201, "immediately_execute");
-	return make_uniq<PrepareRequestMessage>(connection_id, sql_query, immediately_execute);
+	auto msg = make_uniq<PrepareRequestMessage>(connection_id, sql_query, immediately_execute);
+	msg->SetClientQueryId(cqid);
+	return msg;
 }
 
 void PrepareResponseMessage::Serialize(Serializer &serializer) const {
@@ -168,13 +172,15 @@ unique_ptr<ProtocolMessage> PrepareResponseMessage::Deserialize(Deserializer &de
 void FetchRequestMessage::Serialize(Serializer &serializer) const {
 	ProtocolMessage::Serialize(serializer);
 	serializer.WriteProperty<string>(98, "connection_id", connection_id);
-
-	// 240
+	serializer.WriteProperty<optional_idx>(99, "client_query_id", client_query_id);
 }
 
 unique_ptr<ProtocolMessage> FetchRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto connection_id = deserializer.ReadProperty<string>(98, "connection_id");
-	return make_uniq<FetchRequestMessage>(connection_id);
+	auto cqid = deserializer.ReadProperty<optional_idx>(99, "client_query_id");
+	auto msg = make_uniq<FetchRequestMessage>(connection_id);
+	msg->SetClientQueryId(cqid);
+	return msg;
 }
 
 void FetchResponseMessage::Serialize(Serializer &serializer) const {
@@ -213,6 +219,7 @@ void CatalogRequestMessage::Serialize(Serializer &serializer) const {
 	D_ASSERT(parse_info);
 	ProtocolMessage::Serialize(serializer);
 	serializer.WriteProperty<string>(98, "connection_id", connection_id);
+	serializer.WriteProperty<optional_idx>(99, "client_query_id", client_query_id);
 	// FIXME this is only required because serialization of parse info is borked
 	serializer.WriteProperty<ParseInfoType>(97, "info_type", parse_info->info_type);
 	parse_info->Serialize(serializer);
@@ -220,6 +227,7 @@ void CatalogRequestMessage::Serialize(Serializer &serializer) const {
 
 unique_ptr<ProtocolMessage> CatalogRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto connection_id = deserializer.ReadProperty<string>(98, "connection_id");
+	auto cqid = deserializer.ReadProperty<optional_idx>(99, "client_query_id");
 	auto info_type = deserializer.ReadProperty<ParseInfoType>(97, "info_type");
 	unique_ptr<ParseInfo> parse_info;
 	switch (info_type) {
@@ -230,7 +238,9 @@ unique_ptr<ProtocolMessage> CatalogRequestMessage::Deserialize(Deserializer &des
 		parse_info = ParseInfo::Deserialize(deserializer);
 		break;
 	}
-	return make_uniq<CatalogRequestMessage>(connection_id, std::move(parse_info));
+	auto msg = make_uniq<CatalogRequestMessage>(connection_id, std::move(parse_info));
+	msg->SetClientQueryId(cqid);
+	return msg;
 }
 
 void CatalogResponseMessage::Serialize(Serializer &serializer) const {
@@ -259,6 +269,7 @@ void AppendRequestMessage::Serialize(Serializer &serializer) const {
 	D_ASSERT(append_chunk);
 	ProtocolMessage::Serialize(serializer);
 	serializer.WriteProperty<string>(98, "connection_id", connection_id);
+	serializer.WriteProperty<optional_idx>(99, "client_query_id", client_query_id);
 	serializer.WriteProperty<string>(270, "schema_name", schema_name);
 	serializer.WriteProperty<string>(271, "table_name", table_name);
 
@@ -268,6 +279,7 @@ void AppendRequestMessage::Serialize(Serializer &serializer) const {
 
 unique_ptr<ProtocolMessage> AppendRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto connection_id_p = deserializer.ReadProperty<string>(98, "connection_id");
+	auto cqid = deserializer.ReadProperty<optional_idx>(99, "client_query_id");
 	auto schema_name_p = deserializer.ReadProperty<string>(270, "schema_name");
 	auto table_name_p = deserializer.ReadProperty<string>(271, "table_name");
 
@@ -275,7 +287,9 @@ unique_ptr<ProtocolMessage> AppendRequestMessage::Deserialize(Deserializer &dese
 	deserializer.ReadObject(272, "append_chunk",
 	                        [&](Deserializer &inner_deserializer) { append_chunk_p->Deserialize(inner_deserializer); });
 
-	return make_uniq<AppendRequestMessage>(connection_id_p, schema_name_p, table_name_p, std::move(append_chunk_p));
+	auto msg = make_uniq<AppendRequestMessage>(connection_id_p, schema_name_p, table_name_p, std::move(append_chunk_p));
+	msg->SetClientQueryId(cqid);
+	return msg;
 }
 
 void AppendResponseMessage::Serialize(Serializer &serializer) const {

--- a/src/rpc_extension.cpp
+++ b/src/rpc_extension.cpp
@@ -3,11 +3,13 @@
 #include "duckdb.hpp"
 
 #include "remote_extension.hpp"
+#include "rpc_log_type.hpp"
 #include "rpc_scan_function.hpp"
 #include "rpc_start_function.hpp"
 #include "rpc_storage_extension.hpp"
 #include "rpc_uri.hpp"
 
+#include "duckdb/logging/log_manager.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 
 #include "catalog.hpp"
@@ -19,7 +21,7 @@ static unique_ptr<Catalog> RpcAttach(optional_ptr<StorageExtensionInfo> storage_
                                      AttachOptions &attach_options) {
 	auto diable_ssl = attach_options.options.find("disable_ssl") != attach_options.options.end() &&
 	                  attach_options.options["disable_ssl"].GetValue<bool>();
-	return make_uniq<RpcCatalog>(db, RpcUri("remote:" + info.path, !diable_ssl));
+	return make_uniq<RpcCatalog>(db, RpcUri("remote:" + info.path, !diable_ssl), context);
 }
 
 static unique_ptr<TransactionManager> RpcCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,
@@ -109,6 +111,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                                   {"url", LogicalType::VARCHAR}}),
 	                              RpcUriParser);
 	loader.RegisterFunction(rpc_uri_parser);
+
+	loader.GetDatabaseInstance().GetLogManager().RegisterLogType(make_uniq<RPCLogType>());
 
 	// (ab)use storage extension info to store our state
 	auto ext = duckdb::make_shared_ptr<RpcStorageExtension>();

--- a/src/rpc_log_type.cpp
+++ b/src/rpc_log_type.cpp
@@ -1,0 +1,38 @@
+#include "rpc_log_type.hpp"
+
+namespace duckdb {
+
+constexpr LogLevel RPCLogType::LEVEL;
+
+RPCLogType::RPCLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType RPCLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"message_type", LogicalType::VARCHAR},
+	    {"rpc_connection_id", LogicalType::VARCHAR},
+	    {"query", LogicalType::VARCHAR},
+	    {"server", LogicalType::VARCHAR},
+	    {"duration_ms", LogicalType::BIGINT},
+	    {"response_type", LogicalType::VARCHAR},
+	    {"error", LogicalType::VARCHAR},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
+string RPCLogType::ConstructLogMessage(MessageType request_type, const string &rpc_connection_id, const string &query,
+                                       const string &server_uri, int64_t duration_ms, MessageType response_type,
+                                       const string &error) {
+	child_list_t<Value> child_list = {
+	    {"message_type", Value(MessageTypeToString(request_type))},
+	    {"rpc_connection_id", Value(rpc_connection_id)},
+	    {"query", query.empty() ? Value() : Value(query)},
+	    {"server", server_uri.empty() ? Value() : Value(server_uri)},
+	    {"duration_ms", Value::BIGINT(duration_ms)},
+	    {"response_type", Value(MessageTypeToString(response_type))},
+	    {"error", error.empty() ? Value() : Value(error)},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
+} // namespace duckdb

--- a/src/rpc_log_type.cpp
+++ b/src/rpc_log_type.cpp
@@ -11,6 +11,7 @@ LogicalType RPCLogType::GetLogType() {
 	child_list_t<LogicalType> child_list = {
 	    {"message_type", LogicalType::VARCHAR},
 	    {"rpc_connection_id", LogicalType::VARCHAR},
+	    {"client_query_id", LogicalType::UBIGINT},
 	    {"query", LogicalType::VARCHAR},
 	    {"server", LogicalType::VARCHAR},
 	    {"duration_ms", LogicalType::BIGINT},
@@ -20,12 +21,13 @@ LogicalType RPCLogType::GetLogType() {
 	return LogicalType::STRUCT(child_list);
 }
 
-string RPCLogType::ConstructLogMessage(MessageType request_type, const string &rpc_connection_id, const string &query,
-                                       const string &server_uri, int64_t duration_ms, MessageType response_type,
-                                       const string &error) {
+string RPCLogType::ConstructLogMessage(MessageType request_type, const string &rpc_connection_id,
+                                       optional_idx client_query_id, const string &query, const string &server_uri,
+                                       int64_t duration_ms, MessageType response_type, const string &error) {
 	child_list_t<Value> child_list = {
 	    {"message_type", Value(MessageTypeToString(request_type))},
 	    {"rpc_connection_id", Value(rpc_connection_id)},
+	    {"client_query_id", client_query_id.IsValid() ? Value::UBIGINT(client_query_id.GetIndex()) : Value()},
 	    {"query", query.empty() ? Value() : Value(query)},
 	    {"server", server_uri.empty() ? Value() : Value(server_uri)},
 	    {"duration_ms", Value::BIGINT(duration_ms)},

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -28,6 +28,7 @@ static unique_ptr<FunctionData> RpcBind(ClientContext &context, TableFunctionBin
 	bind_data->server_uri = RpcUri(input.inputs[0].GetValue<string>(), !disable_ssl);
 
 	bind_data->initial_client = RpcClient::GetClient(bind_data->server_uri);
+	bind_data->initial_client->SetContext(&context);
 
 	Value default_token_val;
 	auto &config = DBConfig::GetConfig(context);
@@ -209,6 +210,7 @@ unique_ptr<GlobalTableFunctionState> RpcInitGlobal(ClientContext &context, Table
 	if (!bind_data.table_name.empty()) {
 		auto query = BuildPushdownQuery(bind_data, input);
 		auto client = RpcClient::GetClient(bind_data.server_uri);
+		client->SetContext(&context);
 		client->Request<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(bind_data.connection_id, query, true));
 	}
 
@@ -228,6 +230,7 @@ unique_ptr<LocalTableFunctionState> RpcInitLocal(ExecutionContext &context, Tabl
 		local_state->client = unique_ptr<RpcClient>(bind_data.initial_client.release());
 	} else {
 		local_state->client = RpcClient::GetClient(bind_data.server_uri);
+		local_state->client->SetContext(&context.client);
 	}
 
 	return local_state;

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -1,7 +1,9 @@
 #include "rpc_server.hpp"
 #include "message.hpp"
+#include "rpc_log_type.hpp"
 #include "rpc_storage_extension.hpp"
 
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/common/render_tree.hpp"
@@ -110,8 +112,64 @@ string RpcServer::GenerateSessionId() {
 	return session_id;
 }
 
+// Extract connection_id from a message if available
+static string ExtractConnectionId(ProtocolMessage &msg) {
+	switch (msg.Type()) {
+	case MessageType::PREPARE_REQUEST:
+		return msg.Cast<PrepareRequestMessage>().ConnectionId();
+	case MessageType::FETCH_REQUEST:
+		return msg.Cast<FetchRequestMessage>().ConnectionId();
+	case MessageType::CATALOG_REQUEST:
+		return msg.Cast<CatalogRequestMessage>().ConnectionId();
+	case MessageType::APPEND_REQUEST:
+		return msg.Cast<AppendRequestMessage>().ConnectionId();
+	default:
+		return "";
+	}
+}
+
+static string ExtractQuery(ProtocolMessage &msg) {
+	if (msg.Type() == MessageType::PREPARE_REQUEST) {
+		return msg.Cast<PrepareRequestMessage>().Query();
+	}
+	return "";
+}
+
 // main switcheroo happens here
 unique_ptr<ProtocolMessage> RpcServer::HandleMessage(ProtocolMessage &received_message) {
+	auto &logger = Logger::Get(*db);
+	bool should_log = logger.ShouldLog(RPCLogType::NAME, RPCLogType::LEVEL);
+
+	string rpc_connection_id;
+	string query;
+	int64_t start_time = 0;
+	if (should_log) {
+		rpc_connection_id = ExtractConnectionId(received_message);
+		query = ExtractQuery(received_message);
+		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+		                 .time_since_epoch()
+		                 .count();
+	}
+
+	auto response = HandleMessageInternal(received_message);
+
+	if (should_log) {
+		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+		                       .time_since_epoch()
+		                       .count();
+		string error;
+		if (response->Type() == MessageType::ERROR) {
+			error = response->Cast<ErrorMessage>().Error();
+		}
+		auto msg = RPCLogType::ConstructLogMessage(received_message.Type(), rpc_connection_id, query, "",
+		                                           end_time - start_time, response->Type(), error);
+		logger.WriteLog(RPCLogType::NAME, RPCLogType::LEVEL, msg);
+	}
+
+	return response;
+}
+
+unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &received_message) {
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -128,6 +128,10 @@ static string ExtractConnectionId(ProtocolMessage &msg) {
 	}
 }
 
+static optional_idx ExtractClientQueryId(ProtocolMessage &msg) {
+	return msg.ClientQueryId();
+}
+
 static string ExtractQuery(ProtocolMessage &msg) {
 	if (msg.Type() == MessageType::PREPARE_REQUEST) {
 		return msg.Cast<PrepareRequestMessage>().Query();
@@ -142,9 +146,11 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessage(ProtocolMessage &received_m
 
 	string rpc_connection_id;
 	string query;
+	optional_idx client_query_id;
 	int64_t start_time = 0;
 	if (should_log) {
 		rpc_connection_id = ExtractConnectionId(received_message);
+		client_query_id = ExtractClientQueryId(received_message);
 		query = ExtractQuery(received_message);
 		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 		                 .time_since_epoch()
@@ -161,8 +167,8 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessage(ProtocolMessage &received_m
 		if (response->Type() == MessageType::ERROR) {
 			error = response->Cast<ErrorMessage>().Error();
 		}
-		auto msg = RPCLogType::ConstructLogMessage(received_message.Type(), rpc_connection_id, query, "",
-		                                           end_time - start_time, response->Type(), error);
+		auto msg = RPCLogType::ConstructLogMessage(received_message.Type(), rpc_connection_id, client_query_id, query,
+		                                           "", end_time - start_time, response->Type(), error);
 		logger.WriteLog(RPCLogType::NAME, RPCLogType::LEVEL, msg);
 	}
 

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -1,0 +1,134 @@
+# name: test/sql/logging.test
+# description: test RPC and HTTP logging
+# group: [sql]
+
+require remote
+
+# start server
+statement ok
+call rpc_generate_keys();
+
+statement ok con1
+call rpc_start('remote:localhost', disable_ssl=false);
+
+sleep 100 millisecond
+
+# --- RPC logging ---
+
+statement ok con2
+CALL enable_logging('RPC');
+
+# rpc_call should produce RPC log entries
+query I con2
+from rpc_call('remote:localhost', 'select 42 as answer', disable_ssl=false)
+----
+42
+
+# check that we have RPC logs with correct structure
+query I con2
+select count(*) > 0 from duckdb_logs where type = 'RPC'
+----
+true
+
+# check that PREPARE_REQUEST has the query
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where message_type = 'PREPARE_REQUEST' and query = 'select 42 as answer'
+----
+true
+
+# check that FETCH_REQUEST entries exist
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where message_type = 'FETCH_REQUEST'
+----
+true
+
+# check that rpc_connection_id is set on non-connection messages
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where message_type = 'PREPARE_REQUEST' and rpc_connection_id != ''
+----
+true
+
+# check duration_ms is non-negative
+query I con2
+select count(*) = 0 from duckdb_logs_parsed('RPC') where duration_ms < 0
+----
+true
+
+# check server field is populated on client-side logs
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where server is not null and server != ''
+----
+true
+
+# check response_type is populated
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where response_type = 'PREPARE_RESPONSE'
+----
+true
+
+# check error field for successful queries is NULL
+query I con2
+select count(*) = 0 from duckdb_logs_parsed('RPC') where error is not null and server is not null
+----
+true
+
+# check server-side logs exist (scope=DATABASE, no server field)
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where server is null or server = ''
+----
+true
+
+# clear logs and test error logging
+statement ok con2
+CALL truncate_duckdb_logs();
+
+statement error con2
+from rpc_call('remote:localhost', 'selexxxct 42', disable_ssl=false)
+----
+Error
+
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where response_type = 'ERROR' and error is not null
+----
+true
+
+# --- HTTP logging ---
+
+statement ok con2
+CALL truncate_duckdb_logs();
+
+statement ok con2
+CALL disable_logging();
+
+statement ok con2
+CALL enable_logging('HTTP');
+
+query I con2
+from rpc_call('remote:localhost', 'select 1', disable_ssl=false)
+----
+1
+
+# check HTTP logs exist with POST method
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.type = 'POST'
+----
+true
+
+# check HTTP response status
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('HTTP') where response.status = '200'
+----
+true
+
+# check URL contains /rpc
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.url like '%/rpc'
+----
+true
+
+# clean up
+statement ok con2
+CALL disable_logging();
+
+statement ok con1
+call rpc_stop('remote:localhost');

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -72,6 +72,18 @@ select count(*) = 0 from duckdb_logs_parsed('RPC') where error is not null and s
 ----
 true
 
+# check client_query_id is populated on client-side logs
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where client_query_id is not null and server is not null
+----
+true
+
+# check client_query_id is populated on server-side logs
+query I con2
+select count(*) > 0 from duckdb_logs_parsed('RPC') where client_query_id is not null and (server is null or server = '')
+----
+true
+
 # check server-side logs exist (scope=DATABASE, no server field)
 query I con2
 select count(*) > 0 from duckdb_logs_parsed('RPC') where server is null or server = ''


### PR DESCRIPTION
This PR focuses on two logging avenues:

## HTTP logs
Hook in our own `HTTPLogType`, which fires on every request. I went the route of passing the client context since looking across implementations this seems like the cleanest. HTTP logs are only gathered client side in `HttpsRpcClient::RequestInternal`. 

> [!NOTE]
> We can consider implementing this server side in `HttpsRpcServer::Listen` but I am unsure if this is necessary since at the server side the RPC logs are probably enough.

## RPC logs 
Build `RPCLogType`. This log type is present both in the client and server side. Again I went the client context route instead of wrapping requests/responses in timings. The ConstructorLogMessage struct looks like:
```
STRUCT {
    message_type: VARCHAR,      -- "PREPARE_REQUEST", "FETCH_REQUEST", etc.
    rpc_connection_id: VARCHAR, -- server session token (distinct from DuckDB's connection_id in log context)
    query: VARCHAR,             -- SQL query (PREPARE_REQUEST only, NULL otherwise)
    server: VARCHAR,            -- server URI (client-side only, NULL on server)
    duration_ms: BIGINT,        -- round-trip time for this message
    response_type: VARCHAR,     -- "PREPARE_RESPONSE", "ERROR", etc.
    error: VARCHAR              -- error message if ERROR response, NULL otherwise
  }
```
Note that the distinction in the logs between server side and client side is based on the `sever` field.

### RPC logs client-side
Logging happens in `RpcClient::Request<T>`. `RequestInternal` is timed. Because the context is passed, the logger framework autopopulates `query_id`, `connection_id` and `transaction_id`. What ties client and server logs together though is the `rpc_connection_id`.

### RPC logs server-side
Logging happens in `RpcServer::HandleMessage`. The `connection_id` and `query` are extracted from the incoming message. `HandleMessageInternal` is timed. Server side logging goes through `Logger::Get(*db)` so fields like `query_id` are null. Tying point between client and server is still `rpc_connection_id`.

## Sample usage

We are going to divide this in client and server side.

### Server side
```sql
-- Enable RPC logging and start a server
CALL enable_logging('RPC');
SET rpc_default_token='test';
CALL rpc_start('remote:localhost:19558', disable_ssl=true);
```

You can query the server from within, but that would clog our logs so don't be lazy and open up a new terminal.

```sql
-- Client does a query
SET rpc_default_token='test';
SELECT * FROM rpc_call('remote:localhost:19558', 'SELECT 42 AS answer', disable_ssl=true);
```

```sql
-- Server side logs
SELECT message_type, rpc_connection_id, query, server, duration_ms, response_type, error
FROM duckdb_logs_parsed('RPC');
┌────────────────────┬──────────────────────────────────────────────┬─────────────────────┬─────────┬─────────────┬─────────────────────┬─────────┐
│    message_type    │              rpc_connection_id               │        query        │ server  │ duration_ms │    response_type    │  error  │
│      varchar       │                   varchar                    │       varchar       │ varchar │    int64    │       varchar       │ varchar │
├────────────────────┼──────────────────────────────────────────────┼─────────────────────┼─────────┼─────────────┼─────────────────────┼─────────┤
│ CONNECTION_REQUEST │                                              │ NULL                │ NULL    │           5 │ CONNECTION_RESPONSE │ NULL    │
│ PREPARE_REQUEST    │ aBLfdHhGQ6WYtUgUptpI6aPairELlZIf+/m7z5s5CXw= │ SELECT 42 AS answer │ NULL    │           0 │ PREPARE_RESPONSE    │ NULL    │
│ FETCH_REQUEST      │ aBLfdHhGQ6WYtUgUptpI6aPairELlZIf+/m7z5s5CXw= │ NULL                │ NULL    │           0 │ FETCH_RESPONSE      │ NULL    │
│ FETCH_REQUEST      │ aBLfdHhGQ6WYtUgUptpI6aPairELlZIf+/m7z5s5CXw= │ NULL                │ NULL    │           0 │ FETCH_RESPONSE      │ NULL    │
└────────────────────┴──────────────────────────────────────────────┴─────────────────────┴─────────┴─────────────┴─────────────────────┴─────────┘
```

> [!IMPORTANT] 
> There is a caveat: the `ATTACH` path establishes one rpc_connection_id for the same ATTACH connection. So currently there is no way to identify one specific query log in the server side. A good idea (I think) would be to pass in the message `client_query_id` and use this server side so that client query ids match sever query ids. An alternative is to have a separate query_id in the server side but I'm not sure what is the value of having mismatching logs.


### Client side logs
```sql
-- Assuming you have the same server running
SET rpc_default_token='test';
CALL enable_logging(['RPC', 'HTTP']);

-- Create and query a table
SELECT * FROM rpc_call('remote:localhost:19558', 'CREATE TABLE t as SELECT range a FROM range(100)', disable_ssl=true);
SELECT * FROM rpc_call('remote:localhost:19558', 'SELECT * FROM t WHERE a > 50', disable_ssl=true);

-- Query RPC logs
FROM duckdb_logs_parsed('RPC') SELECT query_id, query, server, duration_ms, response_type, error;
┌──────────┬─────────────────────────────────────────┬─────────────────────────────────────────┬────────────────────────┬─────────────┬─────────────────────┬─────────┐
│ query_id │            rpc_connection_id            │                  query                  │         server         │ duration_ms │    response_type    │  error  │
│  uint64  │                 varchar                 │                 varchar                 │        varchar         │    int64    │       varchar       │ varchar │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       10 │                                         │ NULL                                    │ http://localhost:19558 │           3 │ CONNECTION_RESPONSE │ NULL    │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       10 │ mENoor8f5zqEiLpMBvZQXnRAz9/Civ0Ph8Opej7 │ CREATE TABLE t as SELECT range a FROM r │ http://localhost:19558 │           2 │ PREPARE_RESPONSE    │ NULL    │
│          │ kewI=                                   │ ange(100)                               │                        │             │                     │         │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       10 │ mENoor8f5zqEiLpMBvZQXnRAz9/Civ0Ph8Opej7 │ NULL                                    │ http://localhost:19558 │           1 │ FETCH_RESPONSE      │ NULL    │
│          │ kewI=                                   │                                         │                        │             │                     │         │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       10 │ mENoor8f5zqEiLpMBvZQXnRAz9/Civ0Ph8Opej7 │ NULL                                    │ http://localhost:19558 │           0 │ FETCH_RESPONSE      │ NULL    │
│          │ kewI=                                   │                                         │                        │             │                     │         │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       11 │                                         │ NULL                                    │ http://localhost:19558 │           3 │ CONNECTION_RESPONSE │ NULL    │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       11 │ 50a1sknVAJGtoz2tta33ukV8MPT7SCqPUH0cBJe │ SELECT * FROM t WHERE a > 50            │ http://localhost:19558 │           2 │ PREPARE_RESPONSE    │ NULL    │
│          │ jxD8=                                   │                                         │                        │             │                     │         │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       11 │ 50a1sknVAJGtoz2tta33ukV8MPT7SCqPUH0cBJe │ NULL                                    │ http://localhost:19558 │           0 │ FETCH_RESPONSE      │ NULL    │
│          │ jxD8=                                   │                                         │                        │             │                     │         │
├──────────┼─────────────────────────────────────────┼─────────────────────────────────────────┼────────────────────────┼─────────────┼─────────────────────┼─────────┤
│       11 │ 50a1sknVAJGtoz2tta33ukV8MPT7SCqPUH0cBJe │ NULL                                    │ http://localhost:19558 │           1 │ FETCH_RESPONSE      │ NULL    │
│          │ jxD8=                                   │                                         │                        │             │                     │         │
└──────────┴─────────────────────────────────────────┴─────────────────────────────────────────┴────────────────────────┴─────────────┴─────────────────────┴─────────┘

-- Query HTTP logs
FROM duckdb_logs_parsed('HTTP') SELECT transaction_id, query_id, type, request, response;
┌────────────────┬──────────┬─────────┬───────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────┐
│ transaction_id │ query_id │  type   │                            request                            │                           response                            │
│     uint64     │  uint64  │ varchar │ struct("type" varchar, url varchar, start_time timestamp with │ struct(status varchar, reason varchar, headers map(varchar, v │
│                │          │         │  time zone, duration_ms bigint, headers map(varchar, varchar) │                           archar))                            │
│                │          │         │                               )                               │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             10 │       10 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 3, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             10 │       10 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 2, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             10 │       10 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 0, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             10 │       10 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 0, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             11 │       11 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 3, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             11 │       11 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 2, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             11 │       11 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 0, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
├────────────────┼──────────┼─────────┼───────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
│             11 │       11 │ HTTP    │ {                                                             │ {'status': 200, 'reason': OK, 'headers': null}                │
│                │          │         │   'type': POST, 'url': 'http://localhost:19558/rpc',          │                                                               │
│                │          │         │   'start_time': null, 'duration_ms': 1, 'headers': null       │                                                               │
│                │          │         │ }                                                             │                                                               │
└────────────────┴──────────┴─────────┴───────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┘
```