### PR TITLE
Fix/http logging

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,11 +33,13 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 	request_message->ToMemoryStream(write_stream);
 
 	int64_t start_time = 0;
+	timestamp_t request_start;
 	bool should_log_http = context && Logger::Get(*context).ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
 	if (should_log_http) {
 		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 		                 .time_since_epoch()
 		                 .count();
+		request_start = Timestamp::GetCurrentTimestamp();
 	}
 
 	auto https_result = https_client->Post("/rpc", (const char *)write_stream.GetData(), write_stream.GetPosition(),
@@ -50,17 +52,40 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 		int64_t duration_ms = end_time - start_time;
 		int status = https_result ? https_result->status : -1;
 
+		// Build request headers map
+		vector<Value> req_header_keys;
+		vector<Value> req_header_values;
+		req_header_keys.emplace_back("Content-Type");
+		req_header_values.emplace_back("application/duckdb");
+		auto request_headers_value =
+		    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, req_header_keys, req_header_values);
+
 		child_list_t<Value> request_child_list = {
-		    {"type", Value("POST")}, {"url", Value(uri.Http() + "/rpc")},
-		    {"start_time", Value()}, {"duration_ms", Value::BIGINT(duration_ms)},
-		    {"headers", Value()},
+		    {"type", Value("POST")},
+		    {"url", Value(uri.Http() + "/rpc")},
+		    {"start_time", Value::TIMESTAMP(request_start)},
+		    {"duration_ms", Value::BIGINT(duration_ms)},
+		    {"headers", request_headers_value},
 		};
 		auto request_value = Value::STRUCT(request_child_list);
+
+		// Build response headers map from cpp-httplib result
+		Value response_headers_value;
+		if (https_result) {
+			vector<Value> resp_header_keys;
+			vector<Value> resp_header_values;
+			for (const auto &header : https_result->headers) {
+				resp_header_keys.emplace_back(header.first);
+				resp_header_values.emplace_back(header.second);
+			}
+			response_headers_value =
+			    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, resp_header_keys, resp_header_values);
+		}
 
 		child_list_t<Value> response_child_list = {
 		    {"status", Value(to_string(status))},
 		    {"reason", https_result ? Value(https_result->reason) : Value()},
-		    {"headers", Value()},
+		    {"headers", response_headers_value},
 		};
 		auto response_value = Value::STRUCT(response_child_list);
 

--- a/src/include/client.hpp
+++ b/src/include/client.hpp
@@ -49,8 +49,11 @@ public:
 			break;
 		}
 
-		// Inject client_query_id from context into the message before sending
-		if (context) {
+		// Inject client_query_id from context into the message before sending.
+		// Guard against reading the active query during transaction start itself
+		// (e.g. BEGIN TRANSACTION via RpcCatalog::ExecuteCommand), where the
+		// transaction isn't yet installed on the TransactionContext.
+		if (context && context->transaction.HasActiveTransaction()) {
 			client_query_id = context->transaction.GetActiveQuery();
 			request_message->SetClientQueryId(client_query_id);
 		}

--- a/test/sql/attach_ctas.test
+++ b/test/sql/attach_ctas.test
@@ -6,11 +6,13 @@ require quack
 
 foreach server 'quack:localhost'
 
+foreach ssl false true
+
 statement ok con1
-call rpc_start(${server});
+call rpc_start({server}, disable_ssl={ssl});
 
 statement ok con2
-attach ${server} as rpc (TYPE rpc)
+attach {server} as rpc (disable_ssl {ssl})
 
 statement ok
 create table rpc.t as select range a from range(10);
@@ -27,6 +29,8 @@ statement ok con2
 detach rpc;
 
 statement ok con1
-call rpc_stop(${server});
+call rpc_stop({server});
+
+endloop
 
 endloop

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -6,6 +6,8 @@ require quack
 
 foreach server 'quack:localhost'
 
+foreach ssl false true
+
 statement ok con1
 create table t1 as select range i from range(100);
 
@@ -13,10 +15,10 @@ statement ok con1
 create table t2 as select range j from range(200);
 
 statement ok con1
-call rpc_start(${server});
+call rpc_start({server}, disable_ssl={ssl});
 
 statement ok con2
-attach ${server} as rpc (TYPE rpc)
+attach {server} as rpc (disable_ssl {ssl})
 
 # Single table scan should work
 query I
@@ -41,6 +43,8 @@ statement ok con2
 detach rpc;
 
 statement ok con1
-call rpc_stop(${server});
+call rpc_stop({server});
+
+endloop
 
 endloop

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -4,15 +4,15 @@
 
 require quack
 
-foreach server 'quack:localhost'
-
-foreach ssl false true
-
 statement ok con1
 create table t1 as select range i from range(100);
 
 statement ok con1
 create table t2 as select range j from range(200);
+
+foreach server 'quack:localhost'
+
+foreach ssl false true
 
 statement ok con1
 call rpc_start({server}, disable_ssl={ssl});

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -4,12 +4,12 @@
 
 require quack
 
+statement ok con1
+create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
+
 foreach server 'quack:localhost'
 
 foreach ssl false true
-
-statement ok con1
-create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
 
 statement ok con1
 call rpc_start({server}, disable_ssl={ssl});

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -4,16 +4,18 @@
 
 require quack
 
-foreach server  '__TEST_DIR__/duckdb-rpc-socket-pushdown'
+foreach server 'quack:localhost'
+
+foreach ssl false true
 
 statement ok con1
 create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
 
 statement ok con1
-call rpc_start(${server});
+call rpc_start({server}, disable_ssl={ssl});
 
 statement ok con2
-attach ${server} as rpc (TYPE rpc)
+attach {server} as rpc (disable_ssl {ssl})
 
 # Verify projection pushdown: selecting one column should only project that column
 query II
@@ -91,6 +93,8 @@ statement ok con2
 detach rpc;
 
 statement ok con1
-call rpc_stop(${server});
+call rpc_stop({server});
+
+endloop
 
 endloop


### PR DESCRIPTION
Requests and responses had just placeholder `Value` i forgot to fill in. I constructed something based on what I see available in httplib:

```sql
memory D from duckdb_logs_parsed('http') select query_id, type, request limit 2;
┌──────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ query_id │  type   │                                                                              request                                                                               │
│  uint64  │ varchar │                    struct("type" varchar, url varchar, start_time timestamp with time zone, duration_ms bigint, headers map(varchar, varchar))                     │
├──────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│        9 │ HTTP    │ {'type': POST, 'url': 'http://localhost:9090/rpc', 'start_time': '2026-04-13 14:48:25.583641+00', 'duration_ms': 3, 'headers': {Content-Type=application/duckdb}}  │
│        9 │ HTTP    │ {'type': POST, 'url': 'http://localhost:9090/rpc', 'start_time': '2026-04-13 14:48:25.587081+00', 'duration_ms': 52, 'headers': {Content-Type=application/duckdb}} │
└──────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
memory D from duckdb_logs_parsed('http') select query_id, type, response limit 2;
┌──────────┬─────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ query_id │  type   │                                                             response                                                             │
│  uint64  │ varchar │                              struct(status varchar, reason varchar, headers map(varchar, varchar))                               │
├──────────┼─────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│        9 │ HTTP    │ {'status': 200, 'reason': OK, 'headers': {Content-Length=52, Keep-Alive='timeout=5, max=100', Content-Type=application/duckdb}}  │
│        9 │ HTTP    │ {'status': 200, 'reason': OK, 'headers': {Content-Length=341, Keep-Alive='timeout=5, max=100', Content-Type=application/duckdb}} │
└──────────┴─────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
I think this looks reasonable but I don't know if I'm missing something.

I also fixed some tests.

> FYI, new changes in main broke the Attach path, a subsequent PR may follow!

### Edit
I also fixed a bug when using GetActiveQuery in a transaction context (relevant for the `ATTACH` path).