### PR TITLE
Some improvement on batching logic to reduce the amount of fetch requests

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -132,10 +132,12 @@ unique_ptr<ColumnDataCollection> RpcCatalog::ExecuteCommand(const string &query)
 	chunk_collection->Initialize(response->Types());
 	while (true) {
 		auto fetch_response = client->Request<FetchResponseMessage>(make_uniq<FetchRequestMessage>(connection_id));
-		if (!fetch_response || !fetch_response->ResponseData() || fetch_response->ResponseData()->size() == 0) {
+		if (!fetch_response || fetch_response->Chunks().empty()) {
 			break;
 		}
-		chunk_collection->Append(*fetch_response->ResponseData());
+		for (auto &chunk : fetch_response->Chunks()) {
+			chunk_collection->Append(*chunk);
+		}
 	}
 	return chunk_collection;
 }

--- a/src/include/message.hpp
+++ b/src/include/message.hpp
@@ -186,17 +186,22 @@ class FetchResponseMessage : public ProtocolMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_RESPONSE;
 
-	explicit FetchResponseMessage(unique_ptr<DataChunk> response_data_p)
-	    : ProtocolMessage(TYPE), response_data(std::move(response_data_p)) {};
+	FetchResponseMessage() : ProtocolMessage(TYPE) {};
+	explicit FetchResponseMessage(vector<unique_ptr<DataChunk>> chunks_p)
+	    : ProtocolMessage(TYPE), chunks(std::move(chunks_p)) {};
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ProtocolMessage> Deserialize(Deserializer &deserializer);
-	optional_ptr<DataChunk> ResponseData() const {
-		return response_data.get();
+
+	const vector<unique_ptr<DataChunk>> &Chunks() const {
+		return chunks;
+	}
+	vector<unique_ptr<DataChunk>> &MutableChunks() {
+		return chunks;
 	}
 
 private:
-	unique_ptr<DataChunk> response_data;
+	vector<unique_ptr<DataChunk>> chunks;
 };
 
 // orrr

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -185,24 +185,19 @@ unique_ptr<ProtocolMessage> FetchRequestMessage::Deserialize(Deserializer &deser
 
 void FetchResponseMessage::Serialize(Serializer &serializer) const {
 	ProtocolMessage::Serialize(serializer);
-	auto response_data_present = response_data && response_data->size() > 0;
-	serializer.WriteProperty<bool>(250, "response_data_present", response_data_present);
-	if (response_data_present) {
-		serializer.WriteObject(251, "response_data",
-		                       [&](Serializer &inner_serializer) { response_data->Serialize(inner_serializer); });
-	}
+	serializer.WriteList(252, "chunks", chunks.size(), [&](Serializer::List &list, idx_t i) {
+		list.WriteObject([&](Serializer &inner) { chunks[i]->Serialize(inner); });
+	});
 }
 
 unique_ptr<ProtocolMessage> FetchResponseMessage::Deserialize(Deserializer &deserializer) {
-	auto response_data_present = deserializer.ReadProperty<bool>(250, "response_data_present");
-	if (!response_data_present) {
-		return make_uniq<FetchResponseMessage>(nullptr);
-	}
-
-	auto result_chunk = make_uniq<DataChunk>();
-	deserializer.ReadObject(251, "response_data",
-	                        [&](Deserializer &inner_deserializer) { result_chunk->Deserialize(inner_deserializer); });
-	return make_uniq<FetchResponseMessage>(std::move(result_chunk));
+	vector<unique_ptr<DataChunk>> chunks;
+	deserializer.ReadList(252, "chunks", [&](Deserializer::List &list, idx_t i) {
+		auto chunk = make_uniq<DataChunk>();
+		list.ReadObject([&](Deserializer &inner) { chunk->Deserialize(inner); });
+		chunks.push_back(std::move(chunk));
+	});
+	return make_uniq<FetchResponseMessage>(std::move(chunks));
 }
 
 void ErrorMessage::Serialize(Serializer &serializer) const {

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -129,6 +129,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// TODO make this readonly from SQL?
 	config.AddExtensionOption("rpc_default_token", "Authorization token used by default", LogicalType::VARCHAR, Value(),
 	                          nullptr, SetScope::GLOBAL);
+
+	config.AddExtensionOption("quack_fetch_batch_chunks",
+	                          "Maximum number of DataChunks returned per FETCH response",
+	                          LogicalType::UBIGINT, Value::UBIGINT(12));
+	config.AddExtensionOption("quack_fetch_batch_bytes",
+	                          "Maximum estimated payload bytes per FETCH response",
+	                          LogicalType::UBIGINT, Value::UBIGINT(4 * (1 << 20)));
 }
 
 void QuackExtension::Load(ExtensionLoader &loader) {

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -11,6 +11,8 @@
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 
+#include <queue>
+
 using namespace duckdb;
 
 static unique_ptr<FunctionData> RpcBind(ClientContext &context, TableFunctionBindInput &input,
@@ -98,6 +100,8 @@ static unique_ptr<FunctionData> RpcBindCatalogName(ClientContext &context, Table
 
 struct RpcLocalState : public LocalTableFunctionState {
 	unique_ptr<RpcClient> client;
+	std::queue<unique_ptr<DataChunk>> pending;
+	bool server_exhausted = false;
 
 	explicit RpcLocalState() {
 	}
@@ -244,14 +248,28 @@ static void RpcScan(ClientContext &context, TableFunctionInput &input, DataChunk
 	if (global_state.done) {
 		return;
 	}
-	auto fetch_response =
-	    local_state.client->Request<FetchResponseMessage>(make_uniq<FetchRequestMessage>(bind_data.connection_id));
-	if (!fetch_response->ResponseData() || fetch_response->ResponseData()->size() == 0) {
+
+	if (local_state.pending.empty() && !local_state.server_exhausted) {
+		auto fetch_response =
+		    local_state.client->Request<FetchResponseMessage>(make_uniq<FetchRequestMessage>(bind_data.connection_id));
+		if (fetch_response->Chunks().empty()) {
+			local_state.server_exhausted = true;
+		} else {
+			for (auto &chunk : fetch_response->MutableChunks()) {
+				local_state.pending.push(std::move(chunk));
+			}
+		}
+	}
+
+	if (local_state.pending.empty()) {
 		global_state.done = true;
 		return;
 	}
 
-	auto &response_chunk = *fetch_response->ResponseData();
+	auto chunk = std::move(local_state.pending.front());
+	local_state.pending.pop();
+
+	auto &response_chunk = *chunk;
 	if (response_chunk.ColumnCount() == output.ColumnCount()) {
 		output.Reference(response_chunk);
 	} else {

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -245,15 +245,15 @@ static void RpcScan(ClientContext &context, TableFunctionInput &input, DataChunk
 	auto &global_state = input.global_state->Cast<RpcGlobalState>();
 	auto &local_state = input.local_state->Cast<RpcLocalState>();
 
-	if (global_state.done) {
-		return;
-	}
-
-	if (local_state.pending.empty() && !local_state.server_exhausted) {
+	// Only issue a new FETCH if we've drained our local batch and the stream
+	// hasn't signalled end. global_state.done is an optimization hint that
+	// skips wasted FETCHes — it must not pre-empt draining local pending.
+	if (local_state.pending.empty() && !local_state.server_exhausted && !global_state.done) {
 		auto fetch_response =
 		    local_state.client->Request<FetchResponseMessage>(make_uniq<FetchRequestMessage>(bind_data.connection_id));
 		if (fetch_response->Chunks().empty()) {
 			local_state.server_exhausted = true;
+			global_state.done = true;
 		} else {
 			for (auto &chunk : fetch_response->MutableChunks()) {
 				local_state.pending.push(std::move(chunk));
@@ -262,7 +262,6 @@ static void RpcScan(ClientContext &context, TableFunctionInput &input, DataChunk
 	}
 
 	if (local_state.pending.empty()) {
-		global_state.done = true;
 		return;
 	}
 

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -228,22 +228,32 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 		std::unique_lock<std::mutex> lock(rpc_connection->lock);
 
 		if (!rpc_connection->duckdb_query_result) {
-			return make_uniq<FetchResponseMessage>(nullptr);
+			return make_uniq<FetchResponseMessage>();
 		}
 		if (rpc_connection->duckdb_query_result->HasError()) {
 			return make_uniq<ErrorMessage>(rpc_connection->duckdb_query_result->GetError());
 		}
-		auto result_chunk = rpc_connection->duckdb_query_result->Fetch();
-		if (!result_chunk && rpc_connection->duckdb_query_result->HasError()) {
-			auto error = make_uniq<ErrorMessage>(rpc_connection->duckdb_query_result->GetError());
-			rpc_connection->duckdb_query_result.reset();
-			return error;
+
+		constexpr idx_t MAX_CHUNKS_PER_BATCH = 12;
+		constexpr idx_t MAX_BYTES_PER_BATCH = 4 * (1 << 20); // 4 MiB
+
+		vector<unique_ptr<DataChunk>> batch;
+		idx_t bytes_est = 0;
+		while (batch.size() < MAX_CHUNKS_PER_BATCH && bytes_est < MAX_BYTES_PER_BATCH) {
+			auto result_chunk = rpc_connection->duckdb_query_result->Fetch();
+			if (!result_chunk && rpc_connection->duckdb_query_result->HasError()) {
+				auto error = make_uniq<ErrorMessage>(rpc_connection->duckdb_query_result->GetError());
+				rpc_connection->duckdb_query_result.reset();
+				return error;
+			}
+			if (!result_chunk || result_chunk->size() == 0) {
+				rpc_connection->duckdb_query_result.reset();
+				break;
+			}
+			bytes_est += result_chunk->size() * result_chunk->ColumnCount() * 8;
+			batch.push_back(std::move(result_chunk));
 		}
-		if (!result_chunk || result_chunk->size() == 0) {
-			rpc_connection->duckdb_query_result.reset();
-			return make_uniq<FetchResponseMessage>(nullptr);
-		}
-		return make_uniq<FetchResponseMessage>(std::move(result_chunk));
+		return make_uniq<FetchResponseMessage>(std::move(batch));
 	}
 
 	case MessageType::CATALOG_REQUEST: {

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -234,12 +234,16 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 			return make_uniq<ErrorMessage>(rpc_connection->duckdb_query_result->GetError());
 		}
 
-		constexpr idx_t MAX_CHUNKS_PER_BATCH = 12;
-		constexpr idx_t MAX_BYTES_PER_BATCH = 4 * (1 << 20); // 4 MiB
+		Value max_chunks_val;
+		Value max_bytes_val;
+		DBConfig::GetConfig(*db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);
+		DBConfig::GetConfig(*db).TryGetCurrentSetting("quack_fetch_batch_bytes", max_bytes_val);
+		auto max_chunks_per_batch = max_chunks_val.GetValue<uint64_t>();
+		auto max_bytes_per_batch = max_bytes_val.GetValue<uint64_t>();
 
 		vector<unique_ptr<DataChunk>> batch;
 		idx_t bytes_est = 0;
-		while (batch.size() < MAX_CHUNKS_PER_BATCH && bytes_est < MAX_BYTES_PER_BATCH) {
+		while (batch.size() < max_chunks_per_batch && bytes_est < max_bytes_per_batch) {
 			auto result_chunk = rpc_connection->duckdb_query_result->Fetch();
 			if (!result_chunk && rpc_connection->duckdb_query_result->HasError()) {
 				auto error = make_uniq<ErrorMessage>(rpc_connection->duckdb_query_result->GetError());


### PR DESCRIPTION
This PR modifies slightly the logic to be able to fetch a vector of data chunks. The heuristics are very simple and depend on two exposed settings:
- `quack_fetch_batch_chunks`: max chunks per batch. Default 12.
- `quack_fetch_batch_bytes`: approximate payload cap in bytes. Default 4 MiB.

The default values are based on a paremeter sweep with `quack` running in localhost. I suspect optimal values may be different if you are running the server remote, and they also may change if you are running both the sever and the client in the same availability zone in the cloud. Further investigation can go into this route. The results of the parameter sweep (using `FROM lineitem` query with sf=10):

```
  ┌─────────────────────────────┬───────────┬────────────────────────────────────┬─────────────────────────────┐
  │           Config            │ Wall time │            FETCH calls             │         vs baseline         │
  ├─────────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
  │ Baseline (1 chunk/FETCH)    │ 4.95 s    │ ~29,290                            │ —                           │
  ├─────────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
  │ 4 chunks × 2 MiB            │ 4.56 s    │ —                                  │ –7.9%                       │
  ├─────────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
  │ 8 chunks × 2 MiB            │ 4.42 s    │ —                                  │ –10.7%                      │
  ├─────────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
  │ 12 chunks × 4 MiB (default) │ 4.42 s    │ 2,452 (measured)                   │ –10.7% / ~12× fewer FETCHes │
  ├─────────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
  │ 16 chunks × 4 MiB           │ 4.52 s    │ —                                  │ –8.7%                       │
  ├─────────────────────────────┼───────────┼────────────────────────────────────┼─────────────────────────────┤
  │ 64 chunks × 16 MiB          │ 5.10 s    │ —                                  │ +3.0% (regression)          │
  └─────────────────────────────┴───────────┴────────────────────────────────────┴─────────────────────────────┘
```

> I did not fetch the amount of requests with the other parameters because I only thought of it after running this benches and I didn't want to run everything again. But the important ones are there.

### Other avenues to explore

- Prefetching on the client: this is only meaningful if the actual fetch requests take some time, so in the localhost checks it improved nothing. The idea is that we can have a sequence like this one `[send FETCH #1] → [send FETCH #2] → [decode #1] → [send FETCH #3] → [decode #2] → ...` where we send a fetch request async before the decoding of the previous request have been done as to not have client threads waiting. This could be interesting because it is low impact in the current code.

- Body compression? DataChunk::Serialize already compresses dictionary / constant / sequence vectors, but flat vectors (the common case for table scans) go out uncompressed AFAIK (I'm not sure).

- The general bottleneck is the mutex in RPCConnection to prevent multiple threads from reading a streaming `QueryResult` in parallel, which is not currently possible (I believe). I think potentially rethinking this will be the biggest gain, since the parallelization at the client side hits this single bottleneck at the server side.