### PR TITLE
Client: Avoid builtin httplib, go with HTTPUtils from DatabaseInstance

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,7 +19,7 @@ jobs:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
       extension_name: quack
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
 
   code-quality-check:
     name: Code Quality Check
@@ -39,6 +39,6 @@ jobs:
       extension_name: quack
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
+      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -28,7 +28,7 @@ jobs:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
       extension_name: quack
-      format_checks: 'format;tidy'
+      format_checks: 'format'
 
   duckdb-stable-deploy:
     name: Deploy extension binaries

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=rpc
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+DEFAULT_TEST_EXTENSION_DEPS=httpfs;
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,5 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=rpc
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-DEFAULT_TEST_EXTENSION_DEPS=httpfs;
-
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,7 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=rpc
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+DEFAULT_TEST_EXTENSION_DEPS=httpfs
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,4 +9,3 @@ duckdb_extension_load(quack
 # Any extra extensions that should be built
 duckdb_extension_load(json)
 duckdb_extension_load(autocomplete)
-duckdb_extension_load(httpfs)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,3 +9,4 @@ duckdb_extension_load(quack
 # Any extra extensions that should be built
 duckdb_extension_load(json)
 duckdb_extension_load(autocomplete)
+duckdb_extension_load(httpfs)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,3 +9,8 @@ duckdb_extension_load(quack
 # Any extra extensions that should be built
 duckdb_extension_load(json)
 duckdb_extension_load(autocomplete)
+
+duckdb_extension_load(httpfs
+    GIT_URL https://github.com/duckdb/duckdb-httpfs
+    GIT_TAG 13e18b3c9f3810334f5972b76a3acc247b28e537
+)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,8 +9,3 @@ duckdb_extension_load(quack
 # Any extra extensions that should be built
 duckdb_extension_load(json)
 duckdb_extension_load(autocomplete)
-
-duckdb_extension_load(httpfs
-    GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 13e18b3c9f3810334f5972b76a3acc247b28e537
-)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,8 +1,9 @@
 #include "client.hpp"
 #include "rpc_uri.hpp"
 
-#define CPPHTTPLIB_OPENSSL_SUPPORT
-#include "httplib.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension_helper.hpp"
 
 using namespace duckdb;
 
@@ -14,90 +15,50 @@ string GetUriPart(T ele) {
 	return string(ele.first, ele.afterLast - ele.first);
 }
 
-HttpsRpcClient::HttpsRpcClient(const RpcUri &uri_p) : RpcClient(uri_p) {
-	https_client = make_uniq<duckdb_httplib_openssl::Client>(uri.Http());
-	if (uri.Ssl()) {
-		https_client->enable_server_certificate_verification(false);
-		https_client->enable_server_hostname_verification(false);
-	}
-	https_client->set_keep_alive(true);
-	https_client->set_follow_location(true);
-};
+HttpsRpcClient::HttpsRpcClient(const RpcUri &uri_p) : RpcClient(uri_p) {};
 
 HttpsRpcClient::~HttpsRpcClient() {
-	https_client.reset();
+	http_client.reset();
 }
 
 unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolMessage> request_message) {
 	D_ASSERT(request_message);
+	if (!context) {
+		throw InvalidInputException("RpcClient requires a ClientContext to make requests");
+	}
 	request_message->ToMemoryStream(write_stream);
 
-	int64_t start_time = 0;
-	timestamp_t request_start;
-	bool should_log_http = context && Logger::Get(*context).ShouldLog(HTTPLogType::NAME, HTTPLogType::LEVEL);
-	if (should_log_http) {
-		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-		                 .time_since_epoch()
-		                 .count();
-		request_start = Timestamp::GetCurrentTimestamp();
+	auto &db = *context->db;
+	ExtensionHelper::AutoLoadExtension(db, "httpfs");
+	if (!db.ExtensionIsLoaded("httpfs")) {
+		throw MissingExtensionException("The rpc extension requires the httpfs extension to be loaded!");
 	}
 
-	auto https_result = https_client->Post("/rpc", (const char *)write_stream.GetData(), write_stream.GetPosition(),
-	                                       "application/duckdb");
-
-	if (should_log_http) {
-		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-		                       .time_since_epoch()
-		                       .count();
-		int64_t duration_ms = end_time - start_time;
-		int status = https_result ? https_result->status : -1;
-
-		// Build request headers map
-		vector<Value> req_header_keys;
-		vector<Value> req_header_values;
-		req_header_keys.emplace_back("Content-Type");
-		req_header_values.emplace_back("application/duckdb");
-		auto request_headers_value =
-		    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, req_header_keys, req_header_values);
-
-		child_list_t<Value> request_child_list = {
-		    {"type", Value("POST")},
-		    {"url", Value(uri.Http() + "/rpc")},
-		    {"start_time", Value::TIMESTAMP(request_start)},
-		    {"duration_ms", Value::BIGINT(duration_ms)},
-		    {"headers", request_headers_value},
-		};
-		auto request_value = Value::STRUCT(request_child_list);
-
-		// Build response headers map from cpp-httplib result
-		Value response_headers_value;
-		if (https_result) {
-			vector<Value> resp_header_keys;
-			vector<Value> resp_header_values;
-			for (const auto &header : https_result->headers) {
-				resp_header_keys.emplace_back(header.first);
-				resp_header_values.emplace_back(header.second);
-			}
-			response_headers_value =
-			    Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, resp_header_keys, resp_header_values);
-		}
-
-		child_list_t<Value> response_child_list = {
-		    {"status", Value(to_string(status))},
-		    {"reason", https_result ? Value(https_result->reason) : Value()},
-		    {"headers", response_headers_value},
-		};
-		auto response_value = Value::STRUCT(response_child_list);
-
-		child_list_t<Value> child_list = {{"request", request_value}, {"response", response_value}};
-		auto msg = Value::STRUCT(child_list).ToString();
-		Logger::Get(*context).WriteLog(HTTPLogType::NAME, HTTPLogType::LEVEL, msg);
+	auto &http_util = HTTPUtil::Get(db);
+	auto request_url = uri.Http() + "/rpc";
+	auto params = http_util.InitializeParameters(*context, request_url);
+	if (uri.Ssl()) {
+		params->verify_ssl = false;
+		params->override_verify_ssl = true;
+	}
+	if (http_client) {
+		http_client->Initialize(*params);
 	}
 
-	if (!https_result) {
-		throw IOException("Failed to send message %s ", to_string(https_result.error()));
+	HTTPHeaders headers;
+	headers.Insert("Content-Type", "application/duckdb");
+
+	PostRequestInfo post_request(request_url, headers, *params,
+	                             reinterpret_cast<const_data_ptr_t>(write_stream.GetData()),
+	                             write_stream.GetPosition());
+	auto response = http_util.Request(post_request, http_client);
+
+	if (!response || !response->Success()) {
+		string error = response ? response->GetError() : "no response";
+		throw IOException("Failed to send message: %s", error);
 	}
-	MemoryStream non_owning_read_stream((data_ptr_t)https_result->body.data(), https_result->body.size());
+
+	MemoryStream non_owning_read_stream((data_ptr_t)post_request.buffer_out.data(), post_request.buffer_out.size());
 	return ProtocolMessage::FromMemoryStream(non_owning_read_stream);
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,23 +36,22 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 
 	auto &http_util = HTTPUtil::Get(db);
 	auto request_url = uri.Http() + "/rpc";
-	auto params = http_util.InitializeParameters(*context, request_url);
-	if (uri.Ssl()) {
-		params->verify_ssl = false;
-		params->override_verify_ssl = true;
+	if (!http_params) {
+		http_params = http_util.InitializeParameters(*context, request_url);
 	}
 	if (http_client) {
-		http_client->Initialize(*params);
+		http_client->Initialize(*http_params);
 	}
 
 	HTTPHeaders headers;
 	headers.Insert("Content-Type", "application/duckdb");
 
-	PostRequestInfo post_request(request_url, headers, *params,
+	PostRequestInfo post_request(request_url, headers, *http_params,
 	                             reinterpret_cast<const_data_ptr_t>(write_stream.GetData()),
 	                             write_stream.GetPosition());
 	unique_ptr<HTTPResponse> response;
 	try {
+		// funny side-effect: Request will create (and populate) http_client if nullptr is passed
 		response = http_util.Request(post_request, http_client);
 	} catch (std::exception &e) {
 		throw IOException("Failed to send message: %s", e.what());

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -51,7 +51,12 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 	PostRequestInfo post_request(request_url, headers, *params,
 	                             reinterpret_cast<const_data_ptr_t>(write_stream.GetData()),
 	                             write_stream.GetPosition());
-	auto response = http_util.Request(post_request, http_client);
+	unique_ptr<HTTPResponse> response;
+	try {
+		response = http_util.Request(post_request, http_client);
+	} catch (std::exception &e) {
+		throw IOException("Failed to send message: %s", e.what());
+	}
 
 	if (!response || !response->Success()) {
 		string error = response ? response->GetError() : "no response";

--- a/src/include/client.hpp
+++ b/src/include/client.hpp
@@ -117,6 +117,7 @@ private:
 
 private:
 	unique_ptr<HTTPClient> http_client;
+	unique_ptr<HTTPParams> http_params;
 };
 
 } // namespace duckdb

--- a/src/include/client.hpp
+++ b/src/include/client.hpp
@@ -4,11 +4,8 @@
 #include "rpc_log_type.hpp"
 #include "rpc_uri.hpp"
 
+#include "duckdb/common/http_util.hpp"
 #include "duckdb/logging/logger.hpp"
-
-namespace duckdb_httplib_openssl {
-class Client;
-}
 
 namespace duckdb {
 
@@ -119,7 +116,7 @@ private:
 	unique_ptr<ProtocolMessage> RequestInternal(unique_ptr<ProtocolMessage> request_message) override;
 
 private:
-	unique_ptr<duckdb_httplib_openssl::Client> https_client;
+	unique_ptr<HTTPClient> http_client;
 };
 
 } // namespace duckdb

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 
+#include <sys/socket.h>
+
 using namespace duckdb;
 
 string duckdb::MessageTypeToString(MessageType type) {

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -6,6 +6,8 @@ require quack
 
 require httpfs
 
+set ignore_error_messages __none__
+
 statement ok
 create schema moo;
 
@@ -134,7 +136,7 @@ call rpc_stop({server});
 statement error con2
 attach {server} as rpc (disable_ssl {ssl})
 ----
-Failed to send message
+IO Error
 
 endloop
 

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -4,6 +4,7 @@
 
 require quack
 
+require httpfs
 
 statement ok
 create schema moo;

--- a/test/sql/attach_ctas.test
+++ b/test/sql/attach_ctas.test
@@ -4,6 +4,8 @@
 
 require quack
 
+require httpfs
+
 foreach server 'quack:localhost'
 
 

--- a/test/sql/attach_ctas.test
+++ b/test/sql/attach_ctas.test
@@ -6,6 +6,8 @@ require quack
 
 require httpfs
 
+set ignore_error_messages __none__
+
 foreach server 'quack:localhost'
 
 

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -4,6 +4,8 @@
 
 require quack
 
+require httpfs
+
 statement ok
 set rpc_default_token='asdf'
 

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -6,6 +6,8 @@ require quack
 
 require httpfs
 
+set ignore_error_messages __none__
+
 statement ok
 set rpc_default_token='asdf'
 

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -129,7 +129,7 @@ true
 
 # check HTTP response status
 query I con2
-select count(*) > 0 from duckdb_logs_parsed('HTTP') where response.status = '200'
+select count(*) > 0 from duckdb_logs_parsed('HTTP') where response.status = 'OK_200'
 ----
 true
 

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -6,6 +6,8 @@ require quack
 
 require httpfs
 
+set ignore_error_messages __none__
+
 statement ok con1
 create table t1 as select range i from range(100);
 
@@ -17,10 +19,10 @@ foreach server 'quack:localhost'
 foreach ssl true
 
 statement ok con1
-call rpc_start({server}, disable_ssl={ssl});
+call rpc_start({server}, disable_ssl=true);
 
 statement ok con2
-attach {server} as rpc (disable_ssl {ssl})
+attach {server} as rpc (disable_ssl true);
 
 # Single table scan should work
 query I

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -4,6 +4,8 @@
 
 require quack
 
+require httpfs
+
 statement ok con1
 create table t1 as select range i from range(100);
 

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -4,6 +4,8 @@
 
 require quack
 
+require httpfs
+
 statement ok con1
 create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
 

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -6,6 +6,8 @@ require quack
 
 require httpfs
 
+set ignore_error_messages __none__
+
 statement ok con1
 create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
 

--- a/test/sql/rpc.test
+++ b/test/sql/rpc.test
@@ -8,6 +8,8 @@ require json
 
 require httpfs
 
+set ignore_error_messages __none__
+
 foreach server 'quack:localhost'
 
 foreach ssl true

--- a/test/sql/rpc.test
+++ b/test/sql/rpc.test
@@ -6,6 +6,8 @@ require quack
 
 require json
 
+require httpfs
+
 foreach server 'quack:localhost'
 
 foreach ssl true

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,1 @@
-{
-        "dependencies": [
-        ],
-        "vcpkg-configuration": {
-                "overlay-ports": [
-                        "./extension-ci-tools/vcpkg_ports"
-                ],
-                "overlay-triplets": [
-                        "./extension-ci-tools/toolchains"
-                ]
-        }
-}
+{ }


### PR DESCRIPTION
This is similar to (and substitute) https://github.com/duckdb/duckdb-quack/pull/16, modelled after https://github.com/duckdb/duckdb-iceberg/pull/576.

After that, a few other changes for errors I bumped against.
* add httpfs as dependency
* fixup tests to require https (autoload) + adapt them to httpfs logging
* do check (before `rpc_start`) whether the port is already taken by a different process. Same process, the check do not works, but that should be less of an issue.