### PR TITLE
Bring back httpfs dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,5 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=rpc
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-DEFAULT_TEST_EXTENSION_DEPS=httpfs
-
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -9,3 +9,8 @@ duckdb_extension_load(quack
 # Any extra extensions that should be built
 duckdb_extension_load(json)
 duckdb_extension_load(autocomplete)
+
+duckdb_extension_load(httpfs
+    GIT_URL https://github.com/duckdb/duckdb-httpfs
+    GIT_TAG 13e18b3c9f3810334f5972b76a3acc247b28e537
+)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,1 +1,14 @@
-{ }
+{
+        "dependencies": [
+                "openssl", "curl"
+        ],
+        "vcpkg-configuration": {
+                "overlay-ports": [
+                        "./extension-ci-tools/vcpkg_ports"
+                ],
+                "overlay-triplets": [
+                        "./extension-ci-tools/toolchains"
+                ]
+        }
+}
+


### PR DESCRIPTION
Those are needed for `httpfs`, I need to figure out how to remove those, but likely requires changes in extension-ci-tools, that's out of scope for now.