### PR TITLE
Add catalog enumeration in attach path

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -289,34 +289,6 @@ void RpcSchemaCatalogEntry::RemoveFromTableCache(const string &table_name) {
 	table_cache.erase(table_name);
 }
 
-optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::ReloadTableEntry(const string &table_name) {
-	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
-	auto &context = rpc_catalog.GetContext();
-
-	auto query = StringUtil::Format("SELECT column_name, data_type "
-	                                "FROM duckdb_columns() "
-	                                "WHERE schema_name = %s AND table_name = %s AND NOT internal "
-	                                "ORDER BY column_index",
-	                                KeywordHelper::WriteQuoted(name, '\''),
-	                                KeywordHelper::WriteQuoted(table_name, '\''));
-	auto result = rpc_catalog.ExecuteCommand(query);
-	auto rows = result->GetRows();
-
-	if (rows.size() == 0) {
-		return nullptr;
-	}
-
-	CreateTableInfo create_info(*this, table_name);
-	for (idx_t i = 0; i < rows.size(); i++) {
-		create_info.columns.AddColumn(ColumnDefinition(rows.GetValue(0, i).GetValue<string>(),
-		                                               TransformStringToLogicalType(rows.GetValue(1, i).GetValue<string>(), context)));
-	}
-	auto entry = make_uniq<RpcTableCatalogEntry>(catalog, *this, create_info);
-	auto result_ptr = entry.get();
-	AddToTableCache(table_name, std::move(entry));
-	return result_ptr;
-}
-
 void RpcSchemaCatalogEntry::LoadTableCache() {
 	{
 		lock_guard<mutex> guard(table_cache_lock);

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -88,7 +88,7 @@ void RpcTransactionManager::Checkpoint(ClientContext &context, bool force) {
 }
 
 RpcCatalog::RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p, ClientContext &context)
-    : Catalog(db_p), server_uri(server_uri_p), client(RpcClient::GetClient(server_uri)), client_context(&context) {
+    : Catalog(db_p), server_uri(server_uri_p), client(RpcClient::GetClient(server_uri)), client_context(context) {
 	client->SetContext(&context);
 
 	// evil copy paste
@@ -170,7 +170,7 @@ const string &RpcCatalog::GetConnectionId() {
 }
 
 ClientContext &RpcCatalog::GetContext() {
-	return *client_context;
+	return client_context;
 }
 
 optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::LookupEntry(CatalogTransaction transaction,
@@ -221,7 +221,8 @@ optional_ptr<CatalogEntry> RpcCatalog::CreateSchema(CatalogTransaction transacti
 	auto catalog_request_message = make_uniq<CatalogRequestMessage>(GetConnectionId(), std::move(create_schema_info));
 	auto catalog_response = GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
 
-	auto &response_info = catalog_response->GetParseInfo()->Cast<CreateSchemaInfo>();
+	auto response_parse_info = catalog_response->GetParseInfo();
+	auto &response_info = response_parse_info->Cast<CreateSchemaInfo>();
 	auto entry = make_uniq<RpcSchemaCatalogEntry>(*this, response_info);
 	auto result = entry.get();
 	schemas[response_info.schema] = std::move(entry);
@@ -286,16 +287,16 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::ReloadTableEntry(const string 
 	                                KeywordHelper::WriteQuoted(name, '\''),
 	                                KeywordHelper::WriteQuoted(table_name, '\''));
 	auto result = rpc_catalog.ExecuteCommand(query);
-	auto rows = make_uniq<ColumnDataRowCollection>(result->GetRows());
+	auto rows = result->GetRows();
 
-	if (rows->size() == 0) {
+	if (rows.size() == 0) {
 		return nullptr;
 	}
 
 	CreateTableInfo create_info(*this, table_name);
-	for (idx_t i = 0; i < rows->size(); i++) {
-		create_info.columns.AddColumn(ColumnDefinition(rows->GetValue(0, i).GetValue<string>(),
-		                                               TransformStringToLogicalType(rows->GetValue(1, i).GetValue<string>(), context)));
+	for (idx_t i = 0; i < rows.size(); i++) {
+		create_info.columns.AddColumn(ColumnDefinition(rows.GetValue(0, i).GetValue<string>(),
+		                                               TransformStringToLogicalType(rows.GetValue(1, i).GetValue<string>(), context)));
 	}
 	auto entry = make_uniq<RpcTableCatalogEntry>(catalog, *this, create_info);
 	auto result_ptr = entry.get();
@@ -320,16 +321,16 @@ void RpcSchemaCatalogEntry::LoadTableCache() {
 	                                "ORDER BY table_name, column_index",
 	                                KeywordHelper::WriteQuoted(name, '\''));
 	auto result = rpc_catalog.ExecuteCommand(query);
-	auto rows = make_uniq<ColumnDataRowCollection>(result->GetRows());
+	auto rows = result->GetRows();
 
 	case_insensitive_map_t<unique_ptr<CatalogEntry>> new_entries;
 	string current_table;
 	unique_ptr<CreateTableInfo> current_info;
 
-	for (idx_t i = 0; i < rows->size(); i++) {
-		auto table_name = rows->GetValue(0, i).GetValue<string>();
-		auto col_name = rows->GetValue(1, i).GetValue<string>();
-		auto type_str = rows->GetValue(2, i).GetValue<string>();
+	for (idx_t i = 0; i < rows.size(); i++) {
+		auto table_name = rows.GetValue(0, i).GetValue<string>();
+		auto col_name = rows.GetValue(1, i).GetValue<string>();
+		auto type_str = rows.GetValue(2, i).GetValue<string>();
 
 		if (table_name != current_table) {
 			if (current_info) {

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -21,21 +21,27 @@ RpcTransaction::RpcTransaction(RpcCatalog &rpc_catalog_p, TransactionManager &ma
     : Transaction(manager_p, context_p), rpc_catalog(rpc_catalog_p) {
 }
 
-void RpcTransaction::EnsureBegun() {
-	if (!begun) {
-		rpc_catalog.ExecuteCommand("BEGIN TRANSACTION");
-		begun = true;
+RpcClient &RpcTransaction::GetClient() {
+	if (transaction_state == RpcTransactionState::TRANSACTION_FINISHED) {
+		throw InternalException("Cannot use RPC transaction after commit/rollback");
 	}
+	if (transaction_state == RpcTransactionState::TRANSACTION_NOT_YET_STARTED) {
+		rpc_catalog.ExecuteCommand("BEGIN TRANSACTION");
+		transaction_state = RpcTransactionState::TRANSACTION_STARTED;
+	}
+	return rpc_catalog.GetRawClient();
 }
 
 void RpcTransaction::Commit() {
-	if (begun) {
+	if (transaction_state == RpcTransactionState::TRANSACTION_STARTED) {
+		transaction_state = RpcTransactionState::TRANSACTION_FINISHED;
 		rpc_catalog.ExecuteCommand("COMMIT");
 	}
 }
 
 void RpcTransaction::Rollback() {
-	if (begun) {
+	if (transaction_state == RpcTransactionState::TRANSACTION_STARTED) {
+		transaction_state = RpcTransactionState::TRANSACTION_FINISHED;
 		rpc_catalog.ExecuteCommand("ROLLBACK");
 	}
 }
@@ -44,14 +50,9 @@ RpcTransaction &RpcTransaction::Get(ClientContext &context, Catalog &catalog) {
 	return Transaction::Get(context, catalog).Cast<RpcTransaction>();
 }
 
-void RpcTransaction::EnsureActive(CatalogTransaction &transaction) {
-	if (transaction.transaction) {
-		transaction.transaction->Cast<RpcTransaction>().EnsureBegun();
-	}
-}
-
-void RpcTransaction::EnsureActive(ClientContext &context, Catalog &catalog) {
-	RpcTransaction::Get(context, catalog).EnsureBegun();
+RpcTransaction &RpcTransaction::Get(CatalogTransaction &transaction) {
+	D_ASSERT(transaction.transaction);
+	return transaction.transaction->Cast<RpcTransaction>();
 }
 
 RpcTransaction::~RpcTransaction() {
@@ -214,12 +215,12 @@ TableFunction RpcTableCatalogEntry::GetScanFunction(ClientContext &context, uniq
 }
 
 optional_ptr<CatalogEntry> RpcCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
-	RpcTransaction::EnsureActive(transaction);
+	auto &txn = RpcTransaction::Get(transaction);
 	auto create_schema_info = info.Copy();
 	create_schema_info->catalog = "memory";
 
 	auto catalog_request_message = make_uniq<CatalogRequestMessage>(GetConnectionId(), std::move(create_schema_info));
-	auto catalog_response = GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
+	auto catalog_response = txn.GetClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
 
 	auto response_parse_info = catalog_response->GetParseInfo();
 	auto &response_info = response_parse_info->Cast<CreateSchemaInfo>();
@@ -381,7 +382,7 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateFunction(CatalogTransact
 
 optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateTable(CatalogTransaction transaction,
                                                               BoundCreateTableInfo &info) {
-	RpcTransaction::EnsureActive(transaction);
+	auto &txn = RpcTransaction::Get(transaction);
 	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
 
 	auto create_table_info = info.Base().Copy();
@@ -391,7 +392,7 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateTable(CatalogTransaction
 	auto catalog_request_message =
 	    make_uniq<CatalogRequestMessage>(rpc_catalog.GetConnectionId(), std::move(create_table_info));
 	auto catalog_response =
-	    rpc_catalog.GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
+	    txn.GetClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
 
 	auto entry = make_uniq<RpcTableCatalogEntry>(catalog, *this,
 	                                             catalog_response->GetParseInfo()->Cast<CreateTableInfo>());
@@ -429,7 +430,7 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateType(CatalogTransaction 
 }
 
 void RpcSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) {
-	RpcTransaction::EnsureActive(context, catalog);
+	auto &txn = RpcTransaction::Get(context, catalog);
 	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
 	auto drop_info = info_p.Copy();
 	drop_info->catalog = GetInfo()->catalog;
@@ -438,7 +439,7 @@ void RpcSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) 
 	auto catalog_request_message =
 	    make_uniq<CatalogRequestMessage>(rpc_catalog.GetConnectionId(), std::move(drop_info));
 
-	rpc_catalog.GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
+	txn.GetClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
 	RemoveFromTableCache(info_p.name);
 }
 void RpcSchemaCatalogEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {

--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -21,20 +21,37 @@ RpcTransaction::RpcTransaction(RpcCatalog &rpc_catalog_p, TransactionManager &ma
     : Transaction(manager_p, context_p), rpc_catalog(rpc_catalog_p) {
 }
 
-void RpcTransaction::Start() {
-	rpc_catalog.ExecuteCommand("BEGIN TRANSACTION");
+void RpcTransaction::EnsureBegun() {
+	if (!begun) {
+		rpc_catalog.ExecuteCommand("BEGIN TRANSACTION");
+		begun = true;
+	}
 }
 
 void RpcTransaction::Commit() {
-	rpc_catalog.ExecuteCommand("COMMIT");
+	if (begun) {
+		rpc_catalog.ExecuteCommand("COMMIT");
+	}
 }
 
 void RpcTransaction::Rollback() {
-	rpc_catalog.ExecuteCommand("ROLLBACK");
+	if (begun) {
+		rpc_catalog.ExecuteCommand("ROLLBACK");
+	}
 }
 
 RpcTransaction &RpcTransaction::Get(ClientContext &context, Catalog &catalog) {
 	return Transaction::Get(context, catalog).Cast<RpcTransaction>();
+}
+
+void RpcTransaction::EnsureActive(CatalogTransaction &transaction) {
+	if (transaction.transaction) {
+		transaction.transaction->Cast<RpcTransaction>().EnsureBegun();
+	}
+}
+
+void RpcTransaction::EnsureActive(ClientContext &context, Catalog &catalog) {
+	RpcTransaction::Get(context, catalog).EnsureBegun();
 }
 
 RpcTransaction::~RpcTransaction() {
@@ -46,7 +63,6 @@ RpcTransactionManager::RpcTransactionManager(AttachedDatabase &db_p, RpcCatalog 
 
 Transaction &RpcTransactionManager::StartTransaction(ClientContext &context) {
 	auto transaction = make_uniq<RpcTransaction>(rpc_catalog, *this, context);
-	transaction->Start();
 	auto &result = *transaction;
 	lock_guard<mutex> l(transaction_lock);
 	transactions[result] = std::move(transaction);
@@ -72,7 +88,7 @@ void RpcTransactionManager::Checkpoint(ClientContext &context, bool force) {
 }
 
 RpcCatalog::RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p, ClientContext &context)
-    : Catalog(db_p), server_uri(server_uri_p), client(RpcClient::GetClient(server_uri)) {
+    : Catalog(db_p), server_uri(server_uri_p), client(RpcClient::GetClient(server_uri)), client_context(&context) {
 	client->SetContext(&context);
 
 	// evil copy paste
@@ -92,11 +108,14 @@ RpcCatalog::RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p, Clien
 	                               "catalog_name NOT IN ('system', 'temp') ORDER BY ALL");
 	auto row_collection = make_uniq<ColumnDataRowCollection>(schemata->GetRows());
 	for (idx_t row_idx = 0; row_idx < row_collection->size(); row_idx++) {
-		RpcSchemaInfo info;
-		info.catalog_name = row_collection->GetValue(0, row_idx).GetValue<string>();
-		info.schema_name = row_collection->GetValue(1, row_idx).GetValue<string>();
+		CreateSchemaInfo info;
+		info.catalog = row_collection->GetValue(0, row_idx).GetValue<string>();
+		info.schema = row_collection->GetValue(1, row_idx).GetValue<string>();
 		// TODO this will fail if there are two schemas with the same name in different catalogs :/
-		schemas[info.schema_name] = make_uniq<RpcSchemaCatalogEntry>(*this, info);
+		schemas[info.schema] = make_uniq<RpcSchemaCatalogEntry>(*this, info);
+	}
+	for (auto &schema : schemas) {
+		schema.second->LoadTableCache();
 	}
 }
 
@@ -150,13 +169,12 @@ const string &RpcCatalog::GetConnectionId() {
 	return connection_id;
 }
 
+ClientContext &RpcCatalog::GetContext() {
+	return *client_context;
+}
+
 optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::LookupEntry(CatalogTransaction transaction,
                                                               const EntryLookupInfo &lookup_info) {
-	auto &schema_create_info = GetInfo()->Cast<RpcSchemaInfo>();
-
-	CreateTableInfo create_info(*this, lookup_info.GetEntryName());
-	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
-
 	auto catalog_type = lookup_info.GetCatalogType();
 	auto &entry_name = lookup_info.GetEntryName();
 	if (catalog_type == CatalogType::TABLE_FUNCTION_ENTRY) {
@@ -166,17 +184,19 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::LookupEntry(CatalogTransaction
 		}
 	}
 
-	try {
-		auto bind_response =
-		    rpc_catalog.GetRawClient().Request<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(
-		        rpc_catalog.GetConnectionId(), StringUtil::Format("FROM %s", lookup_info.GetEntryName()), false));
-		for (idx_t i = 0; i < bind_response->Types().size(); i++) {
-			create_info.columns.AddColumn(ColumnDefinition(bind_response->Names()[i], bind_response->Types()[i]));
-		}
-		return new RpcTableCatalogEntry(catalog, *this, create_info);
-	} catch (IOException &ex) { // FIXME this should not be a catch on IOError
+	if (catalog_type != CatalogType::TABLE_ENTRY) {
 		return nullptr;
 	}
+
+	LoadTableCache();
+	{
+		lock_guard<mutex> guard(table_cache_lock);
+		auto it = table_cache.find(entry_name);
+		if (it != table_cache.end()) {
+			return it->second.get();
+		}
+	}
+	return ReloadTableEntry(entry_name);
 }
 
 TableFunction RpcTableCatalogEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data_p) {
@@ -194,18 +214,23 @@ TableFunction RpcTableCatalogEntry::GetScanFunction(ClientContext &context, uniq
 }
 
 optional_ptr<CatalogEntry> RpcCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
+	RpcTransaction::EnsureActive(transaction);
 	auto create_schema_info = info.Copy();
 	create_schema_info->catalog = "memory";
 
 	auto catalog_request_message = make_uniq<CatalogRequestMessage>(GetConnectionId(), std::move(create_schema_info));
 	auto catalog_response = GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
-	return make_uniq_base<CatalogEntry, RpcSchemaCatalogEntry>(
-	    *this, catalog_response->GetParseInfo()->Cast<CreateSchemaInfo>());
+
+	auto &response_info = catalog_response->GetParseInfo()->Cast<CreateSchemaInfo>();
+	auto entry = make_uniq<RpcSchemaCatalogEntry>(*this, response_info);
+	auto result = entry.get();
+	schemas[response_info.schema] = std::move(entry);
+	return result;
 }
 
 void RpcCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {
 	for (auto &schema : schemas) {
-		// callback(*schema.second);
+		callback(*schema.second);
 	}
 }
 
@@ -240,12 +265,108 @@ void RpcCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 	throw NotImplementedException("DropSchema not implemented yet");
 }
 
+void RpcSchemaCatalogEntry::AddToTableCache(const string &table_name, unique_ptr<CatalogEntry> entry) {
+	lock_guard<mutex> guard(table_cache_lock);
+	table_cache[table_name] = std::move(entry);
+}
+
+void RpcSchemaCatalogEntry::RemoveFromTableCache(const string &table_name) {
+	lock_guard<mutex> guard(table_cache_lock);
+	table_cache.erase(table_name);
+}
+
+optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::ReloadTableEntry(const string &table_name) {
+	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
+	auto &context = rpc_catalog.GetContext();
+
+	auto query = StringUtil::Format("SELECT column_name, data_type "
+	                                "FROM duckdb_columns() "
+	                                "WHERE schema_name = %s AND table_name = %s AND NOT internal "
+	                                "ORDER BY column_index",
+	                                KeywordHelper::WriteQuoted(name, '\''),
+	                                KeywordHelper::WriteQuoted(table_name, '\''));
+	auto result = rpc_catalog.ExecuteCommand(query);
+	auto rows = make_uniq<ColumnDataRowCollection>(result->GetRows());
+
+	if (rows->size() == 0) {
+		return nullptr;
+	}
+
+	CreateTableInfo create_info(*this, table_name);
+	for (idx_t i = 0; i < rows->size(); i++) {
+		create_info.columns.AddColumn(ColumnDefinition(rows->GetValue(0, i).GetValue<string>(),
+		                                               TransformStringToLogicalType(rows->GetValue(1, i).GetValue<string>(), context)));
+	}
+	auto entry = make_uniq<RpcTableCatalogEntry>(catalog, *this, create_info);
+	auto result_ptr = entry.get();
+	AddToTableCache(table_name, std::move(entry));
+	return result_ptr;
+}
+
+void RpcSchemaCatalogEntry::LoadTableCache() {
+	{
+		lock_guard<mutex> guard(table_cache_lock);
+		if (table_cache_loaded) {
+			return;
+		}
+	}
+
+	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
+	auto &context = rpc_catalog.GetContext();
+
+	auto query = StringUtil::Format("SELECT table_name, column_name, data_type "
+	                                "FROM duckdb_columns() "
+	                                "WHERE schema_name = %s AND NOT internal "
+	                                "ORDER BY table_name, column_index",
+	                                KeywordHelper::WriteQuoted(name, '\''));
+	auto result = rpc_catalog.ExecuteCommand(query);
+	auto rows = make_uniq<ColumnDataRowCollection>(result->GetRows());
+
+	case_insensitive_map_t<unique_ptr<CatalogEntry>> new_entries;
+	string current_table;
+	unique_ptr<CreateTableInfo> current_info;
+
+	for (idx_t i = 0; i < rows->size(); i++) {
+		auto table_name = rows->GetValue(0, i).GetValue<string>();
+		auto col_name = rows->GetValue(1, i).GetValue<string>();
+		auto type_str = rows->GetValue(2, i).GetValue<string>();
+
+		if (table_name != current_table) {
+			if (current_info) {
+				new_entries[current_table] = make_uniq<RpcTableCatalogEntry>(catalog, *this, *current_info);
+			}
+			current_table = table_name;
+			current_info = make_uniq<CreateTableInfo>(*this, table_name);
+		}
+		current_info->columns.AddColumn(
+		    ColumnDefinition(col_name, TransformStringToLogicalType(type_str, context)));
+	}
+	if (current_info) {
+		new_entries[current_table] = make_uniq<RpcTableCatalogEntry>(catalog, *this, *current_info);
+	}
+
+	lock_guard<mutex> guard(table_cache_lock);
+	if (table_cache_loaded) {
+		return;
+	}
+	table_cache = std::move(new_entries);
+	table_cache_loaded = true;
+}
+
 void RpcSchemaCatalogEntry::Scan(ClientContext &context, CatalogType type,
                                  const std::function<void(CatalogEntry &)> &callback) {
-	// TODO
+	Scan(type, callback);
 }
+
 void RpcSchemaCatalogEntry::Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) {
-	// TODO
+	if (type != CatalogType::TABLE_ENTRY) {
+		return;
+	}
+	LoadTableCache();
+	lock_guard<mutex> guard(table_cache_lock);
+	for (auto &entry : table_cache) {
+		callback(*entry.second);
+	}
 }
 
 optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
@@ -259,6 +380,7 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateFunction(CatalogTransact
 
 optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateTable(CatalogTransaction transaction,
                                                               BoundCreateTableInfo &info) {
+	RpcTransaction::EnsureActive(transaction);
 	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
 
 	auto create_table_info = info.Base().Copy();
@@ -269,8 +391,12 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateTable(CatalogTransaction
 	    make_uniq<CatalogRequestMessage>(rpc_catalog.GetConnectionId(), std::move(create_table_info));
 	auto catalog_response =
 	    rpc_catalog.GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
-	return make_uniq_base<CatalogEntry, RpcTableCatalogEntry>(
-	    catalog, *this, catalog_response->GetParseInfo()->Cast<CreateTableInfo>());
+
+	auto entry = make_uniq<RpcTableCatalogEntry>(catalog, *this,
+	                                             catalog_response->GetParseInfo()->Cast<CreateTableInfo>());
+	auto result = entry.get();
+	AddToTableCache(info.Base().table, std::move(entry));
+	return result;
 }
 
 optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
@@ -302,6 +428,7 @@ optional_ptr<CatalogEntry> RpcSchemaCatalogEntry::CreateType(CatalogTransaction 
 }
 
 void RpcSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) {
+	RpcTransaction::EnsureActive(context, catalog);
 	auto &rpc_catalog = catalog.Cast<RpcCatalog>();
 	auto drop_info = info_p.Copy();
 	drop_info->catalog = GetInfo()->catalog;
@@ -311,6 +438,7 @@ void RpcSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) 
 	    make_uniq<CatalogRequestMessage>(rpc_catalog.GetConnectionId(), std::move(drop_info));
 
 	rpc_catalog.GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
+	RemoveFromTableCache(info_p.name);
 }
 void RpcSchemaCatalogEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
 	throw NotImplementedException("Alter not implemented yet, Alter!");
@@ -321,7 +449,9 @@ unique_ptr<BaseStatistics> RpcTableCatalogEntry::GetStatistics(ClientContext &co
 }
 
 TableStorageInfo RpcTableCatalogEntry::GetStorageInfo(ClientContext &context) {
-	throw NotImplementedException("GetStorageInfo not implemented yet");
+	// Minimal info: cardinality is unknown, and we have no local index/column segment metadata
+	// to report. Returning a default-constructed value is enough for SHOW TABLES / duckdb_tables().
+	return TableStorageInfo();
 }
 
 // clang-format off

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -102,12 +102,14 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 		}
 
 		// Inject client_query_id from context into the message before sending.
-		// Guard against reading the active query during transactiopn start itself
-		// (e.g. BEGIN TRANSACTION via RpcCatalog::ExecuteCommand), where the
-		// transaction isn't yet installed on the TransactionContext.
+		// Two guards: (1) no active transaction yet (e.g. during attach), and
+		// (2) active transaction but no active query (e.g. pragma preprocessing).
 		if (context->transaction.HasActiveTransaction()) {
-			client_query_id = context->transaction.GetActiveQuery();
-			request_message->SetClientQueryId(client_query_id);
+			auto raw_query_id = context->transaction.GetActiveQuery();
+			if (raw_query_id != DConstants::INVALID_INDEX) {
+				client_query_id = raw_query_id;
+				request_message->SetClientQueryId(client_query_id);
+			}
 		}
 
 		// Log RPC message

--- a/src/include/catalog.hpp
+++ b/src/include/catalog.hpp
@@ -95,8 +95,6 @@ public:
 private:
 	optional_ptr<CatalogEntry> TryLoadBuiltInFunction(const string &entry_name);
 	optional_ptr<CatalogEntry> LoadBuiltInFunction(DefaultTableMacro macro);
-	optional_ptr<CatalogEntry> ReloadTableEntry(const string &table_name);
-
 public:
 	void LoadTableCache();
 	void AddToTableCache(const string &table_name, unique_ptr<CatalogEntry> entry);

--- a/src/include/catalog.hpp
+++ b/src/include/catalog.hpp
@@ -17,19 +17,17 @@ class RpcTransaction : public Transaction {
 public:
 	RpcTransaction(RpcCatalog &rpc_catalog_p, TransactionManager &manager_p, ClientContext &context_p);
 	~RpcTransaction() override;
-	// TODO
-	void Start();
 	void Commit();
 	void Rollback();
-	//
-	// optional_ptr<CatalogEntry> GetCatalogEntry(const string &table_name);
-	// void DropEntry(CatalogType type, const string &table_name, bool cascade);
-	// void ClearTableEntry(const string &table_name);
-	//
+	void EnsureBegun();
+
 	static RpcTransaction &Get(ClientContext &context, Catalog &catalog);
+	static void EnsureActive(CatalogTransaction &transaction);
+	static void EnsureActive(ClientContext &context, Catalog &catalog);
 
 private:
 	RpcCatalog &rpc_catalog;
+	bool begun = false;
 	case_insensitive_map_t<unique_ptr<CatalogEntry>> catalog_entries;
 };
 
@@ -47,11 +45,6 @@ private:
 	RpcCatalog &rpc_catalog;
 	mutex transaction_lock;
 	reference_map_t<Transaction, unique_ptr<RpcTransaction>> transactions;
-};
-
-struct RpcSchemaInfo : CreateSchemaInfo {
-	string schema_name;
-	string catalog_name;
 };
 
 class RpcTableCatalogEntry : public TableCatalogEntry {
@@ -96,10 +89,20 @@ public:
 private:
 	optional_ptr<CatalogEntry> TryLoadBuiltInFunction(const string &entry_name);
 	optional_ptr<CatalogEntry> LoadBuiltInFunction(DefaultTableMacro macro);
+	optional_ptr<CatalogEntry> ReloadTableEntry(const string &table_name);
+
+public:
+	void LoadTableCache();
+	void AddToTableCache(const string &table_name, unique_ptr<CatalogEntry> entry);
+	void RemoveFromTableCache(const string &table_name);
 
 private:
 	mutex default_function_lock;
 	case_insensitive_map_t<unique_ptr<CatalogEntry>> default_function_map;
+
+	mutex table_cache_lock;
+	bool table_cache_loaded = false;
+	case_insensitive_map_t<unique_ptr<CatalogEntry>> table_cache;
 };
 
 class RpcCatalog : public Catalog {
@@ -139,6 +142,7 @@ public:
 	unique_ptr<ColumnDataCollection> ExecuteCommand(const string &query);
 	const RpcUri &GetServerUri();
 	const string &GetConnectionId();
+	ClientContext &GetContext();
 
 	RpcClient &GetRawClient();
 
@@ -147,6 +151,7 @@ private:
 	RpcUri server_uri;
 	unique_ptr<RpcClient> client;
 	string connection_id;
+	ClientContext *client_context;
 	unordered_map<string, unique_ptr<RpcSchemaCatalogEntry>> schemas;
 };
 

--- a/src/include/catalog.hpp
+++ b/src/include/catalog.hpp
@@ -151,7 +151,7 @@ private:
 	RpcUri server_uri;
 	unique_ptr<RpcClient> client;
 	string connection_id;
-	ClientContext *client_context;
+	ClientContext &client_context;
 	unordered_map<string, unique_ptr<RpcSchemaCatalogEntry>> schemas;
 };
 

--- a/src/include/catalog.hpp
+++ b/src/include/catalog.hpp
@@ -13,22 +13,23 @@ namespace duckdb {
 
 class RpcCatalog;
 
+enum class RpcTransactionState { TRANSACTION_NOT_YET_STARTED, TRANSACTION_STARTED, TRANSACTION_FINISHED };
+
 class RpcTransaction : public Transaction {
 public:
 	RpcTransaction(RpcCatalog &rpc_catalog_p, TransactionManager &manager_p, ClientContext &context_p);
 	~RpcTransaction() override;
 	void Commit();
 	void Rollback();
-	void EnsureBegun();
+
+	RpcClient &GetClient();
 
 	static RpcTransaction &Get(ClientContext &context, Catalog &catalog);
-	static void EnsureActive(CatalogTransaction &transaction);
-	static void EnsureActive(ClientContext &context, Catalog &catalog);
+	static RpcTransaction &Get(CatalogTransaction &transaction);
 
 private:
 	RpcCatalog &rpc_catalog;
-	bool begun = false;
-	case_insensitive_map_t<unique_ptr<CatalogEntry>> catalog_entries;
+	RpcTransactionState transaction_state = RpcTransactionState::TRANSACTION_NOT_YET_STARTED;
 };
 
 class RpcTransactionManager : public TransactionManager {

--- a/src/rpc_insert.cpp
+++ b/src/rpc_insert.cpp
@@ -43,7 +43,7 @@ unique_ptr<GlobalSinkState> RpcInsert::GetGlobalSinkState(ClientContext &context
 	// table cache, and hand the sink a reference into the cache. The cache owns lifetime.
 	auto &rpc_schema = schema.get_mutable()->Cast<RpcSchemaCatalogEntry>();
 	auto &rpc_catalog = rpc_schema.catalog.Cast<RpcCatalog>();
-	RpcTransaction::EnsureActive(context, rpc_catalog);
+	auto &txn = RpcTransaction::Get(context, rpc_catalog);
 
 	auto create_table_info = info->Base().Copy();
 	create_table_info->catalog = rpc_schema.GetInfo()->catalog;
@@ -52,7 +52,7 @@ unique_ptr<GlobalSinkState> RpcInsert::GetGlobalSinkState(ClientContext &context
 	auto catalog_request_message =
 	    make_uniq<CatalogRequestMessage>(rpc_catalog.GetConnectionId(), std::move(create_table_info));
 	auto catalog_response =
-	    rpc_catalog.GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
+	    txn.GetClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
 
 	auto entry = make_uniq<RpcTableCatalogEntry>(rpc_schema.catalog, rpc_schema,
 	                                             catalog_response->GetParseInfo()->Cast<CreateTableInfo>());
@@ -68,12 +68,13 @@ SinkResultType RpcInsert::Sink(ExecutionContext &context, DataChunk &chunk, Oper
 	auto &global_state = input.global_state.Cast<RpcInsertGlobalState>();
 	auto &tbl = global_state.table;
 	auto &rpc_catalog = tbl.catalog.Cast<RpcCatalog>();
+	auto &txn = RpcTransaction::Get(context.client, rpc_catalog);
 	auto append_chunk = make_uniq<DataChunk>();
 	append_chunk->Initialize(context.client, chunk.GetTypes());
 	append_chunk->Reference(chunk);
 	auto append_message = make_uniq<AppendRequestMessage>(rpc_catalog.GetConnectionId(), tbl.schema.name, tbl.name,
 	                                                      std::move(append_chunk));
-	rpc_catalog.GetRawClient().Request<AppendResponseMessage>(std::move(append_message));
+	txn.GetClient().Request<AppendResponseMessage>(std::move(append_message));
 	global_state.insert_count += chunk.size();
 	return SinkResultType::NEED_MORE_INPUT;
 }

--- a/src/rpc_insert.cpp
+++ b/src/rpc_insert.cpp
@@ -30,12 +30,8 @@ class RpcInsertGlobalState : public GlobalSinkState {
 public:
 	explicit RpcInsertGlobalState(RpcTableCatalogEntry &table_p) : table(table_p), insert_count(0) {
 	}
-	explicit RpcInsertGlobalState(unique_ptr<CatalogEntry> owned_entry_p)
-	    : table(owned_entry_p->Cast<RpcTableCatalogEntry>()), owned_entry(std::move(owned_entry_p)), insert_count(0) {
-	}
 
 	RpcTableCatalogEntry &table;
-	unique_ptr<CatalogEntry> owned_entry;
 	idx_t insert_count;
 };
 
@@ -43,9 +39,11 @@ unique_ptr<GlobalSinkState> RpcInsert::GetGlobalSinkState(ClientContext &context
 	if (table) {
 		return make_uniq<RpcInsertGlobalState>(table.get_mutable()->Cast<RpcTableCatalogEntry>());
 	}
-	// CREATE TABLE AS path: create the table on the remote side first
+	// CREATE TABLE AS path: create the table on the remote side, stash it in the schema's
+	// table cache, and hand the sink a reference into the cache. The cache owns lifetime.
 	auto &rpc_schema = schema.get_mutable()->Cast<RpcSchemaCatalogEntry>();
 	auto &rpc_catalog = rpc_schema.catalog.Cast<RpcCatalog>();
+	RpcTransaction::EnsureActive(context, rpc_catalog);
 
 	auto create_table_info = info->Base().Copy();
 	create_table_info->catalog = rpc_schema.GetInfo()->catalog;
@@ -55,9 +53,12 @@ unique_ptr<GlobalSinkState> RpcInsert::GetGlobalSinkState(ClientContext &context
 	    make_uniq<CatalogRequestMessage>(rpc_catalog.GetConnectionId(), std::move(create_table_info));
 	auto catalog_response =
 	    rpc_catalog.GetRawClient().Request<CatalogResponseMessage>(std::move(catalog_request_message));
-	auto entry = make_uniq_base<CatalogEntry, RpcTableCatalogEntry>(
-	    rpc_schema.catalog, rpc_schema, catalog_response->GetParseInfo()->Cast<CreateTableInfo>());
-	return make_uniq<RpcInsertGlobalState>(std::move(entry));
+
+	auto entry = make_uniq<RpcTableCatalogEntry>(rpc_schema.catalog, rpc_schema,
+	                                             catalog_response->GetParseInfo()->Cast<CreateTableInfo>());
+	auto &cache_ref = *entry;
+	rpc_schema.AddToTableCache(info->Base().table, std::move(entry));
+	return make_uniq<RpcInsertGlobalState>(cache_ref);
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -17,7 +17,7 @@ create table fuu as values(42, 43);
 statement ok
 create table moo.fuu2 as values(44, 45);
 
-foreach server 'quack:localhost'
+foreach server 'quack:localhost:20110'
 
 foreach ssl  true
 

--- a/test/sql/attach_ctas.test
+++ b/test/sql/attach_ctas.test
@@ -8,7 +8,7 @@ require httpfs
 
 set ignore_error_messages __none__
 
-foreach server 'quack:localhost'
+foreach server 'quack:localhost:20111'
 
 
 statement ok

--- a/test/sql/catalog.test
+++ b/test/sql/catalog.test
@@ -22,7 +22,7 @@ create table fuu as values(42, 43);
 statement ok
 create table bar as values(1, 2);
 
-foreach server 'quack:localhost'
+foreach server 'quack:localhost:20112'
 
 foreach ssl  true
 

--- a/test/sql/catalog.test
+++ b/test/sql/catalog.test
@@ -1,0 +1,62 @@
+# name: test/sql/catalog.test
+# description: SHOW TABLES / duckdb_tables() on an attached RPC catalog
+# group: [sql]
+#
+# Reproducer for the missing catalog enumeration path.
+#
+# Expected behaviour: SHOW TABLES against the attached RPC catalog should list
+# the remote tables. Today RpcCatalog::ScanSchemas has its callback commented
+# out (src/catalog.cpp:206-210) and both RpcSchemaCatalogEntry::Scan overloads
+# are empty stubs (src/catalog.cpp:243-249), so the query either returns no
+# rows or crashes depending on which code path DuckDB takes to enumerate.
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok
+create table fuu as values(42, 43);
+
+statement ok
+create table bar as values(1, 2);
+
+foreach server 'quack:localhost'
+
+foreach ssl  true
+
+statement ok con1
+call rpc_start({server}, disable_ssl={ssl});
+
+statement ok con2
+attach {server} as rpc (disable_ssl {ssl})
+
+# Baseline: a direct lookup works (LookupEntry is wired up).
+query II con2
+from rpc.fuu;
+----
+42	43
+
+# Enumeration: this is the failing path. Expect the remote tables to appear.
+query I con2
+select table_name from duckdb_tables() where database_name = 'rpc' order by table_name;
+----
+bar
+fuu
+
+query I con2
+show tables from rpc;
+----
+bar
+fuu
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call rpc_stop({server});
+
+endloop
+
+endloop

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -11,8 +11,10 @@ set ignore_error_messages __none__
 statement ok
 set rpc_default_token='asdf'
 
+foreach server 'quack:localhost:20113'
+
 statement ok con1
-call rpc_start('quack:localhost', disable_ssl=true);
+call rpc_start({server}, disable_ssl=true);
 
 sleep 100 millisecond
 
@@ -23,7 +25,7 @@ CALL enable_logging('RPC');
 
 # rpc_call should produce RPC log entries
 query I con2
-from rpc_call('quack:localhost', 'select 42 as answer', disable_ssl=true)
+from rpc_call({server}, 'select 42 as answer', disable_ssl=true)
 ----
 42
 
@@ -102,7 +104,7 @@ statement ok con2
 CALL truncate_duckdb_logs();
 
 statement error con2
-from rpc_call('quack:localhost', 'selexxxct 42', disable_ssl=true)
+from rpc_call({server}, 'selexxxct 42', disable_ssl=true)
 ----
 Error
 
@@ -123,7 +125,7 @@ statement ok con2
 CALL enable_logging('HTTP');
 
 query I con2
-from rpc_call('quack:localhost', 'select 1', disable_ssl=true)
+from rpc_call({server}, 'select 1', disable_ssl=true)
 ----
 1
 
@@ -150,4 +152,6 @@ statement ok con2
 CALL disable_logging();
 
 statement ok con1
-call rpc_stop('quack:localhost');
+call rpc_stop({server});
+
+endloop

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -14,7 +14,7 @@ create table t1 as select range i from range(100);
 statement ok con1
 create table t2 as select range j from range(200);
 
-foreach server 'quack:localhost'
+foreach server 'quack:localhost:20114'
 
 foreach ssl true
 

--- a/test/sql/pgbench.test
+++ b/test/sql/pgbench.test
@@ -24,11 +24,13 @@ CREATE TABLE pgbench_tellers(tid INTEGER, bid INTEGER, tbalance INTEGER, filler 
 statement ok
 set rpc_default_token='asdf'
 
+foreach server 'quack:localhost:20115'
+
 statement ok con1
-call rpc_start('quack:localhost', disable_ssl=true);
+call rpc_start({server}, disable_ssl=true);
 
 statement ok con2
-attach 'quack:localhost' as rpc (disable_ssl true)
+attach {server} as rpc (disable_ssl true)
 
 statement ok con2
 CALL enable_logging('RPC');
@@ -67,4 +69,6 @@ select count(*) from duckdb_logs where type = 'RPC' and scope = 'CONNECTION'
 
 
 statement ok con1
-call rpc_stop('quack:localhost');
+call rpc_stop({server});
+
+endloop

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -11,7 +11,7 @@ set ignore_error_messages __none__
 statement ok con1
 create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
 
-foreach server 'quack:localhost'
+foreach server 'quack:localhost:20116'
 
 statement ok con1
 call rpc_start({server});

--- a/test/sql/rpc.test
+++ b/test/sql/rpc.test
@@ -10,7 +10,7 @@ require httpfs
 
 set ignore_error_messages __none__
 
-foreach server 'quack:localhost'
+foreach server 'quack:localhost:20117'
 
 foreach ssl true
 

--- a/test/sql/use_pragma_crash.test
+++ b/test/sql/use_pragma_crash.test
@@ -1,0 +1,39 @@
+# name: test/sql/use_pragma_crash.test
+# description: USE on RPC catalog then PRAGMA should not crash (optional_idx with no active query)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok
+set rpc_default_token='1234'
+
+foreach server 'quack:localhost:20118'
+
+foreach ssl true
+
+statement ok con1
+call rpc_start({server}, disable_ssl={ssl});
+
+statement ok con2
+CREATE OR REPLACE SECRET q2 (TYPE quack, SCOPE {server}, TOKEN '1234');
+
+statement ok con2
+attach {server} as rpc (disable_ssl {ssl})
+
+statement ok con2
+USE rpc;
+
+# This should not crash with optional_idx error
+statement ok con2
+PRAGMA version;
+
+statement ok con1
+call rpc_stop({server});
+
+endloop
+
+endloop


### PR DESCRIPTION
It all started wanting to make this work:

```sql
ATTACH 'quack:localhost:9090' AS rpc (disable_ssl true);
USE rpc;
SHOW TABLES;
┌───────────┐
│   name    │
│  varchar  │
├───────────┤
│ another_t │
│ t         │
└───────────┘
```

> I go through the regular `PrepareRequestMessage`. We could argue that this could be a different instruction/request type.

### First rabbit hole - transactions

`RpcTransaction::Start()` was being called eagerly every time DuckDB opened a transaction. This conflicted with calling `FROM duckdb_tables()`, I think in the server side duckdb_tables was probably initiating a transaction already? 

New path is lazily initiate transactions, only when they are actually needed. The read path will not really initiate a transaction on the server side. This approach is based on what I've seen in duckdb-postgres.

### Second rabbit hole - caching catalog entries

The idea is that you cache the RPC catalog once when ATTACHing, were we fetch schema names from `information_schema.schemata`, then for each schema we eagerly call `LoadTableCache` — a single query to `duckdb_columns()` that returns all table names + column names + types in one RPC round-trip. Results are stored in a `case_insensitive_map_t<unique_ptr<CatalogEntry>>` per schema, guarded by `table_cache_lock`. Once loaded,  subsequent calls to `LoadTableCache` return immediately.

Then of course there is the problem if you have multiple clients attaching. Right now for this cache miss reload, if `LookupEntry` doesn't find a table after the cache is loaded, it calls `ReloadTableEntry` which fetches that single table's metadata from the server. So if another client created a table, you can query it by name and it'll be discovered on the fly. This is okeyish, but still doesn't solve the problem that if `client a attached > CREATE TABLE a` then `client b attached > CREATE TABLE b` then `client a > SHOW TABLES` shows only table `a`.

A couple of ways to solve this:
- Refetch on every query. The overhead may be negligible, depends on the amount of tables x columns.
- Have a function that refreshes all cache or clears it, then it will be reloaded again.
- Refresh cache on specific queries (like duckdb_tables/show tables)

> I am afraid of transactions so please review this!
