### PR TITLE
[feature] Add whoami() macro

### DIFF
--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -14,6 +14,11 @@
 
 #include "catalog.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/catalog/default/default_table_functions.hpp"
 
 namespace duckdb {
 
@@ -92,11 +97,40 @@ static void RpcUriParser(const DataChunk &args, ExpressionState &, Vector &resul
 	                                  {"url", Value(parsed.Http())}}));
 }
 
+static void QuackIdentifyFun(ClientContext &, TableFunctionInput &, DataChunk &) {
+	// No-op: side effects are in bind.
+}
+
+static unique_ptr<FunctionData> QuackIdentifyBind(ClientContext &ctx, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+	auto &config = ClientConfig::GetConfig(ctx);
+	for (auto &kv : input.named_parameters) {
+		if (kv.second.IsNull()) {
+			continue;
+		}
+		config.SetUserVariable("whoami_" + kv.first, kv.second);
+	}
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("ok");
+	return nullptr;
+}
+
+static TableFunction GetQuackIdentifyFunction() {
+	TableFunction fun("quack_identify", {}, QuackIdentifyFun, QuackIdentifyBind);
+	fun.named_parameters["name"]     = LogicalType::VARCHAR;
+	fun.named_parameters["provider"] = LogicalType::VARCHAR;
+	fun.named_parameters["hostname"] = LogicalType::VARCHAR;
+	fun.named_parameters["region"]   = LogicalType::VARCHAR;
+	fun.named_parameters["meta"]     = LogicalType::VARCHAR; // JSON as string
+	return fun;
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
 	loader.SetDescription("Adds support for DuckDB Remote Procedure Calls (RPC)");
 
 	loader.RegisterFunction(RpcScanFunction::GetFunction());
 	loader.RegisterFunction(RpcScanByNameFunction::GetFunction());
+	loader.RegisterFunction(GetQuackIdentifyFunction());
 
 	loader.RegisterFunction(RpcStartFunction::GetFunction());
 	loader.RegisterFunction(RpcStopFunction::GetFunction());
@@ -143,6 +177,42 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::UBIGINT, Value::UBIGINT(12));
 	config.AddExtensionOption("quack_fetch_batch_bytes", "Maximum estimated payload bytes per FETCH response",
 	                          LogicalType::UBIGINT, Value::UBIGINT(4 * (1 << 20)));
+
+	// Process-wide fallback anchor for whoami().uptime when whoami_started_at isn't set.
+	// Stored as BIGINT epoch-microseconds to stay TZ-invariant regardless of ICU state.
+	config.AddExtensionOption("quack_loaded_at_us", "Epoch microseconds at extension load",
+	                          LogicalType::BIGINT,
+	                          Value::BIGINT(Timestamp::GetCurrentTimestamp().value));
+
+	// whoami() contract — register the table macro directly via the default-table-macro
+	// machinery so function resolution in the body is deferred to invocation time
+	// (avoids the get_current_timestamp / core_functions chicken-and-egg).
+	static const DefaultTableMacro whoami_macro = {
+	    DEFAULT_SCHEMA,
+	    "whoami",
+	    {nullptr},                    // no positional parameters
+	    {{nullptr, nullptr}},         // no named parameters
+	    R"SQL(SELECT
+		    getvariable('whoami_name')::VARCHAR     AS name,
+		    getvariable('whoami_provider')::VARCHAR AS provider,
+		    getvariable('whoami_hostname')::VARCHAR AS hostname,
+		    getvariable('whoami_region')::VARCHAR   AS region,
+		    (epoch_us(current_timestamp) - COALESCE(
+		      epoch_us(getvariable('whoami_started_at')::TIMESTAMPTZ),
+		      current_setting('quack_loaded_at_us')::BIGINT
+		    )) * INTERVAL 1 MICROSECOND  AS uptime,
+		    current_timestamp              AS ts_now,
+		    json_merge_patch(
+		      json_object(
+		        'duckdb_version', version(),
+		        'platform',       (SELECT platform FROM pragma_platform())
+		      ),
+		      COALESCE(TRY_CAST(getvariable('whoami_meta') AS JSON), '{}'::JSON)
+		    )                              AS meta
+	    )SQL",
+	};
+	auto whoami_info = DefaultTableFunctionGenerator::CreateTableMacroInfo(whoami_macro);
+	loader.RegisterFunction(*whoami_info);
 }
 
 void QuackExtension::Load(ExtensionLoader &loader) {

--- a/test/sql/whoami.test
+++ b/test/sql/whoami.test
@@ -1,0 +1,93 @@
+# name: test/sql/whoami.test
+# description: whoami() / quack_identify contract
+# group: [sql]
+
+require quack
+
+require json
+
+# --- baseline: fresh session, no identity set ---
+# name/provider/hostname/region are NULL; uptime is non-negative; meta auto-filled.
+
+query I
+SELECT name IS NULL FROM whoami();
+----
+true
+
+query I
+SELECT provider IS NULL FROM whoami();
+----
+true
+
+query I
+SELECT uptime >= INTERVAL 0 SECOND FROM whoami();
+----
+true
+
+query I
+SELECT meta->>'duckdb_version' IS NOT NULL FROM whoami();
+----
+true
+
+query I
+SELECT meta->>'platform' IS NOT NULL FROM whoami();
+----
+true
+
+# --- quack_identify sets individual fields ---
+
+statement ok
+CALL quack_identify(name => 'test-node', region => 'eu-west-1');
+
+query II
+SELECT name, region FROM whoami();
+----
+test-node	eu-west-1
+
+# --- provider / hostname still NULL (only set ones updated) ---
+
+query I
+SELECT provider IS NULL FROM whoami();
+----
+true
+
+# --- user-supplied meta merges with auto-computed; user wins on key conflict ---
+
+statement ok
+CALL quack_identify(meta => '{"role": "worker", "platform": "override"}');
+
+query I
+SELECT meta->>'role' FROM whoami();
+----
+worker
+
+query I
+SELECT meta->>'platform' FROM whoami();
+----
+override
+
+# duckdb_version survives (not overridden by user)
+query I
+SELECT meta->>'duckdb_version' IS NOT NULL FROM whoami();
+----
+true
+
+# --- whoami_started_at override changes uptime ---
+
+statement ok
+SET VARIABLE whoami_started_at = TIMESTAMP '2020-01-01 00:00:00';
+
+query I
+SELECT uptime > INTERVAL 365 DAY FROM whoami();
+----
+true
+
+# --- direct SET VARIABLE also works (quack_identify is sugar, not gatekeeper) ---
+
+statement ok
+SET VARIABLE whoami_name = 'hand-set';
+
+query I
+SELECT name FROM whoami();
+----
+hand-set


### PR DESCRIPTION
Nice to have (and to demo) macro, added on load of the quack extension.

Demo:
```sql
memory D FROM whoami();
┌─────────┬──────────┬──────────┬─────────┬─────────────────┬───────────────────────────────┬─────────────────────────────────────────┐
│  name   │ provider │ hostname │ region  │     uptime      │            ts_now             │                  meta                   │
│ varchar │ varchar  │ varchar  │ varchar │    interval     │   timestamp with time zone    │                  json                   │
├─────────┼──────────┼──────────┼─────────┼─────────────────┼───────────────────────────────┼─────────────────────────────────────────┤
│ NULL    │ NULL     │ NULL     │ NULL    │ 00:00:01.160623 │ 2026-04-21 07:19:17.391519+00 │ {                                       │
│         │          │          │         │                 │                               │   "duckdb_version": "v1.5.2",           │
│         │          │          │         │                 │                               │   "platform": "osx_arm64"               │
│         │          │          │         │                 │                               │ }                                       │
└─────────┴──────────┴──────────┴─────────┴─────────────────┴───────────────────────────────┴─────────────────────────────────────────┘
memory D CALL quack_identify(name => 'carlo''s remote', provider => 'local', region => 'europe');
┌─────────┐
│   ok    │
│ boolean │
└─────────┘
  0 rows
memory D FROM whoami();
┌────────────────┬──────────┬──────────┬─────────┬─────────────────┬───────────────────────────────┬──────────────────────────────────┐
│      name      │ provider │ hostname │ region  │     uptime      │            ts_now             │               meta               │
│    varchar     │ varchar  │ varchar  │ varchar │    interval     │   timestamp with time zone    │               json               │
├────────────────┼──────────┼──────────┼─────────┼─────────────────┼───────────────────────────────┼──────────────────────────────────┤
│ carlo's remote │ local    │ NULL     │ europe  │ 00:00:05.814475 │ 2026-04-21 07:19:22.045371+00 │ {                                │
│                │          │          │         │                 │                               │   "duckdb_version": "v1.5.2",    │
│                │          │          │         │                 │                               │   "platform": "osx_arm64"        │
│                │          │          │         │                 │                               │ }                                │
└────────────────┴──────────┴──────────┴─────────┴─────────────────┴───────────────────────────────┴──────────────────────────────────┘
```

It's just a SQL macro that looks like:
```sql
  CREATE OR REPLACE MACRO whoami() AS TABLE
    SELECT
      getvariable('whoami_name')::VARCHAR                             AS name,
      getvariable('whoami_provider')::VARCHAR                         AS provider,
      getvariable('whoami_hostname')::VARCHAR                         AS hostname,
      getvariable('whoami_region')::VARCHAR                           AS region,
      (epoch_us(current_timestamp) - COALESCE(
        epoch_us(getvariable('whoami_started_at')::TIMESTAMPTZ),
        current_setting('quack_loaded_at_us')::BIGINT
      )) * INTERVAL 1 MICROSECOND                                     AS uptime,
      current_timestamp                                               AS ts_now,
      json_merge_patch(
        json_object(
          'duckdb_version', version(),
          'platform',       (SELECT platform FROM pragma_platform())
        ),
        COALESCE(TRY_CAST(getvariable('whoami_meta') AS JSON), '{}'::JSON)
      )                                                               AS meta;
```

There are some fields pre-populated, like uptime / meta.duckdb_version, meta.platform, while others can be overridden via either `SET whoami_name = 'mini'; SET whoami_provider = 'docker';` or via helper:
```sql
CALL quack_identify(name => 'local', region => 'europe');
```

Intended usage: a boot script might call quack_identify with relevant values, and than those can be queried back via `FROM rpc_call('<uri>', 'FROM whoami();');`

`whoami` might even have a place as standard macro in duckdb, but that's for a later day.