### PR TITLE
Add secret of type `quack`, and use that for attach AND `rpc_call` path

### DIFF
--- a/src/catalog.cpp
+++ b/src/catalog.cpp
@@ -5,6 +5,8 @@
 #include "rpc_insert.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
@@ -75,16 +77,27 @@ RpcCatalog::RpcCatalog(AttachedDatabase &db_p, const RpcUri &server_uri_p, Clien
     : Catalog(db_p), server_uri(server_uri_p), client(RpcClient::GetClient(server_uri)) {
 	client->SetContext(&context);
 
-	// evil copy paste
-	Value default_token_val;
-	auto &config = DBConfig::GetConfig(db_p.GetDatabase());
+	// Resolve auth token: prefer a quack secret scoped to this URI; fall back to the
+	// global rpc_default_token setting.
+	string token;
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	auto match = secret_manager.LookupSecret(transaction, server_uri.Uri(), "quack");
+	if (match.HasMatch()) {
+		const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
+		token = kv.TryGetValue("token", true).ToString();
+	} else {
+		Value default_token_val;
+		auto &config = DBConfig::GetConfig(db_p.GetDatabase());
+		auto lookup_result_token = config.TryGetCurrentSetting("rpc_default_token", default_token_val);
+		D_ASSERT(lookup_result_token);
+		if (!default_token_val.IsNull()) {
+			token = default_token_val.GetValue<string>();
+		}
+	}
 
-	// TODO there could be a race condition here, lock this
-	auto lookup_result_token = config.TryGetCurrentSetting("rpc_default_token", default_token_val);
-	D_ASSERT(lookup_result_token);
-
-	auto connection_response = client->Request<ConnectionResponseMessage>(
-	    make_uniq<ConnectionRequestMessage>(default_token_val.GetValue<string>()));
+	auto connection_response =
+	    client->Request<ConnectionResponseMessage>(make_uniq<ConnectionRequestMessage>(token));
 	connection_id = connection_response->ConnectionId();
 
 	// TODO a tiiny bit clunky this

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -57,7 +57,9 @@ static unique_ptr<Catalog> RpcAttach(optional_ptr<StorageExtensionInfo> storage_
                                      AttachOptions &attach_options) {
 	auto diable_ssl = attach_options.options.find("disable_ssl") != attach_options.options.end() &&
 	                  attach_options.options["disable_ssl"].GetValue<bool>();
-	return make_uniq<RpcCatalog>(db, RpcUri("quack:" + info.path, !diable_ssl), context);
+	// info.path may or may not already carry the "quack:" prefix.
+	auto uri = StringUtil::StartsWith(info.path, "quack:") ? info.path : "quack:" + info.path;
+	return make_uniq<RpcCatalog>(db, RpcUri(uri, !diable_ssl), context);
 }
 
 static unique_ptr<TransactionManager> RpcCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -10,12 +10,47 @@
 #include "rpc_uri.hpp"
 
 #include "duckdb/logging/log_manager.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 
 #include "catalog.hpp"
 #include "duckdb/parser/parser.hpp"
 
 namespace duckdb {
+
+static constexpr const char *QUACK_SECRET_TYPE = "quack";
+
+static unique_ptr<BaseSecret> CreateQuackSecretFromConfig(ClientContext &, CreateSecretInput &input) {
+	auto scope = input.scope;
+	if (scope.empty()) {
+		scope.emplace_back("quack:");
+	}
+	auto secret = make_uniq<KeyValueSecret>(scope, input.type, input.provider, input.name);
+	for (const auto &named_param : input.options) {
+		auto lower_name = StringUtil::Lower(named_param.first);
+		if (lower_name == "token") {
+			secret->secret_map["token"] = named_param.second.ToString();
+		} else {
+			throw InvalidInputException("Unknown named parameter for quack secret: %s", lower_name);
+		}
+	}
+	secret->redact_keys = {"token"};
+	return std::move(secret);
+}
+
+static void RegisterQuackSecretType(ExtensionLoader &loader) {
+	SecretType secret_type;
+	secret_type.name = QUACK_SECRET_TYPE;
+	secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+	secret_type.default_provider = "config";
+	secret_type.extension = "quack";
+	loader.RegisterSecretType(secret_type);
+
+	CreateSecretFunction config_fun = {QUACK_SECRET_TYPE, "config", CreateQuackSecretFromConfig};
+	config_fun.named_parameters["token"] = LogicalType::VARCHAR;
+	loader.RegisterFunction(config_fun);
+}
 
 static unique_ptr<Catalog> RpcAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                      AttachedDatabase &db, const string &name, AttachInfo &info,
@@ -120,6 +155,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                                   {"url", LogicalType::VARCHAR}}),
 	                              RpcUriParser);
 	loader.RegisterFunction(rpc_uri_parser);
+
+	RegisterQuackSecretType(loader);
 
 	loader.GetDatabaseInstance().GetLogManager().RegisterLogType(make_uniq<RPCLogType>());
 

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "rpc_bind_data.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
@@ -29,17 +30,28 @@ static unique_ptr<FunctionData> RpcBind(ClientContext &context, TableFunctionBin
 	bind_data->initial_client = RpcClient::GetClient(bind_data->server_uri);
 	bind_data->initial_client->SetContext(&context);
 
-	Value default_token_val;
-	auto &config = DBConfig::GetConfig(context);
-
-	auto lookup_result_token = config.TryGetCurrentSetting("rpc_default_token", default_token_val);
-	D_ASSERT(lookup_result_token);
-	if (default_token_val.IsNull() || default_token_val.type().id() != LogicalTypeId::VARCHAR) {
-		throw InvalidConfigurationException("No RPC token found");
+	// Resolve auth token: prefer a quack secret scoped to this URI; fall back to the
+	// global rpc_default_token setting. Mirrors the logic in RpcCatalog::RpcCatalog.
+	string token;
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	auto match = secret_manager.LookupSecret(transaction, bind_data->server_uri.Uri(), "quack");
+	if (match.HasMatch()) {
+		const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
+		token = kv.TryGetValue("token", true).ToString();
+	} else {
+		Value default_token_val;
+		auto &config = DBConfig::GetConfig(context);
+		auto lookup_result_token = config.TryGetCurrentSetting("rpc_default_token", default_token_val);
+		D_ASSERT(lookup_result_token);
+		if (default_token_val.IsNull() || default_token_val.type().id() != LogicalTypeId::VARCHAR) {
+			throw InvalidConfigurationException("No RPC token found");
+		}
+		token = default_token_val.GetValue<string>();
 	}
 
 	auto connection_request_response = bind_data->initial_client->Request<ConnectionResponseMessage>(
-	    make_uniq<ConnectionRequestMessage>(default_token_val.GetValue<string>()));
+	    make_uniq<ConnectionRequestMessage>(token));
 	bind_data->connection_id = connection_request_response->ConnectionId();
 
 	auto bind_response = bind_data->initial_client->Request<PrepareResponseMessage>(

--- a/test/sql/secret.test
+++ b/test/sql/secret.test
@@ -1,0 +1,67 @@
+# name: test/sql/secret.test
+# description: verify quack auth token resolution via DuckDB secrets (with rpc_default_token fallback)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+# Server-side: set the auth token and start listening
+statement ok con1
+set rpc_default_token='s3kr3t'
+
+statement ok con1
+call rpc_start('quack:localhost:20101', disable_ssl=true);
+
+sleep 100 millisecond
+
+# --- 1. Matching secret: ATTACH succeeds without touching rpc_default_token on the client ---
+
+statement ok con2
+create secret quack_ok (type quack, token 's3kr3t', scope 'quack:localhost:20101')
+
+statement ok con2
+attach 'quack:localhost:20101' as r_ok (type quack, disable_ssl true)
+
+query II con2
+from r_ok.call('select 1, 2')
+----
+1	2
+
+statement ok con2
+detach r_ok
+
+statement ok con2
+drop secret quack_ok
+
+# --- 2. Wrong secret: ATTACH fails with Authentication failed ---
+
+statement ok con2
+create secret quack_bad (type quack, token 'nope', scope 'quack:localhost:20101')
+
+statement error con2
+attach 'quack:localhost:20101' as r_bad (type quack, disable_ssl true)
+----
+Authentication failed
+
+statement ok con2
+drop secret quack_bad
+
+# --- 3. No secret: falls back to rpc_default_token on the client ---
+
+statement ok con2
+set rpc_default_token='s3kr3t'
+
+statement ok con2
+attach 'quack:localhost:20101' as r_fallback (type quack, disable_ssl true)
+
+query I con2
+from r_fallback.call('select 7')
+----
+7
+
+statement ok con2
+detach r_fallback
+
+statement ok con1
+call rpc_stop('quack:localhost:20101')

--- a/test/sql/secret_rpc_call.test
+++ b/test/sql/secret_rpc_call.test
@@ -1,0 +1,55 @@
+# name: test/sql/secret_rpc_call.test
+# description: verify rpc_call(uri, sql) picks up auth token from quack secrets
+# group: [sql]
+
+require quack
+
+require httpfs
+
+# Server-side
+statement ok con1
+set rpc_default_token='s3kr3t'
+
+statement ok con1
+call rpc_start('quack:localhost:20102', disable_ssl=true);
+
+sleep 100 millisecond
+
+# --- 1. Matching secret: rpc_call succeeds with the secret's token ---
+
+statement ok con2
+create secret rpc_ok (type quack, token 's3kr3t', scope 'quack:localhost:20102')
+
+query II con2
+from rpc_call('quack:localhost:20102', 'select 1, 2', disable_ssl=true)
+----
+1	2
+
+statement ok con2
+drop secret rpc_ok
+
+# --- 2. Wrong secret: rpc_call fails with Authentication failed ---
+
+statement ok con2
+create secret rpc_bad (type quack, token 'nope', scope 'quack:localhost:20102')
+
+statement error con2
+from rpc_call('quack:localhost:20102', 'select 1', disable_ssl=true)
+----
+Authentication failed
+
+statement ok con2
+drop secret rpc_bad
+
+# --- 3. No secret: falls back to rpc_default_token on the client ---
+
+statement ok con2
+set rpc_default_token='s3kr3t'
+
+query I con2
+from rpc_call('quack:localhost:20102', 'select 7', disable_ssl=true)
+----
+7
+
+statement ok con1
+call rpc_stop('quack:localhost:20102')


### PR DESCRIPTION
Note: secret are (as of now) NOT yet used for `rpc_start` path.

I'll tackle that in a follow up.

SQL side is:
```sql
SET rpc_default_token='1234';
CALL rpc_start('quack:localhost', disable_ssl = true);

CREATE OR REPLACE SECRET xxx(TYPE quack, TOKEN '1234');
CALL rpc_call('quack:localhost', 'SELECT 32', disable_ssl= true);
--- ┌───────┐
--- │  32   │
--- │ int32 │
--- ├───────┤
--- │    32 │
--- └───────┘

CREATE OR REPLACE SECRET xxx(TYPE quack, TOKEN 'abcd');
CALL rpc_call('quack:localhost', 'SELECT 32', disable_ssl= true);
---- IO Error:
---- Expected CONNECTION_RESPONSE message, got error message instead: Authentication failed
```

Note that rpc_start will still use `rpc_default_token` or a randomly generated one.
Persistent secrets and other secret niceties comes for free due to secret manager.