### PR TITLE
Fix rpc scan when remapping

### DIFF
--- a/src/include/rpc_bind_data.hpp
+++ b/src/include/rpc_bind_data.hpp
@@ -19,5 +19,7 @@ struct RpcBindData : FunctionData {
 	vector<LogicalType> column_types;
 	vector<unique_ptr<DataChunk>> initial_results;
 	bool needs_more_fetch;
+	vector<column_t> column_ids;
+	vector<idx_t> projection_ids;
 };
 } // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -203,13 +203,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// whoami() identity fields — global settings so they propagate across all sessions
 	// (rpc_call creates fresh server-side sessions that wouldn't see per-connection state).
-	config.AddExtensionOption("whoami_name", "Human-readable name for this node", LogicalType::VARCHAR, Value());
+	config.AddExtensionOption("whoami_name", "Human-readable name for this node", LogicalType::VARCHAR, Value(""));
 	config.AddExtensionOption("whoami_provider", "Deployment provider (ec2, docker, local, ...)", LogicalType::VARCHAR,
-	                          Value());
-	config.AddExtensionOption("whoami_hostname", "Network hostname / public address", LogicalType::VARCHAR, Value());
-	config.AddExtensionOption("whoami_region", "Deployment region", LogicalType::VARCHAR, Value());
+	                          Value(""));
+	config.AddExtensionOption("whoami_hostname", "Network hostname / public address", LogicalType::VARCHAR, Value(""));
+	config.AddExtensionOption("whoami_region", "Deployment region", LogicalType::VARCHAR, Value(""));
 	config.AddExtensionOption("whoami_started_at", "Node start time (ISO-8601 TIMESTAMP)", LogicalType::VARCHAR,
-	                          Value());
+	                          Value(""));
 	config.AddExtensionOption("whoami_meta", "Provider-specific metadata as JSON", LogicalType::VARCHAR, Value("{}"));
 
 	// whoami() contract — register the table macro directly via the default-table-macro
@@ -219,14 +219,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    DEFAULT_SCHEMA,       "whoami", {nullptr}, // no positional parameters
 	    {{nullptr, nullptr}},                      // no named parameters
 	    R"SQL(SELECT
-		    current_setting('whoami_name')::VARCHAR     AS name,
-		    current_setting('whoami_provider')::VARCHAR AS provider,
-		    current_setting('whoami_hostname')::VARCHAR AS hostname,
-		    current_setting('whoami_region')::VARCHAR   AS region,
+		    NULLIF(current_setting('whoami_name'), '')::VARCHAR     AS name,
+		    NULLIF(current_setting('whoami_provider'), '')::VARCHAR AS provider,
+		    NULLIF(current_setting('whoami_hostname'), '')::VARCHAR AS hostname,
+		    NULLIF(current_setting('whoami_region'), '')::VARCHAR   AS region,
 		    to_microseconds(epoch_us(current_timestamp) - COALESCE(
-		      epoch_us(current_setting('whoami_started_at')::TIMESTAMPTZ),
+		      epoch_us(NULLIF(current_setting('whoami_started_at'), '')::TIMESTAMPTZ),
 		      current_setting('quack_loaded_at_us')::BIGINT
-		    ))                                          AS uptime,
+		    ))                                                      AS uptime,
 		    current_timestamp                           AS ts_now,
 		    json_merge_patch(
 		      json_object(

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -233,6 +233,9 @@ static string BuildPushdownQuery(const RpcBindData &bind_data, const TableFuncti
 unique_ptr<GlobalTableFunctionState> RpcInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->CastNoConst<RpcBindData>();
 
+	bind_data.column_ids = input.column_ids;
+	bind_data.projection_ids = input.projection_ids;
+
 	// For the catalog path (ATTACH), LookupEntry only prepares without executing
 	// to avoid the server-side result being overwritten by subsequent lookups.
 	// We execute the query here, right before scanning, so the result is fresh.
@@ -312,13 +315,27 @@ static void RpcScan(ClientContext &context, TableFunctionInput &input, DataChunk
 	local_state.pending.pop();
 
 	auto &response_chunk = *chunk;
-	if (response_chunk.ColumnCount() == output.ColumnCount()) {
+	const auto &col_ids = bind_data.column_ids;
+	const auto &proj_ids = bind_data.projection_ids;
+	if (response_chunk.ColumnCount() == output.ColumnCount() && col_ids.empty() && proj_ids.empty()) {
 		output.Reference(response_chunk);
 	} else {
-		// Server returned more columns than needed (e.g. rpc_call with projection pushdown).
-		// Copy only the columns DuckDB expects.
+		// Map each output column to the right response column. DuckDB's pushdown contract:
+		//   - column_ids lists which source columns the scan should read (in that order).
+		//   - projection_ids (when filter_prune=true) indexes into column_ids for the outputs.
+		// The server ignores pushdown and returns every column, so we apply both hops here.
 		for (idx_t i = 0; i < output.ColumnCount(); i++) {
-			output.data[i].Reference(response_chunk.data[i]);
+			idx_t src;
+			if (!proj_ids.empty()) {
+				src = col_ids[proj_ids[i]];
+			} else if (!col_ids.empty()) {
+				src = col_ids[i];
+			} else {
+				src = i;
+			}
+			D_ASSERT(src < response_chunk.ColumnCount());
+			D_ASSERT(response_chunk.data[src].GetType() == output.data[i].GetType());
+			output.data[i].Reference(response_chunk.data[src]);
 		}
 	}
 	output.SetCardinality(response_chunk.size());

--- a/test/sql/rpc_call_projection.test
+++ b/test/sql/rpc_call_projection.test
@@ -1,0 +1,82 @@
+# name: test/sql/rpc_call_projection.test
+# description: projection pushdown through rpc_call returns the RIGHT column (not just first-N)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+call rpc_start('quack:localhost', disable_ssl=true);
+
+# Pick the non-first column — exercises the column_ids remap in RpcScan.
+query I con2
+SELECT b FROM rpc_call('quack:localhost', 'SELECT 1 as a, ''2'' as b', disable_ssl=true);
+----
+2
+
+# Multi-column projection with reordering — output wants b, a (reverse of server order).
+query II con2
+SELECT b, a FROM rpc_call('quack:localhost', 'SELECT 1 as a, ''2'' as b', disable_ssl=true);
+----
+2	1
+
+# Types differ per column — catches type-mismatch (INTEGER vs VARCHAR).
+query I con2
+SELECT b FROM rpc_call('quack:localhost', 'SELECT 42 as a, ''hello'' as b', disable_ssl=true);
+----
+hello
+
+# Projection of a single middle column.
+query I con2
+SELECT middle FROM rpc_call('quack:localhost',
+    'SELECT 1 as first, 2.5 as middle, ''last'' as last',
+    disable_ssl=true);
+----
+2.5
+
+# No projection — SELECT * — identity mapping should still work.
+query III con2
+SELECT * FROM rpc_call('quack:localhost',
+    'SELECT 1 as a, ''two'' as b, true as c',
+    disable_ssl=true);
+----
+1	two	true
+
+# Projection + alias at the outer SELECT.
+query I con2
+SELECT b AS renamed FROM rpc_call('quack:localhost',
+    'SELECT 1 as a, ''hello'' as b',
+    disable_ssl=true);
+----
+hello
+
+# Projection through aggregation — only needs `b`, drops `a`.
+query I con2
+SELECT count(b) FROM rpc_call('quack:localhost',
+    'SELECT 1 as a, ''x'' as b UNION ALL SELECT 2, ''y''',
+    disable_ssl=true);
+----
+2
+
+# Same via rpc_call_by_name (ATTACH path).
+statement ok con2
+attach 'quack:localhost' as r (type quack, disable_ssl true);
+
+query I con2
+SELECT b FROM rpc_call_by_name('r', 'SELECT 1 as a, ''2'' as b');
+----
+2
+
+query II con2
+SELECT b, a FROM rpc_call_by_name('r', 'SELECT 1 as a, ''2'' as b');
+----
+2	1
+
+statement ok con2
+detach r;
+
+statement ok con1
+call rpc_stop('quack:localhost');

--- a/test/sql/whoami.test
+++ b/test/sql/whoami.test
@@ -79,17 +79,17 @@ true
 # --- whoami_started_at override changes uptime ---
 
 statement ok
-SET VARIABLE whoami_started_at = TIMESTAMP '2020-01-01 00:00:00';
+SET whoami_started_at = '2020-01-01 00:00:00';
 
 query I
 SELECT uptime > INTERVAL 365 DAY FROM whoami();
 ----
 true
 
-# --- direct SET VARIABLE also works (quack_identify is sugar, not gatekeeper) ---
+# --- direct SET also works (quack_identify is sugar, not gatekeeper) ---
 
 statement ok
-SET VARIABLE whoami_name = 'hand-set';
+SET whoami_name = 'hand-set';
 
 query I
 SELECT name FROM whoami();


### PR DESCRIPTION
Fix for issue found in testing, fixes cases like:
```sql
SELECT b FROM rpc_call('quack:localhost', 'SELECT 1 as a, ''2'' as b', disable_ssl=true);
```

On top of https://github.com/duckdb/duckdb-quack/pull/40