### PR TITLE
Authz rewrite

### DIFF
--- a/src/include/rpc_server.hpp
+++ b/src/include/rpc_server.hpp
@@ -18,6 +18,12 @@ class QueryResult;
 class DatabaseInstance;
 class PreparedStatement;
 
+// Cache for APPEND authz result, as to avoid multiple callbacks.
+struct AppendAuthzCacheEntry {
+	bool allowed = false;
+	string reject_message;
+};
+
 struct RpcConnection {
 	mutex lock;
 	unique_ptr<Connection> duckdb_connection;
@@ -25,6 +31,7 @@ struct RpcConnection {
 	unique_ptr<QueryResult> duckdb_query_result;
 	//! Monotonic counter assigned per FETCH batch — enables order-preserving parallel scans on
 	idx_t next_batch_index = 0;
+	unordered_map<string, AppendAuthzCacheEntry> append_authz_cache;
 };
 
 class RpcServer {

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -99,8 +99,9 @@ static void RpcAuthToken(const DataChunk &args, ExpressionState &state, Vector &
 	result.SetValue(0, Value(auth_str == default_token));
 }
 
-static void RpcDummyAuthorization(const DataChunk &args, ExpressionState &, Vector &result) {
-	result.SetValue(0, Value(true)); // choose life
+// Default authorization callback. Signature: (sid, op_kind, query), all VARCHAR.
+static void RpcDefaultAuthorization(const DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetValue(0, args.GetValue(2, 0)); // returns the query by default
 }
 
 static void RpcUriParser(const DataChunk &args, ExpressionState &, Vector &result) {
@@ -163,9 +164,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	rpc_auth_token.SetVolatile();
 	loader.RegisterFunction(rpc_auth_token);
 
-	ScalarFunction rpc_authorization("rpc_dummy_authorization",
-	                                 {/* session id */ LogicalType::VARCHAR, /* query string */ LogicalType::VARCHAR},
-	                                 LogicalType::BOOLEAN, RpcDummyAuthorization);
+	ScalarFunction rpc_authorization("rpc_default_authorization",
+	                                 {/* session id */ LogicalType::VARCHAR,
+	                                  /* op_kind   */ LogicalType::VARCHAR,
+	                                  /* query     */ LogicalType::VARCHAR},
+	                                 LogicalType::VARCHAR, RpcDefaultAuthorization);
 	rpc_authorization.SetVolatile();
 	loader.RegisterFunction(rpc_authorization);
 
@@ -192,7 +195,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("rpc_authentication_function", "Name of a callback function for authentication",
 	                          LogicalType::VARCHAR, Value("rpc_auth_token"));
 	config.AddExtensionOption("rpc_authorization_function", "Name of a callback function for authorization",
-	                          LogicalType::VARCHAR, Value("rpc_dummy_authorization"));
+	                          LogicalType::VARCHAR, Value("rpc_default_authorization"));
 
 	// TODO make this readonly from SQL?
 	config.AddExtensionOption("rpc_default_token", "Authorization token used by default", LogicalType::VARCHAR, Value(),

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -70,6 +70,48 @@ static bool EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... v
 	return true;
 }
 
+// Run the configured authorization callback as `SELECT <fn>(?, ?, ?)` and
+// return the VARCHAR it produced. Throws on any error from the callback (e.g.
+// `error('msg')`), on missing rows, or on a non-VARCHAR/NULL return.
+static string EvaluateAuthorize(DatabaseInstance &db, const string &sid, const string &op_kind,
+                                const string &payload) {
+	Connection dummy_connection(db);
+	auto sql = StringUtil::Format("SELECT %s(?, ?, ?)", GetSettingString(db, "rpc_authorization_function"));
+	auto result = dummy_connection.Query(sql, Value(sid), Value(op_kind), Value(payload));
+	if (!result || result->HasError()) {
+		throw InvalidInputException(result ? result->GetError() : "authorization callback failed");
+	}
+	auto chunk = result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		throw InvalidInputException("authorization callback returned no rows");
+	}
+	auto val = chunk->GetValue(0, 0);
+	if (val.IsNull() || val.type().id() != LogicalTypeId::VARCHAR) {
+		throw InvalidInputException("authorization callback must return VARCHAR");
+	}
+	return val.GetValue<string>();
+}
+
+// Cached APPEND authz: fires the callback once per (connection, schema.table),
+// this is to avoid repeated calls for every chunk in a large append.
+static const AppendAuthzCacheEntry &AuthorizeAppendCached(DatabaseInstance &db, RpcConnection &conn,
+                                                          const string &sid, const string &target) {
+	auto it = conn.append_authz_cache.find(target);
+	if (it != conn.append_authz_cache.end()) {
+		return it->second;
+	}
+	AppendAuthzCacheEntry entry;
+	try {
+		EvaluateAuthorize(db, sid, "append", target);
+		entry.allowed = true;
+	} catch (const std::exception &e) {
+		entry.allowed = false;
+		entry.reject_message = string("Authorization failed: ") + e.what();
+	}
+	auto inserted = conn.append_authz_cache.emplace(target, std::move(entry));
+	return inserted.first->second;
+}
+
 string RpcServer::GenerateSessionId() {
 	return StringUtil::GenerateRandomName(32);
 }
@@ -175,10 +217,12 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 			return make_uniq<ErrorMessage>("Invalid connection id");
 		}
 
-		if (!EvaluateAuthQuery(
-		        *db, StringUtil::Format("SELECT %s(?, ?)", GetSettingString(*db, "rpc_authorization_function")),
-		        Value(prepare_request_message.ConnectionId()), Value(prepare_request_message.Query()))) {
-			return make_uniq<ErrorMessage>("Authorization failed");
+		string query_to_run;
+		try {
+			query_to_run = EvaluateAuthorize(*db, prepare_request_message.ConnectionId(), "query",
+			                                 prepare_request_message.Query());
+		} catch (const std::exception &e) {
+			return make_uniq<ErrorMessage>(string("Authorization failed: ") + e.what());
 		}
 
 		std::unique_lock<std::mutex> lock(rpc_connection->lock);
@@ -189,7 +233,7 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 		}
 
 		{
-			auto query_result = rpc_connection->duckdb_connection->SendQuery(prepare_request_message.Query());
+			auto query_result = rpc_connection->duckdb_connection->SendQuery(query_to_run);
 			if (query_result->HasError()) {
 				return make_uniq<ErrorMessage>(query_result->GetError());
 			}
@@ -270,6 +314,12 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 			auto &catalog = Catalog::GetCatalog(context, create_info.catalog);
 			switch (create_info.type) {
 			case CatalogType::TABLE_ENTRY: {
+				try {
+					EvaluateAuthorize(*db, catalog_request_message.ConnectionId(), "create_table",
+					                  create_info.ToString());
+				} catch (const std::exception &e) {
+					return make_uniq<ErrorMessage>(string("Authorization failed: ") + e.what());
+				}
 				unique_ptr<CreateTableInfo> create_table_info(
 				    reinterpret_cast<CreateTableInfo *>(parse_info.release()));
 				auto &meta_transaction = MetaTransaction::Get(context);
@@ -278,6 +328,12 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 				return make_uniq<CatalogResponseMessage>(create_result->GetInfo());
 			}
 			case CatalogType::SCHEMA_ENTRY: {
+				try {
+					EvaluateAuthorize(*db, catalog_request_message.ConnectionId(), "create_schema",
+					                  create_info.ToString());
+				} catch (const std::exception &e) {
+					return make_uniq<ErrorMessage>(string("Authorization failed: ") + e.what());
+				}
 				auto &meta_transaction = MetaTransaction::Get(context);
 				meta_transaction.ModifyDatabase(catalog.GetAttached(), DatabaseModificationType::CREATE_CATALOG_ENTRY);
 				auto create_result = catalog.CreateSchema(context, parse_info->Cast<CreateSchemaInfo>());
@@ -293,6 +349,12 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 			auto &catalog = Catalog::GetCatalog(context, drop_info.catalog);
 			switch (drop_info.type) {
 			case CatalogType::TABLE_ENTRY: {
+				try {
+					EvaluateAuthorize(*db, catalog_request_message.ConnectionId(), "drop_table",
+					                  drop_info.ToString());
+				} catch (const std::exception &e) {
+					return make_uniq<ErrorMessage>(string("Authorization failed: ") + e.what());
+				}
 				auto &meta_transaction = MetaTransaction::Get(context);
 				meta_transaction.ModifyDatabase(catalog.GetAttached(), DatabaseModificationType::DROP_CATALOG_ENTRY);
 				catalog.DropEntry(context, drop_info);
@@ -310,7 +372,18 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 	case MessageType::APPEND_REQUEST: {
 		auto &append_request_message = received_message.Cast<AppendRequestMessage>();
 		optional_ptr<RpcConnection> rpc_connection = GetConnection(append_request_message.ConnectionId());
+		if (!rpc_connection) {
+			return make_uniq<ErrorMessage>("Invalid connection id");
+		}
 		std::unique_lock<std::mutex> lock(rpc_connection->lock);
+
+		auto target = append_request_message.SchemaName() + "." + append_request_message.TableName();
+		auto &authz_outcome =
+		    AuthorizeAppendCached(*db, *rpc_connection, append_request_message.ConnectionId(), target);
+		if (!authz_outcome.allowed) {
+			return make_uniq<ErrorMessage>(authz_outcome.reject_message);
+		}
+
 		auto &context = *rpc_connection->duckdb_connection->context;
 		auto table_info = context.TableInfo(append_request_message.SchemaName(), append_request_message.TableName());
 		ColumnDataCollection collection(Allocator::Get(context), append_request_message.AppendChunk().GetTypes());

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -56,15 +56,18 @@ static string GetSettingString(DatabaseInstance &db, const string &setting_name)
 	return setting_str;
 }
 
-template <typename... ARGS>
-static bool EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... values) {
+// Run the configured authentication callback as `SELECT <fn>(?, ?)` and return
+// its BOOLEAN result. Errors thrown by the callback are swallowed as `false`;
+// callers surface a generic "Authentication failed" message.
+static bool EvaluateAuthenticate(DatabaseInstance &db, const string &sid, const string &auth_string) {
 	Connection dummy_connection(db);
-	auto auth_result = dummy_connection.Query(sql, values...);
-	if (!auth_result || auth_result->HasError()) {
+	auto sql = StringUtil::Format("SELECT %s(?, ?)", GetSettingString(db, "rpc_authentication_function"));
+	auto result = dummy_connection.Query(sql, Value(sid), Value(auth_string));
+	if (!result || result->HasError()) {
 		return false;
 	}
-	auto auth_result_chunk = auth_result->Fetch();
-	if (!auth_result_chunk || !auth_result_chunk->GetValue(0, 0).template GetValue<bool>()) {
+	auto chunk = result->Fetch();
+	if (!chunk || !chunk->GetValue(0, 0).GetValue<bool>()) {
 		return false;
 	}
 	return true;
@@ -203,9 +206,7 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();
 		string session_id = GenerateSessionId();
-		if (!EvaluateAuthQuery(
-		        *db, StringUtil::Format("SELECT %s(?, ?)", GetSettingString(*db, "rpc_authentication_function")),
-		        Value(session_id), Value(connection_request_message.AuthString()))) {
+		if (!EvaluateAuthenticate(*db, session_id, connection_request_message.AuthString())) {
 			return make_uniq<ErrorMessage>("Authentication failed");
 		}
 		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id));

--- a/test/sql/auth.test
+++ b/test/sql/auth.test
@@ -1,0 +1,40 @@
+# name: test/sql/auth.test
+# description: custom rpc_authentication_function override
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+# Server: a custom auth that admits exactly the literal token 'magic'.
+statement ok con1
+create macro my_auth(sid, tok) as (tok = 'magic')
+
+statement ok con1
+set global rpc_authentication_function = 'my_auth'
+
+statement ok con1
+call rpc_start('quack:localhost:20201')
+
+# Client supplies the matching token via rpc_default_token.
+statement ok con2
+set rpc_default_token = 'magic'
+
+query I con2
+from rpc_call('quack:localhost:20201', 'select 1')
+----
+1
+
+# Wrong token is rejected.
+statement ok con2
+set rpc_default_token = 'nope'
+
+statement error con2
+from rpc_call('quack:localhost:20201', 'select 1')
+----
+Authentication failed
+
+statement ok con1
+call rpc_stop('quack:localhost:20201')

--- a/test/sql/authz.test
+++ b/test/sql/authz.test
@@ -1,0 +1,118 @@
+# name: test/sql/authz.test
+# description: rpc_authorization_function (3-arg, VARCHAR-returning) on PREPARE / CATALOG / APPEND paths
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+call rpc_start('quack:localhost:20202')
+
+statement ok con1
+create table allowed_tbl(i integer)
+
+statement ok con1
+create table readonly_tbl(i integer)
+
+# --- 1. default passthrough on every path ---
+
+statement ok con2
+attach 'quack:localhost:20202' as r
+
+query I con2
+from rpc_call('quack:localhost:20202', 'select 42')
+----
+42
+
+statement ok con2
+create table r.via_attach(i integer)
+
+statement ok con2
+insert into r.via_attach values (1)
+
+query I con2
+from r.via_attach
+----
+1
+
+statement ok con2
+drop table r.via_attach
+
+# --- 2. custom authz: switches on op_kind ---
+
+statement ok con1
+create macro authz(sid, op, q) as (
+    case
+        when op = 'query'        and q like '%blocked_view%'   then error('query blocked')
+        when op = 'create_table' or op = 'create_schema'       then error('ddl blocked')
+        when op = 'drop_table'                                 then error('drops disabled')
+        when op = 'append'       and q = 'main.readonly_tbl'   then error('append blocked')
+        else q
+    end
+)
+
+statement ok con1
+set global rpc_authorization_function = 'authz'
+
+# 2a. PREPARE via rpc_call: harmless query passes (else arm returns it unchanged).
+query I con2
+from rpc_call('quack:localhost:20202', 'select 7')
+----
+7
+
+# 2b. PREPARE rejection — the thrown message surfaces to the client.
+statement error con2
+from rpc_call('quack:localhost:20202', 'select 1 as blocked_view')
+----
+query blocked
+
+# 2c. CATALOG: CREATE TABLE rejected by table name.
+statement error con2
+create table r.forbidden_thing(i integer)
+----
+ddl blocked
+
+# 2d. CATALOG: DROP TABLE always rejected.
+statement error con2
+drop table r.allowed_tbl
+----
+drops disabled
+
+# 2e. APPEND: INSERT into the gated target rejected.
+statement error con2
+insert into r.readonly_tbl values (1)
+----
+append blocked
+
+# 2f. APPEND into a non-gated target still works.
+statement ok con2
+insert into r.allowed_tbl values (1)
+
+query I con2
+from r.allowed_tbl
+----
+1
+
+# --- 3. rewrite: PREPARE return value is honored as the executed query ---
+
+statement ok con1
+create macro add_limit(sid, op, q) as (
+    case when op = 'query' then q || ' limit 1' else q end
+)
+
+statement ok con1
+set global rpc_authorization_function = 'add_limit'
+
+query I con2
+from rpc_call('quack:localhost:20202', 'from range(10)')
+----
+0
+
+statement ok con2
+detach r
+
+statement ok con1
+call rpc_stop('quack:localhost:20202')


### PR DESCRIPTION
This PR does two main things:
1. Populates the authorization callback to `CATALOG_REQUEST` and `APPEND_REQUEST`.
2. Refactors authorization to return a query, enabling users to provide authorization functions that modify queries. This is cool but could be funky (gun for SQL injection?).

> [!IMPORTANT]
> Very important behavioural change is that that raising an Authorization error is now on the user. They need to throw `error('blabla')` in order for the Authorization to fail. To clarify, this does not happen in the Authentication callback, where the function returns a boolean and the error message is generic and handled outside of the callback. 

There is a small caveat to this PR. Since we don't have `APPEND_REQUEST_BEGIN`/`APPEND_REQUEST_END` in the protocol, `APPEND_REQUEST` runs the authz callback for every message. I added `AppendAuthzCacheEntry` per `RpcConnection` to workaround this issue, but we may consider in the future for `INSERT`, `DELETE`, `UPDATE`, etc. that go through the catalog path, to enable BEGIN/END requests?

## Example usage

A single SQL macro switches on `op_kind` to enforce a read-only policy:

- `query` → block writes/DDL via a regex on the leading keyword.
- `create_table` / `create_schema` → unconditional block.
- `drop_table` → unconditional block.
- `append` → unconditional block.

```sql
LOAD quack;
LOAD httpfs;
SET GLOBAL rpc_default_token = 'demo-token';

CREATE MACRO authz(sid, op, q) AS (
    CASE
        WHEN op = 'query'
             AND regexp_matches(q, '^\s*(insert|update|delete|merge|create|drop|alter|truncate|copy)\b', 'i')
                                                              THEN error('writes blocked')
        WHEN op = 'create_table' OR op = 'create_schema'      THEN error('ddl blocked')
        WHEN op = 'drop_table'                                THEN error('drops disabled')
        WHEN op = 'append'                                    THEN error('writes disabled')
        ELSE q
    END
);
-- Only need GLOBAL if running in the same terminal server and client
SET GLOBAL rpc_authorization_function = 'authz';

CREATE TABLE existing_tbl(i INTEGER);
INSERT INTO existing_tbl VALUES (1), (2);

CALL rpc_start('quack:localhost:31999');
ATTACH 'quack:localhost:31999' AS r;
```

### Reads pass through

```sql
FROM rpc_call('quack:localhost:31999', 'select 42');
```
```
┌───────┐
│  42   │
│ int32 │
├───────┤
│    42 │
└───────┘
```

```sql
FROM r.existing_tbl;
```
```
┌───────┐
│   i   │
│ int32 │
├───────┤
│     1 │
│     2 │
└───────┘
```

### PREPARE rejection — write via `rpc_call`

```sql
FROM rpc_call('quack:localhost:31999', 'insert into existing_tbl values (99)');
```
```
IO Error: Expected PREPARE_RESPONSE message, got error message instead:
Authorization failed: {"exception_type":"Invalid Input","exception_message":"writes blocked"}
```

### CATALOG rejection — `CREATE TABLE` through ATTACH

```sql
CREATE TABLE r.t(i INTEGER);
```
```
IO Error: Expected CATALOG_RESPONSE message, got error message instead:
Authorization failed: {"exception_type":"Invalid Input","exception_message":"ddl blocked"}
```

### CATALOG rejection — `DROP TABLE` through ATTACH

```sql
DROP TABLE r.existing_tbl;
```
```
IO Error: Expected CATALOG_RESPONSE message, got error message instead:
Authorization failed: {"exception_type":"Invalid Input","exception_message":"drops disabled"}
```

### APPEND rejection — `INSERT` through ATTACH

```sql
INSERT INTO r.existing_tbl VALUES (3);
```
```
IO Error: Expected APPEND_RESPONSE message, got error message instead:
Authorization failed: {"exception_type":"Invalid Input","exception_message":"writes disabled"}
```

