### PR TITLE
Let's /quack, change default endpoint from /rpc to /quack

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,7 +36,7 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 	}
 
 	auto &http_util = HTTPUtil::Get(db);
-	auto request_url = uri.Http() + "/rpc";
+	auto request_url = uri.Http() + "/quack";
 	if (!http_params) {
 		http_params = http_util.InitializeParameters(*context, request_url);
 	}

--- a/src/http_rpc_server.cpp
+++ b/src/http_rpc_server.cpp
@@ -51,14 +51,14 @@ void HttpRpcServer::Listen(const RpcUri &uri) {
 
 	// TODO: this is very liberal, and there might be reasonable cases to restrict to trusted domains (note, this is
 	// only relevant from within a Web browser, since other actors can just ignore the CORS convention
-	server->Options("/rpc", [](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {
+	server->Options("/quack", [](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {
 		res.set_header("Access-Control-Allow-Origin", "*");
 		res.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
 		res.set_header("Access-Control-Allow-Headers", "*");
 		res.status = 204;
 	});
 
-	server->Post("/rpc", [&](const duckdb_httplib::Request &, duckdb_httplib::Response &res,
+	server->Post("/quack", [&](const duckdb_httplib::Request &, duckdb_httplib::Response &res,
 	                         const duckdb_httplib::ContentReader &content_reader) {
 		res.set_header("Access-Control-Allow-Origin", "*");
 		MemoryStream stream;

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -139,9 +139,9 @@ select count(*) > 0 from duckdb_logs_parsed('HTTP') where response.status = 'OK_
 ----
 true
 
-# check URL contains /rpc
+# check URL contains /quack
 query I con2
-select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.url like '%/rpc'
+select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.url like '%/quack'
 ----
 true
 


### PR DESCRIPTION
Very minor, in my taste we could as well change the endpoint to quack, so while looking at traffic it's clearer that the two instances quack to each other.