### PR TITLE
Fix/active query

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -102,12 +102,15 @@ unique_ptr<ProtocolMessage> HttpsRpcClient::RequestInternal(unique_ptr<ProtocolM
 		}
 
 		// Inject client_query_id from context into the message before sending.
-		// Guard against reading the active query during transactiopn start itself
+		// Guard against reading the active query during transaction start itself
 		// (e.g. BEGIN TRANSACTION via RpcCatalog::ExecuteCommand), where the
 		// transaction isn't yet installed on the TransactionContext.
 		if (context->transaction.HasActiveTransaction()) {
-			client_query_id = context->transaction.GetActiveQuery();
-			request_message->SetClientQueryId(client_query_id);
+			auto raw_query_id = context->transaction.GetActiveQuery();
+			if (raw_query_id != DConstants::INVALID_INDEX) {
+				client_query_id = raw_query_id;
+				request_message->SetClientQueryId(client_query_id);
+			}
 		}
 
 		// Log RPC message

--- a/test/sql/pragma_crash.test
+++ b/test/sql/pragma_crash.test
@@ -19,17 +19,17 @@ statement ok con1
 call rpc_start({server});
 
 statement ok con2
-CREATE OR REPLACE SECRET q2 (TYPE quack, SCOPE {server}, TOKEN '1234');
+create or replace secret q2 (TYPE quack, SCOPE {server}, TOKEN '1234');
 
 statement ok con2
 attach {server} as rpc
 
 statement ok con2
-USE rpc;
+use rpc;
 
 # This should not crash with optional_idx error
 statement ok con2
-PRAGMA version;
+pragma version;
 
 statement ok con1
 call rpc_stop({server});

--- a/test/sql/pragma_crash.test
+++ b/test/sql/pragma_crash.test
@@ -1,0 +1,39 @@
+# name: test/sql/use_pragma_crash.test
+# description: USE on RPC catalog then PRAGMA should not crash (optional_idx with no active query)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok
+set rpc_default_token='1234'
+
+foreach server 'quack:localhost:20118'
+
+foreach ssl true
+
+statement ok con1
+call rpc_start({server});
+
+statement ok con2
+CREATE OR REPLACE SECRET q2 (TYPE quack, SCOPE {server}, TOKEN '1234');
+
+statement ok con2
+attach {server} as rpc
+
+statement ok con2
+USE rpc;
+
+# This should not crash with optional_idx error
+statement ok con2
+PRAGMA version;
+
+statement ok con1
+call rpc_stop({server});
+
+endloop
+
+endloop


### PR DESCRIPTION
Pragma's seem to do some stuff before bumping the active query. In this case scenario the query id is -1 which throws on `idx_t(-1)`.