### PR TITLE
GenerateRandomData via EncryptionUtils

### DIFF
--- a/src/include/rpc_server.hpp
+++ b/src/include/rpc_server.hpp
@@ -17,6 +17,7 @@ class MemoryStream;
 class QueryResult;
 class DatabaseInstance;
 class PreparedStatement;
+class EncryptionState;
 
 struct RpcConnection {
 	mutex lock;
@@ -40,7 +41,7 @@ public:
 	string CreateNewConnection(const string &session_id);
 	// TODO need something to destroy connections
 
-	static string GenerateSessionId();
+	string GenerateSessionId();
 
 	virtual ~RpcServer();
 
@@ -54,6 +55,9 @@ protected:
 	shared_ptr<DatabaseInstance> db;
 	mutex active_connections_mutex;
 	unordered_map<string, unique_ptr<RpcConnection>> active_connections;
+
+	mutex session_id_rng_mutex;
+	shared_ptr<EncryptionState> session_id_rng;
 };
 
 class HttpRpcServer : public RpcServer {

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/database.hpp"
 
 #include "duckdb/common/types/blob.hpp"
+#include "duckdb/common/encryption_state.hpp"
 
 using namespace duckdb;
 
@@ -71,7 +72,27 @@ static bool EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... v
 }
 
 string RpcServer::GenerateSessionId() {
-	return StringUtil::GenerateRandomName(32);
+	constexpr idx_t kSessionIdBytes = 16; // 128 bits
+
+	{
+		std::lock_guard<std::mutex> lock(session_id_rng_mutex);
+		if (!session_id_rng) {
+			auto encryption_util = db->GetEncryptionUtil(false);
+			auto metadata = make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, kSessionIdBytes,
+			                                                   EncryptionTypes::EncryptionVersion::NONE);
+			session_id_rng = encryption_util->CreateEncryptionState(std::move(metadata));
+		}
+	}
+
+	data_t bytes[kSessionIdBytes];
+	session_id_rng->GenerateRandomData(bytes, kSessionIdBytes);
+
+	string result(kSessionIdBytes * 2, '\0');
+	for (idx_t i = 0; i < kSessionIdBytes; i++) {
+		result[2 * i] = Blob::HEX_TABLE[bytes[i] >> 4];
+		result[2 * i + 1] = Blob::HEX_TABLE[bytes[i] & 0x0F];
+	}
+	return result;
 }
 
 // Extract connection_id from a message if available

--- a/src/rpc_start_function.cpp
+++ b/src/rpc_start_function.cpp
@@ -58,7 +58,7 @@ static void RpcStartFun(ClientContext &context, TableFunctionInput &data_p, Data
 		return;
 	}
 
-	RpcStorageExtensionInfo::GetState(*context.db).FindOrCreateServer(context, bind_data.listen_uri);
+	auto &server = RpcStorageExtensionInfo::GetState(*context.db).FindOrCreateServer(context, bind_data.listen_uri);
 	output.SetValue(0, 0, bind_data.listen_uri.Uri());
 	output.SetValue(1, 0, bind_data.listen_uri.Http());
 
@@ -70,7 +70,7 @@ static void RpcStartFun(ClientContext &context, TableFunctionInput &data_p, Data
 		// TODO there could be a race condition here, lock this
 		auto lookup_result_token = config.TryGetCurrentSetting("rpc_default_token", default_token_val);
 		if (default_token_val.IsNull()) {
-			config.SetOptionByName("rpc_default_token", Value(RpcServer::GenerateSessionId()));
+			config.SetOptionByName("rpc_default_token", Value(server.GenerateSessionId()));
 		}
 
 		lookup_result_token = config.TryGetCurrentSetting("rpc_default_token", default_token_val);


### PR DESCRIPTION
Move `GenerateSessionId` to use `EncryptionUtils`'s provided secure random functionality (possibly autoloading `httpfs` if not there yet).

SQL side, it should be equivalent. Note: I have not benchmarked the impact of random generator with a workload heavy on creating different connections, I am not sure if that might be visible, but I would say while checking how to improve (possibly, bulk generating random bytes and consuming caching them) it would make sense, secure has to be the default here.