### PR TITLE
auth: separate cached Connection per callback

### DIFF
--- a/src/include/rpc_server.hpp
+++ b/src/include/rpc_server.hpp
@@ -43,6 +43,9 @@ public:
 
 	string GenerateSessionId();
 
+	bool EvaluateAuthn(const Value &v1, const Value &v2);
+	bool EvaluateAuthz(const Value &v1, const Value &v2);
+
 	virtual ~RpcServer();
 
 protected:
@@ -58,6 +61,23 @@ protected:
 
 	mutex session_id_rng_mutex;
 	shared_ptr<EncryptionState> session_id_rng;
+
+	//! Separate Connection + cached PreparedStatement for each callback —
+	//! authn and authz are isolated so a misbehaving authn callback (e.g.
+	//! one that leaves transaction state behind) can't poison the authz
+	//! path. SQL string is stashed alongside the prepared statement so a
+	//! setting change (`rpc_authentication_function` etc.) triggers a
+	//! re-prepare on the next call. Each lock serializes its own callback
+	//! across worker threads but doesn't block the other.
+	mutex authn_mutex;
+	unique_ptr<Connection> authn_connection;
+	unique_ptr<PreparedStatement> authn_stmt;
+	string authn_stmt_sql;
+
+	mutex authz_mutex;
+	unique_ptr<Connection> authz_connection;
+	unique_ptr<PreparedStatement> authz_stmt;
+	string authz_stmt_sql;
 };
 
 class HttpRpcServer : public RpcServer {

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -190,10 +190,16 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                           ext);
 
 	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+	// GLOBAL scope: the server runs these callbacks on its own cached
+	// Connection, which reads from the database-wide config. A session-local
+	// SET would change the calling session's view but not the server's
+	// (silently no-op) — forcing GLOBAL makes the only valid form
+	// `SET GLOBAL rpc_authentication_function = '...'` and ensures changes
+	// actually take effect.
 	config.AddExtensionOption("rpc_authentication_function", "Name of a callback function for authentication",
-	                          LogicalType::VARCHAR, Value("rpc_auth_token"));
+	                          LogicalType::VARCHAR, Value("rpc_auth_token"), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("rpc_authorization_function", "Name of a callback function for authorization",
-	                          LogicalType::VARCHAR, Value("rpc_dummy_authorization"));
+	                          LogicalType::VARCHAR, Value("rpc_dummy_authorization"), nullptr, SetScope::GLOBAL);
 
 	// TODO make this readonly from SQL?
 	config.AddExtensionOption("rpc_default_token", "Authorization token used by default", LogicalType::VARCHAR, Value(),

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -14,6 +14,7 @@
 
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/encryption_state.hpp"
+#include "duckdb/main/prepared_statement.hpp"
 
 using namespace duckdb;
 
@@ -57,18 +58,56 @@ static string GetSettingString(DatabaseInstance &db, const string &setting_name)
 	return setting_str;
 }
 
-template <typename... ARGS>
-static bool EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... values) {
-	Connection dummy_connection(db);
-	auto auth_result = dummy_connection.Query(sql, values...);
-	if (!auth_result || auth_result->HasError()) {
+// Shared evaluator for callbacks shaped like `SELECT fn(?, ?)` returning
+// BOOLEAN. Caller owns the Connection / PreparedStatement / SQL slots so
+// authn and authz can be isolated from each other (separate connections,
+// separate locks). On any execution-level error the cached connection +
+// prepared statement are reset so the next call rebuilds from scratch —
+// avoids handing out a connection left in a degraded state by a misbehaving
+// callback. A callback that returns `false` (rejection) is not an error and
+// does not trigger a reset.
+static bool EvaluateBoolCallback(DatabaseInstance &db, unique_ptr<Connection> &conn,
+                                 unique_ptr<PreparedStatement> &stmt, string &stmt_sql, const string &sql,
+                                 const Value &v1, const Value &v2) {
+	auto reset_cache = [&]() {
+		stmt.reset();
+		stmt_sql.clear();
+		conn.reset();
+	};
+	if (!conn) {
+		conn = make_uniq<Connection>(db);
+	}
+	if (!stmt || stmt_sql != sql) {
+		stmt = conn->Prepare(sql);
+		if (!stmt || stmt->HasError()) {
+			reset_cache();
+			return false;
+		}
+		stmt_sql = sql;
+	}
+	auto result = stmt->Execute(v1, v2);
+	if (!result || result->HasError()) {
+		reset_cache();
 		return false;
 	}
-	auto auth_result_chunk = auth_result->Fetch();
-	if (!auth_result_chunk || !auth_result_chunk->GetValue(0, 0).template GetValue<bool>()) {
+	auto chunk = result->Fetch();
+	if (!chunk) {
+		reset_cache();
 		return false;
 	}
-	return true;
+	return chunk->GetValue(0, 0).GetValue<bool>();
+}
+
+bool RpcServer::EvaluateAuthn(const Value &v1, const Value &v2) {
+	auto sql = StringUtil::Format("SELECT %s(?, ?)", GetSettingString(*db, "rpc_authentication_function"));
+	std::lock_guard<std::mutex> lock(authn_mutex);
+	return EvaluateBoolCallback(*db, authn_connection, authn_stmt, authn_stmt_sql, sql, v1, v2);
+}
+
+bool RpcServer::EvaluateAuthz(const Value &v1, const Value &v2) {
+	auto sql = StringUtil::Format("SELECT %s(?, ?)", GetSettingString(*db, "rpc_authorization_function"));
+	std::lock_guard<std::mutex> lock(authz_mutex);
+	return EvaluateBoolCallback(*db, authz_connection, authz_stmt, authz_stmt_sql, sql, v1, v2);
 }
 
 string RpcServer::GenerateSessionId() {
@@ -184,9 +223,7 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();
 		string session_id = GenerateSessionId();
-		if (!EvaluateAuthQuery(
-		        *db, StringUtil::Format("SELECT %s(?, ?)", GetSettingString(*db, "rpc_authentication_function")),
-		        Value(session_id), Value(connection_request_message.AuthString()))) {
+		if (!EvaluateAuthn(Value(session_id), Value(connection_request_message.AuthString()))) {
 			return make_uniq<ErrorMessage>("Authentication failed");
 		}
 		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id));
@@ -199,9 +236,7 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 		}
 
 		// TODO do not do this if there is no fun set
-		if (!EvaluateAuthQuery(
-		        *db, StringUtil::Format("SELECT %s(?, ?)", GetSettingString(*db, "rpc_authorization_function")),
-		        Value(prepare_request_message.ConnectionId()), Value(prepare_request_message.Query()))) {
+		if (!EvaluateAuthz(Value(prepare_request_message.ConnectionId()), Value(prepare_request_message.Query()))) {
 			return make_uniq<ErrorMessage>("Authorization failed");
 		}
 


### PR DESCRIPTION
EvaluateAuthn / EvaluateAuthz each own a Connection + cached PreparedStatement instead of allocating a fresh Connection per call. Caches are independent. On execution-level error the cache is reset so the next call rebuilds from scratch.

On a random benchmark, that is figuring out what's the latency of doing `FROM rcp_call('quack:localhost', 'SELECT 42');`, I got a significant (-30% speedup) via avoiding re-creating the connection AND preparing the statement in advance.

Forces SetScope::GLOBAL on rpc_authentication_function and rpc_authorization_function — the server's eval connection has its own ClientContext, so a session-local SET would silently no-op for the auth path. GLOBAL ensures changes actually take effect.

Note, this does creates some possible issues when authn / authz callbacks if they were misbehaving, like if they have side-effects AND if they happen to fail (like, be semantically incorrect) from time to time. It might be worth taking the hit now, since later it might be harder to restrict this.