### PR TITLE
Add BATCHED_REQUEST | _RESPONSE, that carry multiple messages in one go

### DIFF
--- a/src/include/message.hpp
+++ b/src/include/message.hpp
@@ -19,6 +19,8 @@ enum class MessageType : uint8_t {
 	CATALOG_RESPONSE = 10,
 	APPEND_REQUEST = 11,
 	APPEND_RESPONSE = 12,
+	BATCH_REQUEST = 13,
+	BATCH_RESPONSE = 14,
 	ERROR = 100
 };
 
@@ -60,6 +62,13 @@ public:
 		client_query_id = query_id;
 	}
 
+	//! Used by BATCH_REQUEST processing on the server: if this message carries a
+	//! connection_id field and that field is empty, fill it from the supplied
+	//! sid (typically the one produced by an earlier CONNECTION_RESPONSE in the
+	//! same batch). Default no-op for messages that don't carry a connection_id.
+	virtual void TrySubstituteConnectionId(const string &connection_id) {
+	}
+
 	virtual ~ProtocolMessage() {
 	}
 
@@ -90,6 +99,12 @@ public:
 
 	bool ImmediatelyExecute() const {
 		return immediately_execute;
+	}
+
+	void TrySubstituteConnectionId(const string &cid) override {
+		if (connection_id.empty()) {
+			connection_id = cid;
+		}
 	}
 
 private:
@@ -180,6 +195,12 @@ public:
 	explicit FetchRequestMessage(const string &connection_id_p)
 	    : ProtocolMessage(TYPE), connection_id(connection_id_p) {};
 
+	void TrySubstituteConnectionId(const string &cid) override {
+		if (connection_id.empty()) {
+			connection_id = cid;
+		}
+	}
+
 	// TODO what was this for again?
 	// TODO contain the query ref
 private:
@@ -242,6 +263,12 @@ public:
 		return connection_id;
 	}
 
+	void TrySubstituteConnectionId(const string &cid) override {
+		if (connection_id.empty()) {
+			connection_id = cid;
+		}
+	}
+
 private:
 	string connection_id;
 	unique_ptr<ParseInfo> parse_info;
@@ -288,6 +315,12 @@ public:
 		return table_name;
 	}
 
+	void TrySubstituteConnectionId(const string &cid) override {
+		if (connection_id.empty()) {
+			connection_id = cid;
+		}
+	}
+
 private:
 	string connection_id;
 	string schema_name;
@@ -320,6 +353,65 @@ public:
 private:
 	ErrorMessage() : ProtocolMessage(TYPE) {};
 	string error_message;
+};
+
+//! Bundles N inner messages into a single round-trip. The server processes them
+//! sequentially. If chain_connection_id is true, an empty connection_id field
+//! on inner messages is filled in from the most recent CONNECTION_RESPONSE
+//! produced earlier in the same batch.
+class BatchRequestMessage : public ProtocolMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::BATCH_REQUEST;
+
+	BatchRequestMessage() : ProtocolMessage(TYPE), chain_connection_id(true) {
+	}
+	BatchRequestMessage(vector<unique_ptr<ProtocolMessage>> messages_p, bool chain_connection_id_p = true)
+	    : ProtocolMessage(TYPE), messages(std::move(messages_p)), chain_connection_id(chain_connection_id_p) {
+	}
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ProtocolMessage> Deserialize(Deserializer &deserializer);
+
+	const vector<unique_ptr<ProtocolMessage>> &Messages() const {
+		return messages;
+	}
+	vector<unique_ptr<ProtocolMessage>> &MutableMessages() {
+		return messages;
+	}
+	bool ChainConnectionId() const {
+		return chain_connection_id;
+	}
+
+private:
+	vector<unique_ptr<ProtocolMessage>> messages;
+	bool chain_connection_id;
+};
+
+//! Container of inner responses, one per processed inner request. May be
+//! shorter than the request's message list if processing stopped on error;
+//! in that case the last response is an ERROR.
+class BatchResponseMessage : public ProtocolMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::BATCH_RESPONSE;
+
+	BatchResponseMessage() : ProtocolMessage(TYPE) {
+	}
+	explicit BatchResponseMessage(vector<unique_ptr<ProtocolMessage>> responses_p)
+	    : ProtocolMessage(TYPE), responses(std::move(responses_p)) {
+	}
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<ProtocolMessage> Deserialize(Deserializer &deserializer);
+
+	const vector<unique_ptr<ProtocolMessage>> &Responses() const {
+		return responses;
+	}
+	vector<unique_ptr<ProtocolMessage>> &MutableResponses() {
+		return responses;
+	}
+
+private:
+	vector<unique_ptr<ProtocolMessage>> responses;
 };
 
 } // namespace duckdb

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -27,6 +27,10 @@ string duckdb::MessageTypeToString(MessageType type) {
 		return "APPEND_REQUEST";
 	case MessageType::APPEND_RESPONSE:
 		return "APPEND_RESPONSE";
+	case MessageType::BATCH_REQUEST:
+		return "BATCH_REQUEST";
+	case MessageType::BATCH_RESPONSE:
+		return "BATCH_RESPONSE";
 	case MessageType::ERROR:
 		return "ERROR";
 	case MessageType::INVALID:
@@ -79,6 +83,10 @@ unique_ptr<ProtocolMessage> ProtocolMessage::Deserialize(Deserializer &deseriali
 		return AppendRequestMessage::Deserialize(deserializer);
 	case MessageType::APPEND_RESPONSE:
 		return AppendResponseMessage::Deserialize(deserializer);
+	case MessageType::BATCH_REQUEST:
+		return BatchRequestMessage::Deserialize(deserializer);
+	case MessageType::BATCH_RESPONSE:
+		return BatchResponseMessage::Deserialize(deserializer);
 	case MessageType::ERROR:
 		return ErrorMessage::Deserialize(deserializer);
 	default:
@@ -280,4 +288,36 @@ void AppendResponseMessage::Serialize(Serializer &serializer) const {
 
 unique_ptr<ProtocolMessage> AppendResponseMessage::Deserialize(Deserializer &deserializer) {
 	return make_uniq<AppendResponseMessage>();
+}
+
+void BatchRequestMessage::Serialize(Serializer &serializer) const {
+	ProtocolMessage::Serialize(serializer);
+	serializer.WriteProperty<bool>(50, "chain_connection_id", chain_connection_id);
+	serializer.WriteList(51, "messages", messages.size(), [&](Serializer::List &list, idx_t i) {
+		list.WriteObject([&](Serializer &inner) { messages[i]->Serialize(inner); });
+	});
+}
+
+unique_ptr<ProtocolMessage> BatchRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto chain = deserializer.ReadProperty<bool>(50, "chain_connection_id");
+	vector<unique_ptr<ProtocolMessage>> messages;
+	deserializer.ReadList(51, "messages", [&](Deserializer::List &list, idx_t i) {
+		list.ReadObject([&](Deserializer &inner) { messages.push_back(ProtocolMessage::Deserialize(inner)); });
+	});
+	return make_uniq<BatchRequestMessage>(std::move(messages), chain);
+}
+
+void BatchResponseMessage::Serialize(Serializer &serializer) const {
+	ProtocolMessage::Serialize(serializer);
+	serializer.WriteList(50, "responses", responses.size(), [&](Serializer::List &list, idx_t i) {
+		list.WriteObject([&](Serializer &inner) { responses[i]->Serialize(inner); });
+	});
+}
+
+unique_ptr<ProtocolMessage> BatchResponseMessage::Deserialize(Deserializer &deserializer) {
+	vector<unique_ptr<ProtocolMessage>> responses;
+	deserializer.ReadList(50, "responses", [&](Deserializer::List &list, idx_t i) {
+		list.ReadObject([&](Deserializer &inner) { responses.push_back(ProtocolMessage::Deserialize(inner)); });
+	});
+	return make_uniq<BatchResponseMessage>(std::move(responses));
 }

--- a/src/rpc_scan_function.cpp
+++ b/src/rpc_scan_function.cpp
@@ -56,18 +56,36 @@ static unique_ptr<FunctionData> RpcBind(ClientContext &context, TableFunctionBin
 		token = default_token_val.GetValue<string>();
 	}
 
-	auto connection_request_response =
-	    bind_data->initial_client->Request<ConnectionResponseMessage>(make_uniq<ConnectionRequestMessage>(token));
-	bind_data->connection_id = connection_request_response->ConnectionId();
+	// Bundle CONNECT + PREPARE in a single round-trip. Empty connection_id on
+	// PREPARE is filled in server-side from the CONNECTION_RESPONSE produced
+	// by the CONNECT message earlier in the batch (chain_connection_id).
+	vector<unique_ptr<ProtocolMessage>> batch_messages;
+	batch_messages.push_back(make_uniq<ConnectionRequestMessage>(token));
+	batch_messages.push_back(make_uniq<PrepareRequestMessage>("", query, true));
 
-	auto bind_response = bind_data->initial_client->Request<PrepareResponseMessage>(
-	    make_uniq<PrepareRequestMessage>(bind_data->connection_id, query, true));
+	auto batch_response = bind_data->initial_client->Request<BatchResponseMessage>(
+	    make_uniq<BatchRequestMessage>(std::move(batch_messages), /*chain_connection_id*/ true));
 
-	return_types = bind_response->Types();
-	names = bind_response->Names();
+	auto &responses = batch_response->MutableResponses();
+	if (responses.empty()) {
+		throw IOException("Batch response was empty");
+	}
+	// If the server stopped on error, the last entry is an ERROR.
+	if (responses.back()->Type() == MessageType::ERROR) {
+		throw IOException(responses.back()->Cast<ErrorMessage>().Error());
+	}
+	if (responses.size() != 2 || responses[0]->Type() != MessageType::CONNECTION_RESPONSE ||
+	    responses[1]->Type() != MessageType::PREPARE_RESPONSE) {
+		throw IOException("Unexpected batch response shape");
+	}
+	bind_data->connection_id = responses[0]->Cast<ConnectionResponseMessage>().ConnectionId();
+	auto &bind_response = responses[1]->Cast<PrepareResponseMessage>();
 
-	bind_data->results = std::move(bind_response->MutableResults());
-	bind_data->needs_more_fetch = bind_response->NeedsMoreFetch();
+	return_types = bind_response.Types();
+	names = bind_response.Names();
+
+	bind_data->results = std::move(bind_response.MutableResults());
+	bind_data->needs_more_fetch = bind_response.NeedsMoreFetch();
 
 	return bind_data;
 }

--- a/src/rpc_server.cpp
+++ b/src/rpc_server.cpp
@@ -345,6 +345,37 @@ unique_ptr<ProtocolMessage> RpcServer::HandleMessageInternal(ProtocolMessage &re
 		rpc_connection->duckdb_connection->Append(*table_info, collection);
 		return make_uniq<AppendResponseMessage>();
 	}
+	case MessageType::BATCH_REQUEST: {
+		// FIXME: not every sequence of inner messages makes sense; e.g.
+		//   [PREPARE, CONNECT], multiple CONNECTs, [CONNECT, FETCH] (FETCH
+		//   without a PREPARE), or a Batch containing a Batch. The handler
+		//   currently processes whatever the client sent and surfaces errors
+		//   from the underlying handlers (invalid connection_id, etc.). A
+		//   future pass should validate the batch shape up front and reject
+		//   nonsensical sequences with a clear message.
+		auto &batch = received_message.Cast<BatchRequestMessage>();
+		string chained_sid;
+		vector<unique_ptr<ProtocolMessage>> responses;
+		for (auto &inner_msg : batch.MutableMessages()) {
+			if (inner_msg->Type() == MessageType::BATCH_REQUEST) {
+				responses.push_back(make_uniq<ErrorMessage>("Nested BATCH_REQUEST is not supported"));
+				break;
+			}
+			if (batch.ChainConnectionId() && !chained_sid.empty()) {
+				inner_msg->TrySubstituteConnectionId(chained_sid);
+			}
+			auto resp = HandleMessageInternal(*inner_msg);
+			bool is_error = resp->Type() == MessageType::ERROR;
+			if (resp->Type() == MessageType::CONNECTION_RESPONSE) {
+				chained_sid = resp->Cast<ConnectionResponseMessage>().ConnectionId();
+			}
+			responses.push_back(std::move(resp));
+			if (is_error) {
+				break;
+			}
+		}
+		return make_uniq<BatchResponseMessage>(std::move(responses));
+	}
 	default: {
 		return make_uniq<ErrorMessage>(
 		    StringUtil::Format("Unimplemented message type %s", MessageTypeToString(received_message.Type())));


### PR DESCRIPTION
More or less trivial, but for the fact that CONNECTION returned sid are saved and then propagated to next ones (if they happen to miss a sid). That should make that patterns like "CONNECTION A, CONNECTION B" + "REQUEST A; REQUEST B" are valid, but also: "CONNECTION A; REQUEST ''", where the REQUEST get's the implicit sid of A

Moves queries like `CONNECTION + REQUEST "SELECT 42"` to perform a single roundtrip, that could potentially mean a 30% speedup on repeated `CALL rpc_call('quack:localhost', 'SELECT 42');`

Main cost: this is very much NOT tested, and there are arbitrary path one could build, and some of them likely make little to no sense.