### PR TITLE
Add set_tcp_nodelay(true) to server

### DIFF
--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -46,6 +46,7 @@ void HttpQuackServer::Listen(const QuackUri &uri) {
 	};
 	server->set_keep_alive_max_count(128);
 	server->set_keep_alive_timeout(10);
+	server->set_tcp_nodelay(true);
 
 	server->Get("/", [=](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {
 		res.set_content("This is a DuckDB Quack RPC endpoint. Use ATTACH 'quack:...' to connect here.\n", "text/plain");


### PR DESCRIPTION
This disables Nagle's algorithm on accepted TCP connections. This is CURL default since 7.50, basically trading bandwidth for latency by avoiding packing packages together. While this might save roundtrips, in our case neither side sends OK, so it waits for 40ms before firing independently on network timings