### PR TITLE
Split serialization into `MessageHeader` and `QuackMessage`

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -44,7 +44,9 @@ private:
 string MessageTypeToString(MessageType type);
 
 struct MessageHeader {
-	MessageHeader(MessageType type_p, string connection_id_p) : type(type_p), connection_id(std::move(connection_id_p)) {}
+	MessageHeader(MessageType type_p, string connection_id_p)
+	    : type(type_p), connection_id(std::move(connection_id_p)) {
+	}
 
 	MessageType type = MessageType::INVALID;
 	string connection_id;
@@ -125,7 +127,8 @@ public:
 	static unique_ptr<PrepareRequestMessage> Deserialize(Deserializer &deserializer);
 
 protected:
-	PrepareRequestMessage() : QuackMessage(TYPE) {}
+	PrepareRequestMessage() : QuackMessage(TYPE) {
+	}
 
 private:
 	string sql_query;
@@ -162,7 +165,8 @@ public:
 	static unique_ptr<PrepareResponseMessage> Deserialize(Deserializer &deserializer);
 
 protected:
-	PrepareResponseMessage() : QuackMessage(TYPE) {}
+	PrepareResponseMessage() : QuackMessage(TYPE) {
+	}
 
 private:
 	vector<LogicalType> result_types;
@@ -187,7 +191,8 @@ public:
 	static unique_ptr<ConnectionRequestMessage> Deserialize(Deserializer &deserializer);
 
 protected:
-	ConnectionRequestMessage() : QuackMessage(TYPE) {}
+	ConnectionRequestMessage() : QuackMessage(TYPE) {
+	}
 
 private:
 	string auth_string;
@@ -197,12 +202,12 @@ class ConnectionResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_RESPONSE;
 
-	explicit ConnectionResponseMessage(string connection_id_p)
-	    : QuackMessage(TYPE, std::move(connection_id_p)) {
+	explicit ConnectionResponseMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {
 	}
 
 protected:
-	ConnectionResponseMessage() : QuackMessage(TYPE) {}
+	ConnectionResponseMessage() : QuackMessage(TYPE) {
+	}
 
 public:
 	void Serialize(Serializer &serializer) const override;
@@ -213,10 +218,12 @@ class FetchRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_REQUEST;
 
-	explicit FetchRequestMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {}
+	explicit FetchRequestMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {
+	}
 
 protected:
-	FetchRequestMessage() : QuackMessage(TYPE) {}
+	FetchRequestMessage() : QuackMessage(TYPE) {
+	}
 
 public:
 	void Serialize(Serializer &serializer) const override;
@@ -267,10 +274,11 @@ class AppendRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::APPEND_REQUEST;
 
-	explicit AppendRequestMessage(string connection_id_p, string schema_name_p,
-	                              string table_name_p, unique_ptr<DataChunkWrapper> append_chunk_p)
-	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)), table_name(std::move(table_name_p)),
-	      append_chunk(std::move(append_chunk_p)) {}
+	explicit AppendRequestMessage(string connection_id_p, string schema_name_p, string table_name_p,
+	                              unique_ptr<DataChunkWrapper> append_chunk_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)),
+	      table_name(std::move(table_name_p)), append_chunk(std::move(append_chunk_p)) {
+	}
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<AppendRequestMessage> Deserialize(Deserializer &deserializer);
@@ -286,7 +294,8 @@ public:
 	}
 
 protected:
-	AppendRequestMessage() : QuackMessage(TYPE) {}
+	AppendRequestMessage() : QuackMessage(TYPE) {
+	}
 
 private:
 	string schema_name;
@@ -317,7 +326,8 @@ public:
 	static unique_ptr<ErrorMessage> Deserialize(Deserializer &deserializer);
 
 protected:
-	ErrorMessage() : QuackMessage(TYPE) {}
+	ErrorMessage() : QuackMessage(TYPE) {
+	}
 
 private:
 	string message;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -27,7 +27,7 @@ MessageType EnumUtil::FromString<MessageType>(const char *value);
 // TODO: remove in 2.0
 class DataChunkWrapper {
 public:
-	DataChunkWrapper(DataChunk &chunk_p) {
+	explicit DataChunkWrapper(DataChunk &chunk_p) {
 		chunk.InitializeEmpty(chunk_p.GetTypes());
 		chunk.Reference(chunk_p);
 	}
@@ -43,6 +43,17 @@ private:
 
 string MessageTypeToString(MessageType type);
 
+struct MessageHeader {
+	MessageHeader(MessageType type_p, string connection_id_p) : type(type_p), connection_id(std::move(connection_id_p)) {}
+
+	MessageType type = MessageType::INVALID;
+	string connection_id;
+	optional_idx client_query_id;
+
+	void Serialize(Serializer &serializer) const;
+	static MessageHeader Deserialize(Deserializer &deserializer);
+};
+
 class QuackMessage {
 public:
 	void ToMemoryStream(MemoryStream &write_stream) const;
@@ -50,7 +61,7 @@ public:
 
 	template <class TARGET>
 	TARGET &Cast() {
-		if (type != TARGET::TYPE) {
+		if (header.type != TARGET::TYPE) {
 			throw InternalException("Failed to cast message to type - message type mismatch");
 		}
 		return reinterpret_cast<TARGET &>(*this);
@@ -58,56 +69,65 @@ public:
 
 	template <class TARGET>
 	const TARGET &Cast() const {
-		if (type != TARGET::TYPE) {
+		if (header.type != TARGET::TYPE) {
 			throw InternalException("Failed to cast message to type - message type mismatch");
 		}
 		return reinterpret_cast<const TARGET &>(*this);
 	}
 
-	virtual void Serialize(Serializer &serializer) const;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	virtual void Serialize(Serializer &serializer) const = 0;
+	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer, MessageType message_type);
 
 	const MessageType &Type() const {
-		return type;
+		return header.type;
 	}
 
 	optional_idx ClientQueryId() const {
-		return client_query_id;
+		return header.client_query_id;
 	}
 
 	void SetClientQueryId(optional_idx query_id) {
-		client_query_id = query_id;
+		header.client_query_id = query_id;
 	}
 
 	virtual ~QuackMessage() {
 	}
 
-protected:
-	explicit QuackMessage(MessageType type) : type(type) {
+	const string &ConnectionId() const {
+		return header.connection_id;
 	}
-	MessageType type = MessageType::INVALID;
-	optional_idx client_query_id;
+
+	void SetHeader(MessageHeader header_p) {
+		header = std::move(header_p);
+	}
+
+protected:
+	explicit QuackMessage(MessageType type);
+	explicit QuackMessage(MessageType type, string connection_id_p);
+
+private:
+	MessageHeader header;
 };
 
 class PrepareRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::PREPARE_REQUEST;
 
-	PrepareRequestMessage(const string &connection_id_p, const string &sql_query_p)
-	    : QuackMessage(TYPE), connection_id(connection_id_p), sql_query(sql_query_p) {
+	PrepareRequestMessage(string connection_id_p, string sql_query_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), sql_query(std::move(sql_query_p)) {
 	}
-	const std::string &Query() const {
+
+public:
+	const string &Query() const {
 		return sql_query;
 	}
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<PrepareRequestMessage> Deserialize(Deserializer &deserializer);
 
-	const std::string &ConnectionId() const {
-		return connection_id;
-	}
+protected:
+	PrepareRequestMessage() : QuackMessage(TYPE) {}
 
 private:
-	string connection_id; // FIXME abstract this to some superclass
 	string sql_query;
 };
 
@@ -121,6 +141,7 @@ public:
 	      needs_more_fetch(needs_more_fetch_p) {
 	}
 
+public:
 	const vector<LogicalType> &Types() const {
 		return result_types;
 	}
@@ -138,13 +159,16 @@ public:
 	}
 
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<PrepareResponseMessage> Deserialize(Deserializer &deserializer);
+
+protected:
+	PrepareResponseMessage() : QuackMessage(TYPE) {}
 
 private:
 	vector<LogicalType> result_types;
 	vector<string> result_names;
 	vector<unique_ptr<DataChunkWrapper>> results;
-	bool needs_more_fetch;
+	bool needs_more_fetch = false;
 };
 
 // TODO this is where auth goes
@@ -154,11 +178,16 @@ public:
 
 	explicit ConnectionRequestMessage(const string &auth_string_p) : QuackMessage(TYPE), auth_string(auth_string_p) {
 	}
-	const std::string &AuthString() const {
+
+public:
+	const string &AuthString() const {
 		return auth_string;
 	}
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<ConnectionRequestMessage> Deserialize(Deserializer &deserializer);
+
+protected:
+	ConnectionRequestMessage() : QuackMessage(TYPE) {}
 
 private:
 	string auth_string;
@@ -168,33 +197,30 @@ class ConnectionResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_RESPONSE;
 
-	explicit ConnectionResponseMessage(const string &connection_id_p)
-	    : QuackMessage(TYPE), connection_id(connection_id_p) {
+	explicit ConnectionResponseMessage(string connection_id_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)) {
 	}
 
-	const std::string &ConnectionId() const {
-		return connection_id;
-	}
+protected:
+	ConnectionResponseMessage() : QuackMessage(TYPE) {}
+
+public:
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
-
-private:
-	string connection_id;
+	static unique_ptr<ConnectionResponseMessage> Deserialize(Deserializer &deserializer);
 };
 
 class FetchRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_REQUEST;
 
-	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
-	const std::string &ConnectionId() const {
-		return connection_id;
-	}
-	explicit FetchRequestMessage(const string &connection_id_p) : QuackMessage(TYPE), connection_id(connection_id_p) {};
+	explicit FetchRequestMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {}
 
-private:
-	string connection_id;
+protected:
+	FetchRequestMessage() : QuackMessage(TYPE) {}
+
+public:
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<FetchRequestMessage> Deserialize(Deserializer &deserializer);
 };
 
 class FetchResponseMessage : public QuackMessage {
@@ -208,7 +234,7 @@ public:
 	    : QuackMessage(TYPE), results(std::move(results_p)), batch_index(batch_index_p) {};
 
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<FetchResponseMessage> Deserialize(Deserializer &deserializer);
 
 	vector<unique_ptr<DataChunkWrapper>> &MutableResults() {
 		return results;
@@ -241,28 +267,28 @@ class AppendRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::APPEND_REQUEST;
 
-	explicit AppendRequestMessage(const string &connection_id_p, const string &schema_name_p,
-	                              const string &table_name_p, unique_ptr<DataChunkWrapper> append_chunk_p)
-	    : QuackMessage(TYPE), connection_id(connection_id_p), schema_name(schema_name_p), table_name(table_name_p),
-	      append_chunk(std::move(append_chunk_p)) {};
+	explicit AppendRequestMessage(string connection_id_p, string schema_name_p,
+	                              string table_name_p, unique_ptr<DataChunkWrapper> append_chunk_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)), table_name(std::move(table_name_p)),
+	      append_chunk(std::move(append_chunk_p)) {}
 
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<AppendRequestMessage> Deserialize(Deserializer &deserializer);
+
 	DataChunk &AppendChunk() const {
 		return append_chunk->Chunk();
 	}
-	const std::string &ConnectionId() const {
-		return connection_id;
-	}
-	const std::string &SchemaName() const {
+	const string &SchemaName() const {
 		return schema_name;
 	}
-	const std::string &TableName() const {
+	const string &TableName() const {
 		return table_name;
 	}
 
+protected:
+	AppendRequestMessage() : QuackMessage(TYPE) {}
+
 private:
-	string connection_id;
 	string schema_name;
 	string table_name;
 	unique_ptr<DataChunkWrapper> append_chunk;
@@ -275,23 +301,25 @@ public:
 	explicit AppendResponseMessage() : QuackMessage(TYPE) {};
 
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<AppendResponseMessage> Deserialize(Deserializer &deserializer);
 };
 
 class ErrorMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::ERROR_RESPONSE;
-	explicit ErrorMessage(const string &message_p) : QuackMessage(TYPE), message(message_p) {
+	explicit ErrorMessage(string message_p) : QuackMessage(TYPE), message(std::move(message_p)) {
 	}
 	const std::string &Error() const {
 		return message;
 	}
 
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<ErrorMessage> Deserialize(Deserializer &deserializer);
+
+protected:
+	ErrorMessage() : QuackMessage(TYPE) {}
 
 private:
-	ErrorMessage() : QuackMessage(TYPE) {};
 	string message;
 };
 

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -1,28 +1,34 @@
 [
   {
-    "class": "QuackMessage",
-    "class_type": "type",
+    "class": "MessageHeader",
     "includes": [
       "quack_message.hpp"
     ],
     "members":  [
       {
-        "id": 100,
+        "id": 1,
         "name": "type",
         "type": "MessageType"
+      },
+      {
+        "id": 2,
+        "name": "connection_id",
+        "type": "string"
+      },
+      {
+        "id": 3,
+        "name": "client_query_id",
+        "type": "optional_idx"
       }
-    ]
+    ],
+    "pointer_type": "none",
+    "constructor": ["type", "connection_id"]
   },
   {
     "class": "ErrorMessage",
-    "base": "QuackMessage",
-    "enum" : "ERROR_RESPONSE",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
       {
-        "id": 200,
+        "id": 1,
         "name": "message",
         "type": "string"
       }
@@ -31,75 +37,43 @@
   },
   {
     "class": "PrepareRequestMessage",
-    "base": "QuackMessage",
-    "enum" : "PREPARE_REQUEST",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
       {
-        "id": 200,
-        "name": "connection_id",
-        "type": "string"
-      },
-      {
-        "id": 201,
+        "id": 1,
         "name": "sql_query",
         "type": "string"
       }
-    ],
-    "constructor": ["connection_id", "sql_query"]
+    ]
   },
   {
     "class": "FetchRequestMessage",
-    "base": "QuackMessage",
-    "enum" : "FETCH_REQUEST",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
-      {
-        "id": 200,
-        "name": "connection_id",
-        "type": "string"
-      }
-    ],
-    "constructor": ["connection_id"]
+    ]
   },
   {
     "class": "AppendResponseMessage",
-    "base": "QuackMessage",
-    "enum" : "APPEND_RESPONSE",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": []
   },
   {
     "class": "PrepareResponseMessage",
-    "base": "QuackMessage",
-    "enum" : "PREPARE_RESPONSE",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
       {
-        "id": 200,
+        "id": 1,
         "name": "result_types",
         "type": "vector<LogicalType>"
       },
       {
-        "id": 201,
+        "id": 2,
         "name": "result_names",
         "type": "vector<string>"
       },
       {
-        "id": 202,
+        "id": 3,
         "name": "needs_more_fetch",
         "type": "bool"
       },
       {
-        "id": 203,
+        "id": 4,
         "name": "results",
         "type": "vector<unique_ptr<DataChunkWrapper>>"
       }
@@ -108,87 +82,53 @@
   },
   {
     "class": "AppendRequestMessage",
-    "base": "QuackMessage",
-    "enum" : "APPEND_REQUEST",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
       {
-        "id": 200,
-        "name": "connection_id",
-        "type": "string"
-      },
-      {
-        "id": 201,
+        "id": 1,
         "name": "schema_name",
         "type": "string"
       },
       {
-        "id": 202,
+        "id": 2,
         "name": "table_name",
         "type": "string"
       },
       {
-        "id": 203,
+        "id": 3,
         "name": "append_chunk",
         "type": "unique_ptr<DataChunkWrapper>"
       }
-    ],
-    "constructor": ["connection_id", "schema_name",  "table_name", "append_chunk"]
+    ]
   },
   {
     "class": "FetchResponseMessage",
-    "base": "QuackMessage",
-    "enum" : "FETCH_RESPONSE",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
       {
-        "id": 200,
+        "id": 1,
         "name": "results",
         "type": "vector<unique_ptr<DataChunkWrapper>>"
       },
       {
-        "id": 201,
+        "id": 2,
         "name": "batch_index",
         "type": "optional_idx"
       }
-    ],
-    "constructor": ["results", "batch_index"]
+    ]
   },
   {
     "class": "ConnectionRequestMessage",
-    "base": "QuackMessage",
-    "enum" : "CONNECTION_REQUEST",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
       {
-        "id": 200,
+        "id": 1,
         "name": "auth_string",
         "type": "string"
       }
-    ],
-    "constructor": ["auth_string"]
+    ]
   },
   {
     "class": "ConnectionResponseMessage",
-    "base": "QuackMessage",
-    "enum" : "CONNECTION_RESPONSE",
-    "includes": [
-      "quack_message.hpp"
-    ],
     "members": [
-      {
-        "id": 200,
-        "name": "connection_id",
-        "type": "string"
-      }
-    ],
-    "constructor": ["connection_id"]
+    ]
   }
 ]
 

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -49,8 +49,9 @@ public:
 	virtual ~QuackServer();
 
 protected:
-	unique_ptr<QuackMessage> HandleMessage(QuackMessage &received_message);
-	unique_ptr<QuackMessage> HandleMessageInternal(QuackMessage &received_message);
+	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);
+	unique_ptr<QuackMessage> HandleMessageInternal(QuackMessage &received_message,
+	                                               optional_ptr<QuackConnection> connection);
 
 protected:
 	std::vector<std::thread> listen_threads;
@@ -77,6 +78,8 @@ public:
 
 private:
 	static void ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port);
+
+	unique_ptr<QuackMessage> ReadMessage(MemoryStream &read_stream);
 
 	unique_ptr<duckdb_httplib::Server> server;
 };

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -6,7 +6,7 @@
 
 #include "httplib.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 void HttpQuackServer::Close() {
 	// Stops accepting new connections and joins the listener threads (NOT the
@@ -23,7 +23,7 @@ void HttpQuackServer::Close() {
 }
 
 HttpQuackServer::~HttpQuackServer() {
-	Close();
+	HttpQuackServer::Close();
 }
 
 void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port) {
@@ -69,7 +69,8 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 			stream.WriteData((data_ptr_t)data, data_length);
 			return true;
 		});
-		HandleMessage(*QuackMessage::FromMemoryStream(stream))->ToMemoryStream(stream);
+		auto response = HandleMessage(stream);
+		response->ToMemoryStream(stream);
 		res.set_content((const char *)stream.GetData(), stream.GetPosition(), "application/duckdb");
 	});
 
@@ -79,3 +80,5 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 
 	listen_threads.push_back(std::thread(ListenThread, this, uri_p.Host(), uri_p.Port()));
 }
+
+} // namespace duckdb

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -11,7 +11,8 @@ QuackMessage::QuackMessage(MessageType type) : header(type, string()) {
 }
 QuackMessage::QuackMessage(MessageType type, string connection_id_p) : header(type, std::move(connection_id_p)) {
 	// if (connection_id_p.empty()) {
-	// 	throw InvalidInputException("Received message of type \"%s\" with an empty connection id - but this message type requires a connection id", EnumUtil::ToString(type));
+	// 	throw InvalidInputException("Received message of type \"%s\" with an empty connection id - but this message type
+	// requires a connection id", EnumUtil::ToString(type));
 	// }
 }
 
@@ -79,7 +80,7 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 
 	default:
 		throw NotImplementedException(
-			StringUtil::Format("Enum value of type MessageType: '%d' not implemented", value));
+		    StringUtil::Format("Enum value of type MessageType: '%d' not implemented", value));
 	}
 }
 
@@ -101,7 +102,7 @@ void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 }
 
 unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, MessageType message_type) {
-	switch(message_type) {
+	switch (message_type) {
 	case MessageType::CONNECTION_REQUEST:
 		return ConnectionRequestMessage::Deserialize(deserializer);
 	case MessageType::CONNECTION_RESPONSE:
@@ -149,4 +150,4 @@ unique_ptr<DataChunkWrapper> DataChunkWrapper::Deserialize(Deserializer &deseria
 	deserializer.ReadObject(300, "chunk", [&](Deserializer &inner) { chunk.Deserialize(inner); });
 	return make_uniq<DataChunkWrapper>(chunk);
 }
-}
+} // namespace duckdb

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -5,9 +5,17 @@
 
 #include "quack_message.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
-string duckdb::MessageTypeToString(MessageType type) {
+QuackMessage::QuackMessage(MessageType type) : header(type, string()) {
+}
+QuackMessage::QuackMessage(MessageType type, string connection_id_p) : header(type, std::move(connection_id_p)) {
+	// if (connection_id_p.empty()) {
+	// 	throw InvalidInputException("Received message of type \"%s\" with an empty connection id - but this message type requires a connection id", EnumUtil::ToString(type));
+	// }
+}
+
+string MessageTypeToString(MessageType type) {
 	return EnumUtil::ToString(type);
 }
 
@@ -71,7 +79,7 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 
 	default:
 		throw NotImplementedException(
-		    StringUtil::Format("Enum value of type MessageType: '%d' not implemented", value));
+			StringUtil::Format("Enum value of type MessageType: '%d' not implemented", value));
 	}
 }
 
@@ -81,15 +89,55 @@ void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	options.serialization_compatibility = SerializationCompatibility::FromIndex(10);
 	BinarySerializer serializer(write_stream, options);
 
+	// serializer.Begin();
+	// serializer.End();
+
 	serializer.Begin();
+	// write the header
+	header.Serialize(serializer);
+	// write the body
 	Serialize(serializer);
 	serializer.End();
+}
+
+unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, MessageType message_type) {
+	switch(message_type) {
+	case MessageType::CONNECTION_REQUEST:
+		return ConnectionRequestMessage::Deserialize(deserializer);
+	case MessageType::CONNECTION_RESPONSE:
+		return ConnectionResponseMessage::Deserialize(deserializer);
+	case MessageType::PREPARE_REQUEST:
+		return PrepareRequestMessage::Deserialize(deserializer);
+	case MessageType::PREPARE_RESPONSE:
+		return PrepareResponseMessage::Deserialize(deserializer);
+	case MessageType::FETCH_REQUEST:
+		return FetchRequestMessage::Deserialize(deserializer);
+	case MessageType::FETCH_RESPONSE:
+		return FetchResponseMessage::Deserialize(deserializer);
+	case MessageType::APPEND_REQUEST:
+		return AppendRequestMessage::Deserialize(deserializer);
+	case MessageType::APPEND_RESPONSE:
+		return AppendResponseMessage::Deserialize(deserializer);
+	case MessageType::ERROR_RESPONSE:
+		return ErrorMessage::Deserialize(deserializer);
+	default:
+		throw InternalException("Unsupported type for message deserialization");
+	}
 }
 
 unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_stream) {
 	read_stream.Rewind();
 	BinaryDeserializer deserializer(read_stream);
-	return Deserialize(deserializer);
+
+	deserializer.Begin();
+	// read the header
+	auto header = MessageHeader::Deserialize(deserializer);
+	// read the body
+	auto result = Deserialize(deserializer, header.type);
+	result->SetHeader(std::move(header));
+	deserializer.End();
+
+	return result;
 }
 
 void DataChunkWrapper::Serialize(Serializer &serializer) const {
@@ -100,4 +148,5 @@ unique_ptr<DataChunkWrapper> DataChunkWrapper::Deserialize(Deserializer &deseria
 	DataChunk chunk;
 	deserializer.ReadObject(300, "chunk", [&](Deserializer &inner) { chunk.Deserialize(inner); });
 	return make_uniq<DataChunkWrapper>(chunk);
+}
 }

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -10,10 +10,6 @@ namespace duckdb {
 QuackMessage::QuackMessage(MessageType type) : header(type, string()) {
 }
 QuackMessage::QuackMessage(MessageType type, string connection_id_p) : header(type, std::move(connection_id_p)) {
-	// if (connection_id_p.empty()) {
-	// 	throw InvalidInputException("Received message of type \"%s\" with an empty connection id - but this message type
-	// requires a connection id", EnumUtil::ToString(type));
-	// }
 }
 
 string MessageTypeToString(MessageType type) {
@@ -89,9 +85,6 @@ void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	SerializationOptions options;
 	options.serialization_compatibility = SerializationCompatibility::FromIndex(10);
 	BinarySerializer serializer(write_stream, options);
-
-	// serializer.Begin();
-	// serializer.End();
 
 	serializer.Begin();
 	// write the header

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -134,12 +134,10 @@ bool ServerSupportsMessage(MessageType type) {
 
 bool MessageRequiresConnection(MessageType type) {
 	switch (type) {
-	case MessageType::PREPARE_REQUEST:
-	case MessageType::FETCH_REQUEST:
-	case MessageType::APPEND_REQUEST:
-		return true;
-	default:
+	case MessageType::CONNECTION_REQUEST:
 		return false;
+	default:
+		return true;
 	}
 }
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/storage/temporary_file_manager.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
 
 #include "quack_server.hpp"
 #include "quack_message.hpp"
@@ -119,25 +120,71 @@ static string ExtractQuery(QuackMessage &msg) {
 	return "";
 }
 
+bool ServerSupportsMessage(MessageType type) {
+	switch (type) {
+	case MessageType::CONNECTION_REQUEST:
+	case MessageType::PREPARE_REQUEST:
+	case MessageType::FETCH_REQUEST:
+	case MessageType::APPEND_REQUEST:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool MessageRequiresConnection(MessageType type) {
+	switch (type) {
+	case MessageType::PREPARE_REQUEST:
+	case MessageType::FETCH_REQUEST:
+	case MessageType::APPEND_REQUEST:
+		return true;
+	default:
+		return false;
+	}
+}
+
 // main switcheroo happens here
-unique_ptr<QuackMessage> QuackServer::HandleMessage(QuackMessage &received_message) {
+unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	auto &logger = Logger::Get(*db);
 	bool should_log = logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL);
 
-	string connection_id;
-	string query;
-	optional_idx client_query_id;
 	int64_t start_time = 0;
 	if (should_log) {
-		connection_id = ExtractConnectionId(received_message);
-		client_query_id = ExtractClientQueryId(received_message);
-		query = ExtractQuery(received_message);
 		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 		                 .time_since_epoch()
 		                 .count();
 	}
 
-	auto response = HandleMessageInternal(received_message);
+	// start deserializing the message
+	read_stream.Rewind();
+	BinaryDeserializer deserializer(read_stream);
+
+	// first read the header
+	deserializer.Begin();
+	auto header = MessageHeader::Deserialize(deserializer);
+
+	// validate if the server can handle this type of message - the server cannot handle all message types
+	if (!ServerSupportsMessage(header.type)) {
+		return make_uniq<ErrorMessage>("Unsupported message type for server");
+	}
+
+	// if the message requires it, obtain a connection
+	// these are basically all messages aside from connect request
+	optional_ptr<QuackConnection> connection;
+	if (MessageRequiresConnection(header.type)) {
+		connection = GetConnection(header.connection_id);
+		if (!connection) {
+			return make_uniq<ErrorMessage>("Invalid connection id");
+		}
+	}
+
+	// now deserialize the actual message
+	auto received_message = QuackMessage::Deserialize(deserializer, header.type);
+	received_message->SetHeader(std::move(header));
+	deserializer.End();
+
+	// process the message
+	auto response = HandleMessageInternal(*received_message, connection);
 
 	if (should_log) {
 		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
@@ -147,8 +194,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(QuackMessage &received_messa
 		if (response->Type() == MessageType::ERROR_RESPONSE) {
 			error = response->Cast<ErrorMessage>().Error();
 		}
-		auto msg = QuackLogType::ConstructLogMessage(received_message.Type(), connection_id, client_query_id, query, "",
-		                                             end_time - start_time, response->Type(), error);
+		auto msg = QuackLogType::ConstructLogMessage(header.type, header.connection_id, header.client_query_id,
+		                                             ExtractQuery(*received_message), "", end_time - start_time,
+		                                             response->Type(), error);
 		logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 	}
 
@@ -176,7 +224,8 @@ static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, un
 	return results;
 }
 
-unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &received_message) {
+unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &received_message,
+                                                            optional_ptr<QuackConnection> connection_p) {
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();
@@ -190,10 +239,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &receiv
 	}
 	case MessageType::PREPARE_REQUEST: {
 		auto &prepare_request_message = received_message.Cast<PrepareRequestMessage>();
-		optional_ptr<QuackConnection> connection = GetConnection(prepare_request_message.ConnectionId());
-		if (!connection) {
-			return make_uniq<ErrorMessage>("Invalid connection id");
-		}
+		auto &connection = *connection_p;
 
 		// TODO do not do this if there is no fun set
 		if (!EvaluateAuthQuery(
@@ -202,11 +248,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &receiv
 			return make_uniq<ErrorMessage>("Authorization failed");
 		}
 
-		std::unique_lock<std::mutex> lock(connection->lock);
-		connection->duckdb_query_result.reset();
+		std::unique_lock<std::mutex> lock(connection.lock);
+		connection.duckdb_query_result.reset();
 
 		{
-			auto query_result = connection->duckdb_connection->SendQuery(prepare_request_message.Query());
+			auto query_result = connection.duckdb_connection->SendQuery(prepare_request_message.Query());
 			if (query_result->HasError()) {
 				return make_uniq<ErrorMessage>(query_result->GetError());
 			}
@@ -214,25 +260,25 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &receiv
 				return make_uniq<ErrorMessage>("Query did not return any columns");
 			}
 
-			connection->duckdb_query_result = std::move(query_result);
+			connection.duckdb_query_result = std::move(query_result);
 		}
 		// Fresh query → restart batch numbering. Clients' local state is re-initialized on
 		// a new PREPARE, so indices start at 0 again.
-		connection->next_batch_index = 0;
+		connection.next_batch_index = 0;
 
 		Value max_chunks_val;
 		DBConfig::GetConfig(*db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);
 		auto max_chunks_per_batch = max_chunks_val.GetValue<uint64_t>();
 
-		auto names = connection->duckdb_query_result->names;
-		auto types = connection->duckdb_query_result->types;
+		auto names = connection.duckdb_query_result->names;
+		auto types = connection.duckdb_query_result->types;
 
-		auto results = CreateBatch(Allocator::Get(*db), connection->duckdb_query_result, max_chunks_per_batch);
-		if (connection->duckdb_query_result && connection->duckdb_query_result->HasError()) {
+		auto results = CreateBatch(Allocator::Get(*db), connection.duckdb_query_result, max_chunks_per_batch);
+		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) {
 			D_ASSERT(results.empty());
 
-			auto error_message = connection->duckdb_query_result->GetError();
-			connection->duckdb_query_result.reset();
+			auto error_message = connection.duckdb_query_result->GetError();
+			connection.duckdb_query_result.reset();
 			return make_uniq<ErrorMessage>(error_message);
 		}
 		auto needs_more_fetch = results.size() == max_chunks_per_batch;
@@ -243,40 +289,34 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &receiv
 
 	case MessageType::FETCH_REQUEST: {
 		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
-		optional_ptr<QuackConnection> connection = GetConnection(fetch_request_message.ConnectionId());
-		if (!connection) {
-			return make_uniq<ErrorMessage>("Invalid connection id");
-		}
-		std::unique_lock<std::mutex> lock(connection->lock);
+		auto &connection = *connection_p;
+		std::unique_lock<std::mutex> lock(connection.lock);
 
-		if (!connection->duckdb_query_result) {
+		if (!connection.duckdb_query_result) {
 			return make_uniq<FetchResponseMessage>();
 		}
-		if (connection->duckdb_query_result->HasError()) {
-			return make_uniq<ErrorMessage>(connection->duckdb_query_result->GetError());
+		if (connection.duckdb_query_result->HasError()) {
+			return make_uniq<ErrorMessage>(connection.duckdb_query_result->GetError());
 		}
 
 		Value max_chunks_val;
 		DBConfig::GetConfig(*db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);
 		auto max_chunks_per_batch = max_chunks_val.GetValue<uint64_t>();
 
-		auto results = CreateBatch(Allocator::Get(*db), connection->duckdb_query_result, max_chunks_per_batch);
-		if (connection->duckdb_query_result && connection->duckdb_query_result->HasError()) { // TODO this is duplicated
+		auto results = CreateBatch(Allocator::Get(*db), connection.duckdb_query_result, max_chunks_per_batch);
+		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) { // TODO this is duplicated
 			D_ASSERT(results.empty());
-			auto error_message = connection->duckdb_query_result->GetError();
-			connection->duckdb_query_result.reset();
+			auto error_message = connection.duckdb_query_result->GetError();
+			connection.duckdb_query_result.reset();
 			return make_uniq<ErrorMessage>(error_message);
 		}
-		auto assigned_batch_index = connection->next_batch_index++;
+		auto assigned_batch_index = connection.next_batch_index++;
 		return make_uniq<FetchResponseMessage>(std::move(results), optional_idx(assigned_batch_index));
 	}
 
 	case MessageType::APPEND_REQUEST: {
 		auto &append_request_message = received_message.Cast<AppendRequestMessage>();
-		optional_ptr<QuackConnection> connection = GetConnection(append_request_message.ConnectionId());
-		if (!connection) {
-			return make_uniq<ErrorMessage>("Invalid connection id");
-		}
+		auto &connection = *connection_p;
 
 		// we never execute this query, but throw it at the authorization function so it can check if this user gets to
 		// insert into this table
@@ -290,12 +330,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(QuackMessage &receiv
 			return make_uniq<ErrorMessage>("Authorization failed");
 		}
 
-		std::unique_lock<std::mutex> lock(connection->lock);
-		auto &context = *connection->duckdb_connection->context;
+		std::unique_lock<std::mutex> lock(connection.lock);
+		auto &context = *connection.duckdb_connection->context;
 		auto table_info = context.TableInfo(append_request_message.SchemaName(), append_request_message.TableName());
 		ColumnDataCollection collection(Allocator::Get(context), append_request_message.AppendChunk().GetTypes());
 		collection.Append(append_request_message.AppendChunk());
-		connection->duckdb_connection->Append(*table_info, collection);
+		connection.duckdb_connection->Append(*table_info, collection);
 		return make_uniq<AppendResponseMessage>();
 	}
 	default: {

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -9,158 +9,114 @@
 
 namespace duckdb {
 
-void QuackMessage::Serialize(Serializer &serializer) const {
-	serializer.WriteProperty<MessageType>(100, "type", type);
+void AppendRequestMessage::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(1, "schema_name", schema_name);
+	serializer.WritePropertyWithDefault<string>(2, "table_name", table_name);
+	serializer.WritePropertyWithDefault<unique_ptr<DataChunkWrapper>>(3, "append_chunk", append_chunk);
 }
 
-unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer) {
-	auto type = deserializer.ReadProperty<MessageType>(100, "type");
-	unique_ptr<QuackMessage> result;
-	switch (type) {
-	case MessageType::APPEND_REQUEST:
-		result = AppendRequestMessage::Deserialize(deserializer);
-		break;
-	case MessageType::APPEND_RESPONSE:
-		result = AppendResponseMessage::Deserialize(deserializer);
-		break;
-	case MessageType::CONNECTION_REQUEST:
-		result = ConnectionRequestMessage::Deserialize(deserializer);
-		break;
-	case MessageType::CONNECTION_RESPONSE:
-		result = ConnectionResponseMessage::Deserialize(deserializer);
-		break;
-	case MessageType::ERROR_RESPONSE:
-		result = ErrorMessage::Deserialize(deserializer);
-		break;
-	case MessageType::FETCH_REQUEST:
-		result = FetchRequestMessage::Deserialize(deserializer);
-		break;
-	case MessageType::FETCH_RESPONSE:
-		result = FetchResponseMessage::Deserialize(deserializer);
-		break;
-	case MessageType::PREPARE_REQUEST:
-		result = PrepareRequestMessage::Deserialize(deserializer);
-		break;
-	case MessageType::PREPARE_RESPONSE:
-		result = PrepareResponseMessage::Deserialize(deserializer);
-		break;
-	default:
-		throw SerializationException("Unsupported type for deserialization of QuackMessage!");
-	}
+unique_ptr<AppendRequestMessage> AppendRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<AppendRequestMessage>(new AppendRequestMessage());
+	deserializer.ReadPropertyWithDefault<string>(1, "schema_name", result->schema_name);
+	deserializer.ReadPropertyWithDefault<string>(2, "table_name", result->table_name);
+	deserializer.ReadPropertyWithDefault<unique_ptr<DataChunkWrapper>>(3, "append_chunk", result->append_chunk);
 	return result;
 }
 
-void AppendRequestMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "connection_id", connection_id);
-	serializer.WritePropertyWithDefault<string>(201, "schema_name", schema_name);
-	serializer.WritePropertyWithDefault<string>(202, "table_name", table_name);
-	serializer.WritePropertyWithDefault<unique_ptr<DataChunkWrapper>>(203, "append_chunk", append_chunk);
-}
-
-unique_ptr<QuackMessage> AppendRequestMessage::Deserialize(Deserializer &deserializer) {
-	auto connection_id = deserializer.ReadPropertyWithDefault<string>(200, "connection_id");
-	auto schema_name = deserializer.ReadPropertyWithDefault<string>(201, "schema_name");
-	auto table_name = deserializer.ReadPropertyWithDefault<string>(202, "table_name");
-	auto append_chunk = deserializer.ReadPropertyWithDefault<unique_ptr<DataChunkWrapper>>(203, "append_chunk");
-	auto result = duckdb::unique_ptr<AppendRequestMessage>(new AppendRequestMessage(std::move(connection_id), std::move(schema_name), std::move(table_name), std::move(append_chunk)));
-	return std::move(result);
-}
-
 void AppendResponseMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
 }
 
-unique_ptr<QuackMessage> AppendResponseMessage::Deserialize(Deserializer &deserializer) {
+unique_ptr<AppendResponseMessage> AppendResponseMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<AppendResponseMessage>(new AppendResponseMessage());
-	return std::move(result);
+	return result;
 }
 
 void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "auth_string", auth_string);
+	serializer.WritePropertyWithDefault<string>(1, "auth_string", auth_string);
 }
 
-unique_ptr<QuackMessage> ConnectionRequestMessage::Deserialize(Deserializer &deserializer) {
-	auto auth_string = deserializer.ReadPropertyWithDefault<string>(200, "auth_string");
-	auto result = duckdb::unique_ptr<ConnectionRequestMessage>(new ConnectionRequestMessage(std::move(auth_string)));
-	return std::move(result);
+unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<ConnectionRequestMessage>(new ConnectionRequestMessage());
+	deserializer.ReadPropertyWithDefault<string>(1, "auth_string", result->auth_string);
+	return result;
 }
 
 void ConnectionResponseMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "connection_id", connection_id);
 }
 
-unique_ptr<QuackMessage> ConnectionResponseMessage::Deserialize(Deserializer &deserializer) {
-	auto connection_id = deserializer.ReadPropertyWithDefault<string>(200, "connection_id");
-	auto result = duckdb::unique_ptr<ConnectionResponseMessage>(new ConnectionResponseMessage(std::move(connection_id)));
-	return std::move(result);
+unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<ConnectionResponseMessage>(new ConnectionResponseMessage());
+	return result;
 }
 
 void ErrorMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "message", message);
+	serializer.WritePropertyWithDefault<string>(1, "message", message);
 }
 
-unique_ptr<QuackMessage> ErrorMessage::Deserialize(Deserializer &deserializer) {
-	auto message = deserializer.ReadPropertyWithDefault<string>(200, "message");
+unique_ptr<ErrorMessage> ErrorMessage::Deserialize(Deserializer &deserializer) {
+	auto message = deserializer.ReadPropertyWithDefault<string>(1, "message");
 	auto result = duckdb::unique_ptr<ErrorMessage>(new ErrorMessage(std::move(message)));
-	return std::move(result);
+	return result;
 }
 
 void FetchRequestMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "connection_id", connection_id);
 }
 
-unique_ptr<QuackMessage> FetchRequestMessage::Deserialize(Deserializer &deserializer) {
-	auto connection_id = deserializer.ReadPropertyWithDefault<string>(200, "connection_id");
-	auto result = duckdb::unique_ptr<FetchRequestMessage>(new FetchRequestMessage(std::move(connection_id)));
-	return std::move(result);
+unique_ptr<FetchRequestMessage> FetchRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<FetchRequestMessage>(new FetchRequestMessage());
+	return result;
 }
 
 void FetchResponseMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(200, "results", results);
-	serializer.WriteProperty<optional_idx>(201, "batch_index", batch_index);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(1, "results", results);
+	serializer.WriteProperty<optional_idx>(2, "batch_index", batch_index);
 }
 
-unique_ptr<QuackMessage> FetchResponseMessage::Deserialize(Deserializer &deserializer) {
-	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(200, "results");
-	auto batch_index = deserializer.ReadProperty<optional_idx>(201, "batch_index");
-	auto result = duckdb::unique_ptr<FetchResponseMessage>(new FetchResponseMessage(std::move(results), batch_index));
-	return std::move(result);
+unique_ptr<FetchResponseMessage> FetchResponseMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<FetchResponseMessage>(new FetchResponseMessage());
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(1, "results", result->results);
+	deserializer.ReadProperty<optional_idx>(2, "batch_index", result->batch_index);
+	return result;
+}
+
+void MessageHeader::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<MessageType>(1, "type", type);
+	serializer.WritePropertyWithDefault<string>(2, "connection_id", connection_id);
+	serializer.WriteProperty<optional_idx>(3, "client_query_id", client_query_id);
+}
+
+MessageHeader MessageHeader::Deserialize(Deserializer &deserializer) {
+	auto type = deserializer.ReadProperty<MessageType>(1, "type");
+	auto connection_id = deserializer.ReadPropertyWithDefault<string>(2, "connection_id");
+	MessageHeader result(type, std::move(connection_id));
+	deserializer.ReadProperty<optional_idx>(3, "client_query_id", result.client_query_id);
+	return result;
 }
 
 void PrepareRequestMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<string>(200, "connection_id", connection_id);
-	serializer.WritePropertyWithDefault<string>(201, "sql_query", sql_query);
+	serializer.WritePropertyWithDefault<string>(1, "sql_query", sql_query);
 }
 
-unique_ptr<QuackMessage> PrepareRequestMessage::Deserialize(Deserializer &deserializer) {
-	auto connection_id = deserializer.ReadPropertyWithDefault<string>(200, "connection_id");
-	auto sql_query = deserializer.ReadPropertyWithDefault<string>(201, "sql_query");
-	auto result = duckdb::unique_ptr<PrepareRequestMessage>(new PrepareRequestMessage(std::move(connection_id), std::move(sql_query)));
-	return std::move(result);
+unique_ptr<PrepareRequestMessage> PrepareRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<PrepareRequestMessage>(new PrepareRequestMessage());
+	deserializer.ReadPropertyWithDefault<string>(1, "sql_query", result->sql_query);
+	return result;
 }
 
 void PrepareResponseMessage::Serialize(Serializer &serializer) const {
-	QuackMessage::Serialize(serializer);
-	serializer.WritePropertyWithDefault<vector<LogicalType>>(200, "result_types", result_types);
-	serializer.WritePropertyWithDefault<vector<string>>(201, "result_names", result_names);
-	serializer.WritePropertyWithDefault<bool>(202, "needs_more_fetch", needs_more_fetch);
-	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(203, "results", results);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(1, "result_types", result_types);
+	serializer.WritePropertyWithDefault<vector<string>>(2, "result_names", result_names);
+	serializer.WritePropertyWithDefault<bool>(3, "needs_more_fetch", needs_more_fetch);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results", results);
 }
 
-unique_ptr<QuackMessage> PrepareResponseMessage::Deserialize(Deserializer &deserializer) {
-	auto result_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(200, "result_types");
-	auto result_names = deserializer.ReadPropertyWithDefault<vector<string>>(201, "result_names");
-	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(202, "needs_more_fetch");
-	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(203, "results");
+unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deserializer &deserializer) {
+	auto result_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(1, "result_types");
+	auto result_names = deserializer.ReadPropertyWithDefault<vector<string>>(2, "result_names");
+	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(3, "needs_more_fetch");
+	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results");
 	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch));
-	return std::move(result);
+	return result;
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Currently we (de)serialize only a top-level `QuackMessage`. This means that we always deserialize the full message, even if the user is not authenticated. This greatly increases the attack surface of the protocol as unauthenticated users can send messages of *any* message type and force the server to deserialize the message.

This means the potential attack surface is whatever gets deserialized in messages - which could be rather complex as we can deserialize `DataChunks` with arbitrarily nested data in them. It is currently e.g. possible to trigger stack overflows by sending messages with deeply nested data types (`INT[][][][][]...[]`).

Memory exhaustion is also an issue - while we can limit the message size we accept, deserializing a message can increase our memory footprint by several factors more than the message size. Especially if this is in e.g. complex nested types, this all currently sits in non-buffer-managed memory, which means an attacker could balloon memory usage in the server beyond expected amounts and trigger the OOM killer. 

This PR remedies this by limiting what unauthenticated attackers can send to the server. Instead of (de)serializing only a `QuackMessage`, we split up the message serialization into a `MessageHeader` followed by a `QuackMessage`. The header looks as follows:

```cpp
struct MessageHeader {
	MessageType type = MessageType::INVALID;
	string connection_id;
	optional_idx client_query_id;
};
```

If the message type requires authentication (i.e. a valid connection id), we then *first* check if that connection id is valid before proceeding to deserialize the remaining `QuackMessage`. The only message that does not require a connection id is a `ConnectionRequestMessage` - which only contains a single `string` (the authentication string). This means we no longer deserialize complex messages from potentially unauthenticated users which greatly limits the potential attack surface in this area.

From a code perspective, what has changed to make this happen is that we no longer serialize the `QuackMessage` in one go - but rather serialize two independent objects:

```
[MessageHeader]
[QuackMessage]
```

This allows us to deserialize only the header, followed by verifying it is valid, followed by processing the message. From a serialization perspective the main difference here is that the individual messages are independently serialized and deserialized, and we need to manually call `QuackMessage::Deserialize` with the message type as a parameter to figure out which message to deserialize.