### PR TITLE
Generate token when token option is not passed, and validate tokens (len >= 4)

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -42,6 +42,12 @@ public:
 
 	string GenerateSessionId();
 
+	//! Generate a fresh CSPRNG-backed 128-bit token, hex-encoded (32 chars).
+	static string GenerateRandomToken(DatabaseInstance &db);
+
+	//! Throw InvalidInputException if `token` doesn't meet requirements(currently, length >= 4)
+	static void ValidateToken(const string &token);
+
 	const string &Token() {
 		return token;
 	}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -16,8 +16,15 @@
 
 using namespace duckdb;
 
+void QuackServer::ValidateToken(const string &token) {
+	if (token.size() < 4) {
+		throw InvalidInputException("Quack server token must be at least 4 characters long");
+	}
+}
+
 QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
     : db(context_p.db), uri(uri_p), token(token_p) {
+	ValidateToken(token);
 }
 
 QuackServer::~QuackServer() {
@@ -71,28 +78,42 @@ static bool EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... v
 	return true;
 }
 
-string QuackServer::GenerateSessionId() {
-	constexpr idx_t kSessionIdBytes = 16; // 128 bits
+static constexpr idx_t kTokenBytes = 16; // 128 bits
 
+static string HexEncode(const data_t *bytes, idx_t n) {
+	string result(n * 2, '\0');
+	for (idx_t i = 0; i < n; i++) {
+		result[2 * i] = Blob::HEX_TABLE[bytes[i] >> 4];
+		result[2 * i + 1] = Blob::HEX_TABLE[bytes[i] & 0x0F];
+	}
+	return result;
+}
+
+string QuackServer::GenerateRandomToken(DatabaseInstance &db) {
+	auto encryption_util = db.GetEncryptionUtil(false);
+	auto metadata = make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, kTokenBytes,
+	                                                   EncryptionTypes::EncryptionVersion::NONE);
+	auto rng = encryption_util->CreateEncryptionState(std::move(metadata));
+
+	data_t bytes[kTokenBytes];
+	rng->GenerateRandomData(bytes, kTokenBytes);
+	return HexEncode(bytes, kTokenBytes);
+}
+
+string QuackServer::GenerateSessionId() {
 	{
 		std::lock_guard<std::mutex> lock(session_id_rng_mutex);
 		if (!session_id_rng) {
 			auto encryption_util = db->GetEncryptionUtil(false);
-			auto metadata = make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, kSessionIdBytes,
+			auto metadata = make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, kTokenBytes,
 			                                                   EncryptionTypes::EncryptionVersion::NONE);
 			session_id_rng = encryption_util->CreateEncryptionState(std::move(metadata));
 		}
 	}
 
-	data_t bytes[kSessionIdBytes];
-	session_id_rng->GenerateRandomData(bytes, kSessionIdBytes);
-
-	string result(kSessionIdBytes * 2, '\0');
-	for (idx_t i = 0; i < kSessionIdBytes; i++) {
-		result[2 * i] = Blob::HEX_TABLE[bytes[i] >> 4];
-		result[2 * i + 1] = Blob::HEX_TABLE[bytes[i] & 0x0F];
-	}
-	return result;
+	data_t bytes[kTokenBytes];
+	session_id_rng->GenerateRandomData(bytes, kTokenBytes);
+	return HexEncode(bytes, kTokenBytes);
 }
 
 // Extract connection_id from a message if available

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -49,8 +49,9 @@ static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunc
 		if (input.named_parameters.find("token") != input.named_parameters.end()) {
 			bind_data->token = input.named_parameters["token"].GetValue<string>();
 		} else {
-			// TODO
+			bind_data->token = QuackServer::GenerateRandomToken(*context.db);
 		}
+		QuackServer::ValidateToken(bind_data->token);
 		return_types.emplace_back(LogicalType::VARCHAR);
 		names.emplace_back("auth_token");
 	}

--- a/test/sql/token_validation.test
+++ b/test/sql/token_validation.test
@@ -1,0 +1,45 @@
+# name: test/sql/token_validation.test
+# description: Reject quack_serve() tokens shorter than 4 chars; accept 4+; accept no token (auto-generated).
+# group: [sql]
+
+require quack
+
+require httpfs
+
+# Reject empty token
+statement error
+FROM quack_serve('quack:127.0.0.1', token='');
+----
+Quack server token must be at least 4 characters long
+
+# Reject 1-char token
+statement error
+FROM quack_serve('quack:127.0.0.1', token='1');
+----
+Quack server token must be at least 4 characters long
+
+# Reject 2-char token
+statement error
+FROM quack_serve('quack:127.0.0.1', token='12');
+----
+Quack server token must be at least 4 characters long
+
+# Reject 3-char token
+statement error
+FROM quack_serve('quack:127.0.0.1', token='123');
+----
+Quack server token must be at least 4 characters long
+
+# Accept 4-char token (boundary).
+statement ok
+FROM quack_serve('quack:127.0.0.1', token='1234');
+
+statement ok
+CALL quack_stop('quack:127.0.0.1');
+
+# No token argument -> auto-generated 32-char hex token, should succeed.
+statement ok
+FROM quack_serve('quack:127.0.0.1');
+
+statement ok
+CALL quack_stop('quack:127.0.0.1');


### PR DESCRIPTION
Rule is a bit arbitrary, but I think empty or anyhow very short tokens should be forbidden