### PR TITLE
Three minor fixes: normalize URIs, surface failures in bind, handle self stop

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -33,7 +33,15 @@ class QuackServer {
 public:
 	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
 
+	//! Stop accepting new connections (close the listener socket) without
+	//! joining listener threads. Safe to call from a request-handler thread —
+	//! does not wait on httplib's task-queue, which would deadlock when the
+	//! caller is itself a worker.
+	virtual void StopAccepting() {};
+
 	//! Synchronously stop accepting connections and join the listener threads.
+	//! Must NOT be called from a worker / request-handler thread; httplib's
+	//! listen-loop teardown joins all workers, which would deadlock.
 	virtual void Close() {};
 
 	optional_ptr<QuackConnection> GetConnection(const string &connection_id);
@@ -72,6 +80,7 @@ class HttpQuackServer : public QuackServer {
 public:
 	HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
 
+	void StopAccepting() override;
 	void Close() override;
 
 	~HttpQuackServer() override;

--- a/src/include/quack_uri.hpp
+++ b/src/include/quack_uri.hpp
@@ -17,6 +17,10 @@ public:
 	string Uri() const {
 		return uri;
 	}
+	//! Fully-qualified canonical form, always `quack:<host>:<port>`
+	string CanonicalUri() const {
+		return "quack:" + host + ":" + std::to_string(port);
+	}
 	string Host() const {
 		return host;
 	}

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -8,9 +8,17 @@
 
 namespace duckdb {
 
+void HttpQuackServer::StopAccepting() {
+	// Closes the listening socket only. Idempotent. Safe to call from a
+	// request-handler thread.
+	server->stop();
+}
+
 void HttpQuackServer::Close() {
-	// Stops accepting new connections and joins the listener threads (NOT the
-	// httplib worker pool)
+	// Stops accepting new connections AND joins the listener threads (NOT the
+	// httplib worker pool). Must not be called from a worker thread — the
+	// listener's exit path inside httplib joins all workers, so a worker
+	// joining the listener would deadlock through that chain.
 	server->stop();
 	try {
 		for (auto &thread : listen_threads) {
@@ -29,7 +37,8 @@ HttpQuackServer::~HttpQuackServer() {
 void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port) {
 	D_ASSERT(server->server);
 	D_ASSERT(listen_port > 1 && listen_port < 65535);
-	server->server->listen(listen_host, listen_port);
+	// Socket is already bound (synchronously, in the constructor)
+	server->server->listen_after_bind();
 }
 
 HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
@@ -76,6 +85,14 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 
 	if (!server->is_valid()) {
 		throw IOException("Failed to instantiate DuckDB server at %s / %s", uri_p.Uri(), uri_p.Http());
+	}
+
+	// Bind synchronously here so that bind() failures (e.g. EADDRINUSE)
+	// propagate to the caller of quack_serve()
+	if (!server->bind_to_port(uri_p.Host(), uri_p.Port())) {
+		throw IOException("Failed to bind DuckDB Quack RPC server to %s (address in use, permission denied, "
+		                  "or invalid host/port)",
+		                  uri_p.Http());
 	}
 
 	listen_threads.push_back(std::thread(ListenThread, this, uri_p.Host(), uri_p.Port()));

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -19,22 +19,23 @@ QuackStorageExtensionInfo &QuackStorageExtensionInfo::GetState(const DatabaseIns
 
 QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, const QuackUri &listen_uri,
                                                      const string &token) {
+	auto key = listen_uri.CanonicalUri();
 	std::lock_guard<std::mutex> lock(servers_mutex);
-	auto it = servers.find(listen_uri.Uri());
+	auto it = servers.find(key);
 	if (it != servers.end()) {
-		throw InvalidInputException("Server already exists for %s", listen_uri.Uri());
+		throw InvalidInputException("Server already exists for %s", key);
 	}
 	unique_ptr<QuackServer> server;
 	server = make_uniq<HttpQuackServer>(context, listen_uri, token);
-	servers.emplace(listen_uri.Uri(), std::move(server));
-	return *servers[listen_uri.Uri()];
+	servers.emplace(key, std::move(server));
+	return *servers[key];
 }
 
 bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUri &listen_uri) {
 	unique_ptr<QuackServer> to_destroy;
 	{
 		std::lock_guard<std::mutex> lock(servers_mutex);
-		const auto it = servers.find(listen_uri.Uri());
+		const auto it = servers.find(listen_uri.CanonicalUri());
 		if (it == servers.end()) {
 			return false;
 		}

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -44,7 +44,13 @@ bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUr
 	}
 	// Synchronously free the listening port so that clients racing a subsequent
 	// connect() after quack_stop observe a real refusal rather than a stale socket.
-	to_destroy->Close();
+	// Synchronously close the listening socket so the port is free immediately
+	// (callers racing a subsequent connect() see a real refusal, not a stale
+	// listener). The full teardown (joining listener thread + httplib worker
+	// pool) happens off-thread below — that join cannot run on the worker
+	// that's currently executing this very stop request, because the listener's
+	// exit path joins all workers and would deadlock.
+	to_destroy->StopAccepting();
 	// Full destruction (httplib worker-pool join) runs off-thread so that when
 	// quack_stop is invoked from inside one of the server's own worker threads
 	std::thread([srv = std::move(to_destroy)]() mutable { srv.reset(); }).detach();

--- a/test/sql/self_stop.test
+++ b/test/sql/self_stop.test
@@ -1,0 +1,33 @@
+# name: test/sql/self_stop.test
+# description: A client may instruct a quack server to stop itself via
+#              `CALL quack_stop(...)` over RPC. Must not deadlock or crash.
+# group: [sql]
+
+require quack
+
+require httpfs
+
+# Don't skip on the connection-error string — it's exactly what we expect.
+set ignore_error_messages __none__
+
+# Start the server.
+statement ok
+FROM quack_serve('quack:127.0.0.1', token='abcd');
+
+# Have the client tell the server to stop itself. The server processes the
+# request on a worker thread, runs CALL quack_stop, returns the result row,
+# and asynchronously tears itself down — no deadlock joining the worker pool
+# from inside a worker.
+statement ok
+FROM quack_query('quack:127.0.0.1', 'CALL quack_stop(''quack:127.0.0.1'')', token='abcd');
+
+# Server is now gone — a subsequent client request to the same address must
+# fail (any error is fine, as long as it doesn't hang or succeed).
+statement error
+FROM quack_query('quack:127.0.0.1', 'CALL quack_stop(''quack:127.0.0.1'')', token='abcd');
+----
+Failed to send message
+
+# Local-side stop is a no-op (no entry in the registry).
+statement ok
+CALL quack_stop('quack:127.0.0.1');

--- a/test/sql/serve_canonical.test
+++ b/test/sql/serve_canonical.test
@@ -1,0 +1,48 @@
+# name: test/sql/serve_canonical.test
+# description: quack_serve URI keying is canonical (quack:host:port), so equivalent forms collide.
+# group: [sql]
+
+require quack
+
+require httpfs
+
+# Start a server on the explicit form. listen_uri column preserves what was sent.
+query III
+FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
+----
+quack:127.0.0.1:9494	http://127.0.0.1:9494	abcd
+
+# Same canonical address — must reject regardless of which surface form is used.
+statement error
+FROM quack_serve('quack:127.0.0.1:9494', token='efgh');
+----
+Server already exists for quack:127.0.0.1:9494
+
+statement error
+FROM quack_serve('quack:127.0.0.1', token='efgh');
+----
+Server already exists for quack:127.0.0.1:9494
+
+# Stop using a different surface form than was used to start — should still find it.
+statement ok
+CALL quack_stop('quack:127.0.0.1');
+
+# Now we can re-start either form fresh.
+query III
+FROM quack_serve('quack:127.0.0.1', token='ijkl');
+----
+quack:127.0.0.1	http://127.0.0.1:9494	ijkl
+
+# And both surface forms still collide with the active server.
+statement error
+FROM quack_serve('quack:127.0.0.1:9494', token='mnop');
+----
+Server already exists for quack:127.0.0.1:9494
+
+statement error
+FROM quack_serve('quack:127.0.0.1', token='mnop');
+----
+Server already exists for quack:127.0.0.1:9494
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:9494');

--- a/test/sql/serve_canonical.test
+++ b/test/sql/serve_canonical.test
@@ -46,3 +46,11 @@ Server already exists for quack:127.0.0.1:9494
 
 statement ok
 CALL quack_stop('quack:127.0.0.1:9494');
+
+# Port 1 is privileged — bind() will fail unless the test runs as root.
+# `statement maybe` accepts either outcome but matches the expected error
+# string when the bind does fail.
+statement maybe
+FROM quack_serve('quack:127.0.0.1:1', token='abcd');
+----
+Failed to bind DuckDB Quack RPC server


### PR DESCRIPTION
3 fixes (last two are connected):
* canonicalize URI, so that `quack:1.2.3.4:9494` and `quack:1.2.3.4` are actually the same
* surface failures in bind
* handle somewhat gracefully self-closing the connection (I am not completely sure the test is deterministic, CI will tell)