### PR TITLE
Deserialize fixes

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,6 @@
 # Extension from this repo
 duckdb_extension_load(quack
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    LOAD_TESTS
 )
 
 # Any extra extensions that should be built

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -79,6 +79,8 @@ public:
 
 	virtual void Serialize(Serializer &serializer) const = 0;
 	static unique_ptr<QuackMessage> Deserialize(Deserializer &deserializer, MessageType message_type);
+	static MessageHeader DeserializeHeader(BinaryDeserializer &deserializer);
+	static unique_ptr<QuackMessage> DeserializeMessage(BinaryDeserializer &deserializer, MessageHeader header);
 
 	const MessageType &Type() const {
 		return header.type;
@@ -255,20 +257,6 @@ private:
 	vector<unique_ptr<DataChunkWrapper>> results;
 	optional_idx batch_index;
 };
-
-// orrr
-static unique_ptr<ParseInfo> ParseInfoCopy(ParseInfo &parse_info) {
-	switch (parse_info.info_type) {
-	case ParseInfoType::CREATE_INFO: {
-		return std::move(parse_info.Cast<CreateInfo>().Copy());
-	}
-	case ParseInfoType::DROP_INFO: {
-		return std::move(parse_info.Cast<DropInfo>().Copy());
-	}
-	default:
-		throw NotImplementedException("Unsupported ParseInfoType");
-	}
-}
 
 class AppendRequestMessage : public QuackMessage {
 public:

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -86,10 +86,12 @@ void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	options.serialization_compatibility = SerializationCompatibility::FromIndex(10);
 	BinarySerializer serializer(write_stream, options);
 
-	serializer.Begin();
 	// write the header
+	serializer.Begin();
 	header.Serialize(serializer);
+	serializer.End();
 	// write the body
+	serializer.Begin();
 	Serialize(serializer);
 	serializer.End();
 }
@@ -119,19 +121,30 @@ unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, M
 	}
 }
 
+MessageHeader QuackMessage::DeserializeHeader(BinaryDeserializer &deserializer) {
+	deserializer.Begin();
+	auto header = MessageHeader::Deserialize(deserializer);
+	deserializer.End();
+	return header;
+}
+
+unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &deserializer, MessageHeader header) {
+	// read the body
+	deserializer.Begin();
+	auto result = Deserialize(deserializer, header.type);
+	result->SetHeader(std::move(header));
+	deserializer.End();
+	return result;
+}
+
 unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_stream) {
 	read_stream.Rewind();
 	BinaryDeserializer deserializer(read_stream);
 
-	deserializer.Begin();
 	// read the header
-	auto header = MessageHeader::Deserialize(deserializer);
-	// read the body
-	auto result = Deserialize(deserializer, header.type);
-	result->SetHeader(std::move(header));
-	deserializer.End();
-
-	return result;
+	auto header = DeserializeHeader(deserializer);
+	// read the message
+	return DeserializeMessage(deserializer, std::move(header));
 }
 
 void DataChunkWrapper::Serialize(Serializer &serializer) const {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -91,8 +91,8 @@ static string HexEncode(const data_t *bytes, idx_t n) {
 
 string QuackServer::GenerateRandomToken(DatabaseInstance &db) {
 	auto encryption_util = db.GetEncryptionUtil(false);
-	auto metadata = make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, kTokenBytes,
-	                                                   EncryptionTypes::EncryptionVersion::NONE);
+	auto metadata =
+	    make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, kTokenBytes, EncryptionTypes::EncryptionVersion::NONE);
 	auto rng = encryption_util->CreateEncryptionState(std::move(metadata));
 
 	data_t bytes[kTokenBytes];
@@ -114,24 +114,6 @@ string QuackServer::GenerateSessionId() {
 	data_t bytes[kTokenBytes];
 	session_id_rng->GenerateRandomData(bytes, kTokenBytes);
 	return HexEncode(bytes, kTokenBytes);
-}
-
-// Extract connection_id from a message if available
-static string ExtractConnectionId(QuackMessage &msg) {
-	switch (msg.Type()) {
-	case MessageType::PREPARE_REQUEST:
-		return msg.Cast<PrepareRequestMessage>().ConnectionId();
-	case MessageType::FETCH_REQUEST:
-		return msg.Cast<FetchRequestMessage>().ConnectionId();
-	case MessageType::APPEND_REQUEST:
-		return msg.Cast<AppendRequestMessage>().ConnectionId();
-	default:
-		return "";
-	}
-}
-
-static optional_idx ExtractClientQueryId(QuackMessage &msg) {
-	return msg.ClientQueryId();
 }
 
 static string ExtractQuery(QuackMessage &msg) {
@@ -179,8 +161,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	BinaryDeserializer deserializer(read_stream);
 
 	// first read the header
-	deserializer.Begin();
-	auto header = MessageHeader::Deserialize(deserializer);
+	auto header = QuackMessage::DeserializeHeader(deserializer);
 
 	// validate if the server can handle this type of message - the server cannot handle all message types
 	if (!ServerSupportsMessage(header.type)) {
@@ -198,9 +179,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	}
 
 	// now deserialize the actual message
-	auto received_message = QuackMessage::Deserialize(deserializer, header.type);
-	received_message->SetHeader(std::move(header));
-	deserializer.End();
+	auto received_message = QuackMessage::DeserializeMessage(deserializer, header);
 
 	// process the message
 	auto response = HandleMessageInternal(*received_message, connection);

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -43,17 +43,9 @@ bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUr
 		to_destroy = std::move(it->second);
 		servers.erase(it);
 	}
-	// Synchronously free the listening port so that clients racing a subsequent
-	// connect() after quack_stop observe a real refusal rather than a stale socket.
-	// Synchronously close the listening socket so the port is free immediately
-	// (callers racing a subsequent connect() see a real refusal, not a stale
-	// listener). The full teardown (joining listener thread + httplib worker
-	// pool) happens off-thread below — that join cannot run on the worker
-	// that's currently executing this very stop request, because the listener's
-	// exit path joins all workers and would deadlock.
+	// Synchronously free the listening port
 	to_destroy->StopAccepting();
-	// Full destruction (httplib worker-pool join) runs off-thread so that when
-	// quack_stop is invoked from inside one of the server's own worker threads
+	// Full destruction (httplib worker-pool join) runs off-thread
 	std::thread([srv = std::move(to_destroy)]() mutable { srv.reset(); }).detach();
 	return true;
 }

--- a/test/sql/self_stop.test
+++ b/test/sql/self_stop.test
@@ -1,6 +1,5 @@
 # name: test/sql/self_stop.test
-# description: A client may instruct a quack server to stop itself via
-#              `CALL quack_stop(...)` over RPC. Must not deadlock or crash.
+# description: A client may instruct a quack server to stop itself via `CALL quack_stop(...)` over RPC. Must not deadlock or crash.
 # group: [sql]
 
 require quack


### PR DESCRIPTION
Follow-up fixes from https://github.com/duckdb/duckdb-quack/pull/59

We should be serializing the header and message as separate objects. Also do some clean-up. 