### PR TITLE
Add `quack_server_list` and make `quack_stop` table-in-out

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -64,6 +64,15 @@ public:
 		return token;
 	}
 
+	const QuackUri &ListenUri() const {
+		return uri;
+	}
+
+	idx_t ActiveConnectionCount() {
+		std::lock_guard<std::mutex> lock(active_connections_mutex);
+		return active_connections.size();
+	}
+
 	virtual ~QuackServer();
 
 protected:

--- a/src/include/quack_startstop.hpp
+++ b/src/include/quack_startstop.hpp
@@ -14,4 +14,9 @@ public:
 	static TableFunction GetFunction();
 };
 
+class QuackServerListFunction {
+public:
+	static TableFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/src/include/quack_startstop.hpp
+++ b/src/include/quack_startstop.hpp
@@ -14,11 +14,6 @@ public:
 	static TableFunction GetFunction();
 };
 
-class QuackStopEachFunction {
-public:
-	static TableFunction GetFunction();
-};
-
 class QuackServerListFunction {
 public:
 	static TableFunction GetFunction();

--- a/src/include/quack_startstop.hpp
+++ b/src/include/quack_startstop.hpp
@@ -14,6 +14,11 @@ public:
 	static TableFunction GetFunction();
 };
 
+class QuackStopEachFunction {
+public:
+	static TableFunction GetFunction();
+};
+
 class QuackServerListFunction {
 public:
 	static TableFunction GetFunction();

--- a/src/include/quack_storage.hpp
+++ b/src/include/quack_storage.hpp
@@ -20,6 +20,16 @@ public:
 	QuackServer &CreateServer(ClientContext &context, const QuackUri &listen_uri, const string &token);
 	bool StopServer(ClientContext &context, const QuackUri &listen_uri);
 
+	struct ServerSnapshot {
+		string listen_uri;
+		string listen_url;
+		string host;
+		uint16_t port;
+		idx_t active_connections;
+		vector<std::pair<string, string>> info;
+	};
+	vector<ServerSnapshot> ListServers();
+
 	static constexpr const char *STORAGE_EXTENSION_KEY = "quack";
 
 private:

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -114,6 +114,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackScanByNameFunction::GetFunction());
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());
+	loader.RegisterFunction(QuackServerListFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
 
 	// the default authentication function

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -114,6 +114,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackScanByNameFunction::GetFunction());
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());
+	loader.RegisterFunction(QuackStopEachFunction::GetFunction());
 	loader.RegisterFunction(QuackServerListFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -114,7 +114,6 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackScanByNameFunction::GetFunction());
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());
-	loader.RegisterFunction(QuackStopEachFunction::GetFunction());
 	loader.RegisterFunction(QuackServerListFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
 

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -119,3 +119,57 @@ static void QuackStop(ClientContext &context, TableFunctionInput &data_p, DataCh
 TableFunction QuackStopFunction::GetFunction() {
 	return TableFunction("quack_stop", {LogicalType::VARCHAR}, QuackStop, QuackStopBind);
 }
+
+struct QuackServerListFunctionData : public TableFunctionData {
+	bool finished = false;
+};
+
+static unique_ptr<FunctionData> QuackServerListBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("listen_uri");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("listen_url");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("host");
+	return_types.emplace_back(LogicalType::USMALLINT);
+	names.emplace_back("port");
+	return_types.emplace_back(LogicalType::UBIGINT);
+	names.emplace_back("active_connections");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	names.emplace_back("info");
+	return make_uniq<QuackServerListFunctionData>();
+}
+
+static void QuackServerList(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->CastNoConst<QuackServerListFunctionData>();
+	if (bind_data.finished) {
+		return;
+	}
+	auto snapshots = QuackStorageExtensionInfo::GetState(*context.db).ListServers();
+	idx_t row = 0;
+	for (auto &s : snapshots) {
+		output.SetValue(0, row, Value(s.listen_uri));
+		output.SetValue(1, row, Value(s.listen_url));
+		output.SetValue(2, row, Value(s.host));
+		output.SetValue(3, row, Value::USMALLINT(s.port));
+		output.SetValue(4, row, Value::UBIGINT(s.active_connections));
+		vector<Value> keys;
+		vector<Value> values;
+		keys.reserve(s.info.size());
+		values.reserve(s.info.size());
+		for (auto &kv : s.info) {
+			keys.emplace_back(Value(kv.first));
+			values.emplace_back(Value(kv.second));
+		}
+		output.SetValue(5, row,
+		                Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(keys), std::move(values)));
+		row++;
+	}
+	output.SetCardinality(row);
+	bind_data.finished = true;
+}
+
+TableFunction QuackServerListFunction::GetFunction() {
+	return TableFunction("quack_server_list", {}, QuackServerList, QuackServerListBind);
+}

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -120,6 +120,60 @@ TableFunction QuackStopFunction::GetFunction() {
 	return TableFunction("quack_stop", {LogicalType::VARCHAR}, QuackStop, QuackStopBind);
 }
 
+struct QuackStopEachFunctionData : public TableFunctionData {
+	idx_t listen_uri_col = DConstants::INVALID_INDEX;
+};
+
+static unique_ptr<FunctionData> QuackStopEachBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	auto bind_data = make_uniq<QuackStopEachFunctionData>();
+	for (idx_t i = 0; i < input.input_table_names.size(); i++) {
+		if (StringUtil::Lower(input.input_table_names[i]) == "listen_uri") {
+			if (input.input_table_types[i].id() != LogicalTypeId::VARCHAR) {
+				throw BinderException("quack_stop_each: input column 'listen_uri' must be VARCHAR");
+			}
+			bind_data->listen_uri_col = i;
+			break;
+		}
+	}
+	if (bind_data->listen_uri_col == DConstants::INVALID_INDEX) {
+		throw BinderException("quack_stop_each: input table must contain a 'listen_uri' VARCHAR column");
+	}
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("listen_uri");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("status");
+	return std::move(bind_data);
+}
+
+static OperatorResultType QuackStopEach(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                       DataChunk &output) {
+	auto &bind_data = data_p.bind_data->CastNoConst<QuackStopEachFunctionData>();
+	auto &state = QuackStorageExtensionInfo::GetState(*context.client.db);
+
+	output.SetCardinality(input.size());
+	for (idx_t row = 0; row < input.size(); row++) {
+		auto uri_val = input.GetValue(bind_data.listen_uri_col, row);
+		if (uri_val.IsNull()) {
+			throw InvalidInputException("quack_stop_each: listen_uri must not be NULL");
+		}
+		auto uri_str = uri_val.GetValue<string>();
+		QuackUri listen_uri(uri_str, /* not really */ true);
+		string status = state.StopServer(context.client, listen_uri)
+		                    ? StringUtil::Format("Stopped listening on %s", listen_uri.Uri())
+		                    : StringUtil::Format("No server found listening on %s", listen_uri.Uri());
+		output.SetValue(0, row, Value(uri_str));
+		output.SetValue(1, row, Value(status));
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+TableFunction QuackStopEachFunction::GetFunction() {
+	TableFunction fun("quack_stop_each", {LogicalType::TABLE}, nullptr, QuackStopEachBind);
+	fun.in_out_function = QuackStopEach;
+	return fun;
+}
+
 struct QuackServerListFunctionData : public TableFunctionData {
 	bool finished = false;
 };

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -86,91 +86,65 @@ TableFunction QuackServeFunction::GetFunction() {
 	return fun;
 }
 
-static unique_ptr<FunctionData> QuackStopBind(ClientContext &context, TableFunctionBindInput &input,
-                                              vector<LogicalType> &return_types, vector<string> &names) {
-	auto bind_data = make_uniq<QuackStartStopFunctionData>();
-	auto &uri_value = input.inputs[0];
-	if (uri_value.IsNull() || uri_value.GetValue<string>().empty()) {
-		throw InvalidInputException("Invalid listen string specified");
-	}
-	bind_data->listen_uri =
-	    QuackUri(uri_value.GetValue<string>(), /* not really, but we don't want to ask the user again */ true);
-	return_types.emplace_back(LogicalType::VARCHAR);
-	names.emplace_back("status");
+struct QuackStopFunctionData : public TableFunctionData {};
 
-	return std::move(bind_data);
-}
-
-static void QuackStop(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &bind_data = data_p.bind_data->CastNoConst<QuackStartStopFunctionData>();
-	if (bind_data.finished) {
-		return;
-	}
-	auto &state = QuackStorageExtensionInfo::GetState(*context.db);
-	if (state.StopServer(context, bind_data.listen_uri)) {
-		output.data[0].SetValue(0, StringUtil::Format("Stopped listening on %s", bind_data.listen_uri.Uri()));
-	} else {
-		output.data[0].SetValue(0, StringUtil::Format("No server found listening on %s", bind_data.listen_uri.Uri()));
-	}
-	output.SetCardinality(1);
-	bind_data.finished = true;
-}
-
-TableFunction QuackStopFunction::GetFunction() {
-	return TableFunction("quack_stop", {LogicalType::VARCHAR}, QuackStop, QuackStopBind);
-}
-
-struct QuackStopEachFunctionData : public TableFunctionData {
-	idx_t listen_uri_col = DConstants::INVALID_INDEX;
+struct QuackStopLocalState : public LocalTableFunctionState {
+	bool consumed_current_chunk = false;
 };
 
-static unique_ptr<FunctionData> QuackStopEachBind(ClientContext &context, TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types, vector<string> &names) {
-	auto bind_data = make_uniq<QuackStopEachFunctionData>();
-	for (idx_t i = 0; i < input.input_table_names.size(); i++) {
-		if (StringUtil::Lower(input.input_table_names[i]) == "listen_uri") {
-			if (input.input_table_types[i].id() != LogicalTypeId::VARCHAR) {
-				throw BinderException("quack_stop_each: input column 'listen_uri' must be VARCHAR");
-			}
-			bind_data->listen_uri_col = i;
-			break;
-		}
-	}
-	if (bind_data->listen_uri_col == DConstants::INVALID_INDEX) {
-		throw BinderException("quack_stop_each: input table must contain a 'listen_uri' VARCHAR column");
-	}
+static unique_ptr<FunctionData> QuackStopBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("listen_uri");
 	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("status");
-	return std::move(bind_data);
+	return make_uniq<QuackStopFunctionData>();
 }
 
-static OperatorResultType QuackStopEach(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
-                                       DataChunk &output) {
-	auto &bind_data = data_p.bind_data->CastNoConst<QuackStopEachFunctionData>();
-	auto &state = QuackStorageExtensionInfo::GetState(*context.client.db);
+static unique_ptr<LocalTableFunctionState> QuackStopLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
+                                                              GlobalTableFunctionState *global_state) {
+	return make_uniq<QuackStopLocalState>();
+}
 
+// Implemented as an in_out_function (per-input-row) so the same function works both
+// as a literal call (`CALL quack_stop('quack:host')`) and as a lateral form driven by
+// any subquery — including `FROM quack_server_list() s, quack_stop(s.listen_uri)`.
+// Lateral binding of correlated columns is only allowed for in_out-style table funcs.
+//
+// PhysicalTableScan (the literal-call path) terminates only when the function returns
+// chunk.size() == 0; it currently ignores NEED_MORE_INPUT. So we track per-chunk
+// progress in local state and emit an empty chunk after the input has been consumed,
+// then reset on the next call so we keep processing chunks for the lateral path too.
+static OperatorResultType QuackStop(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                    DataChunk &output) {
+	auto &local = data_p.local_state->Cast<QuackStopLocalState>();
+	if (local.consumed_current_chunk) {
+		local.consumed_current_chunk = false;
+		output.SetCardinality(0);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	auto &state = QuackStorageExtensionInfo::GetState(*context.client.db);
 	output.SetCardinality(input.size());
 	for (idx_t row = 0; row < input.size(); row++) {
-		auto uri_val = input.GetValue(bind_data.listen_uri_col, row);
-		if (uri_val.IsNull()) {
-			throw InvalidInputException("quack_stop_each: listen_uri must not be NULL");
+		auto uri_val = input.GetValue(0, row);
+		if (uri_val.IsNull() || uri_val.GetValue<string>().empty()) {
+			throw InvalidInputException("Invalid listen string specified");
 		}
 		auto uri_str = uri_val.GetValue<string>();
-		QuackUri listen_uri(uri_str, /* not really */ true);
+		QuackUri listen_uri(uri_str, /* not really, but we don't want to ask the user again */ true);
 		string status = state.StopServer(context.client, listen_uri)
 		                    ? StringUtil::Format("Stopped listening on %s", listen_uri.Uri())
 		                    : StringUtil::Format("No server found listening on %s", listen_uri.Uri());
 		output.SetValue(0, row, Value(uri_str));
 		output.SetValue(1, row, Value(status));
 	}
-	return OperatorResultType::NEED_MORE_INPUT;
+	local.consumed_current_chunk = true;
+	return OperatorResultType::HAVE_MORE_OUTPUT;
 }
 
-TableFunction QuackStopEachFunction::GetFunction() {
-	TableFunction fun("quack_stop_each", {LogicalType::TABLE}, nullptr, QuackStopEachBind);
-	fun.in_out_function = QuackStopEach;
+TableFunction QuackStopFunction::GetFunction() {
+	TableFunction fun("quack_stop", {LogicalType::VARCHAR}, nullptr, QuackStopBind, nullptr, QuackStopLocalInit);
+	fun.in_out_function = QuackStop;
 	return fun;
 }
 

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -32,6 +32,24 @@ QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, con
 	return *servers[key];
 }
 
+vector<QuackStorageExtensionInfo::ServerSnapshot> QuackStorageExtensionInfo::ListServers() {
+	vector<ServerSnapshot> result;
+	std::lock_guard<std::mutex> lock(servers_mutex);
+	result.reserve(servers.size());
+	for (auto &kv : servers) {
+		auto &uri = kv.second->ListenUri();
+		ServerSnapshot snap;
+		snap.listen_uri = uri.Uri();
+		snap.listen_url = uri.Http();
+		snap.host = uri.Host();
+		snap.port = uri.Port();
+		snap.active_connections = kv.second->ActiveConnectionCount();
+		snap.info.emplace_back("ipv6", uri.IPv6() ? "true" : "false");
+		result.push_back(std::move(snap));
+	}
+	return result;
+}
+
 bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUri &listen_uri) {
 	unique_ptr<QuackServer> to_destroy;
 	{

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -1,0 +1,63 @@
+# name: test/sql/server_list.test
+# description: quack_server_list returns rows for active servers
+# group: [quack]
+
+require quack
+
+require httpfs
+
+# empty initially
+query I
+SELECT count(*) FROM quack_server_list();
+----
+0
+
+# one server
+statement ok
+FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+1
+
+query IIIII
+SELECT listen_uri, listen_url, host, port, active_connections FROM quack_server_list();
+----
+quack:127.0.0.1:9494	http://127.0.0.1:9494	127.0.0.1	9494	0
+
+# info map carries ipv6 flag
+query I
+SELECT info['ipv6'] FROM quack_server_list();
+----
+false
+
+# add a second server, verify count and ordering-agnostic content
+statement ok
+FROM quack_serve('quack:127.0.0.1:9495', token='abcd');
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+2
+
+query I
+SELECT count(*) FROM quack_server_list() WHERE listen_uri = 'quack:127.0.0.1:9494';
+----
+1
+
+query I
+SELECT count(*) FROM quack_server_list() WHERE listen_uri = 'quack:127.0.0.1:9495';
+----
+1
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:9494');
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:9495');
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+0

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -61,3 +61,32 @@ query I
 SELECT count(*) FROM quack_server_list();
 ----
 0
+
+# quack_stop_each: stop every running server via a table-input subquery
+statement ok
+FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
+
+statement ok
+FROM quack_serve('quack:127.0.0.1:9495', token='abcd');
+
+query I
+SELECT count(*) FROM quack_stop_each((FROM quack_server_list()));
+----
+2
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+0
+
+# quack_stop_each: idempotent on empty
+query I
+SELECT count(*) FROM quack_stop_each((FROM quack_server_list()));
+----
+0
+
+# quack_stop_each: input table without listen_uri fails at bind time
+statement error
+FROM quack_stop_each((SELECT 1 AS x));
+----
+input table must contain a 'listen_uri' VARCHAR column

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -62,7 +62,7 @@ SELECT count(*) FROM quack_server_list();
 ----
 0
 
-# quack_stop_each: stop every running server via a table-input subquery
+# quack_stop via implicit lateral on quack_server_list — stops every running server
 statement ok
 FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
 
@@ -70,7 +70,7 @@ statement ok
 FROM quack_serve('quack:127.0.0.1:9495', token='abcd');
 
 query I
-SELECT count(*) FROM quack_stop_each((FROM quack_server_list()));
+SELECT count(*) FROM quack_server_list() s, quack_stop(s.listen_uri) st;
 ----
 2
 
@@ -79,14 +79,8 @@ SELECT count(*) FROM quack_server_list();
 ----
 0
 
-# quack_stop_each: idempotent on empty
+# Idempotent on empty: empty outer ⇒ no quack_stop invocations ⇒ zero rows
 query I
-SELECT count(*) FROM quack_stop_each((FROM quack_server_list()));
+SELECT count(*) FROM quack_server_list() s, quack_stop(s.listen_uri) st;
 ----
 0
-
-# quack_stop_each: input table without listen_uri fails at bind time
-statement error
-FROM quack_stop_each((SELECT 1 AS x));
-----
-input table must contain a 'listen_uri' VARCHAR column


### PR DESCRIPTION
Combined:
```
FROM quack_server_list() s, quack_stop(s.listen_uri) v;
```
makes for stopping all current active servers.