### PR TITLE
authn & authz are evaluated on separate connections, so arguably GLOBAL

### DIFF
--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -144,9 +144,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
 	config.AddExtensionOption("quack_authentication_function", "Name of a callback function for authentication",
-	                          LogicalType::VARCHAR, Value("quack_check_token"));
+	                          LogicalType::VARCHAR, Value("quack_check_token"), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("quack_authorization_function", "Name of a callback function for authorization",
-	                          LogicalType::VARCHAR, Value("quack_nop_authorization"));
+	                          LogicalType::VARCHAR, Value("quack_nop_authorization"), nullptr, SetScope::GLOBAL);
 
 	config.AddExtensionOption("quack_fetch_batch_chunks", "Maximum number of DataChunks returned per FETCH response",
 	                          LogicalType::UBIGINT, Value::UBIGINT(12));

--- a/test/sql/authn_swap.test
+++ b/test/sql/authn_swap.test
@@ -1,0 +1,103 @@
+# name: test/sql/authn_swap.test
+# description: swap quack_authentication_function at runtime
+# group: [quack]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+CREATE MACRO authn_no(sid, auth_string, token)  AS false;
+
+statement ok con1
+CREATE MACRO authn_yes(sid, auth_string, token) AS true;
+
+query III con1
+CALL quack_serve('quack:localhost', token='asdf');
+----
+quack:localhost	http://localhost:9494	asdf
+
+sleep 100 millisecond
+
+# Phase 1: deny-all — both correct and wrong token rejected
+statement ok con1
+SET quack_authentication_function = 'authn_no';
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+Authentication failed
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+----
+Authentication failed
+
+# Phase 2: token check — correct token works, wrong token fails
+statement ok con1
+SET quack_authentication_function = 'quack_check_token';
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+42
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+----
+Authentication failed
+
+# Phase 3: allow-all — both correct and wrong token accepted
+statement ok con1
+SET quack_authentication_function = 'authn_yes';
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+42
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+----
+42
+
+# Phase 4: non-existent function — auth path fails closed for any token
+statement ok con1
+SET quack_authentication_function = 'authn_does_not_exist';
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+Authentication failed
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+----
+Authentication failed
+
+# Phase 5: RESET GLOBAL restores the default (quack_check_token).
+# Note: plain RESET (without GLOBAL) only clears the session view — the auth
+# callback runs on a fresh connection that would still read the stale GLOBAL
+# value. RESET GLOBAL is the correct incantation.
+statement ok con1
+RESET GLOBAL quack_authentication_function;
+
+query I con1
+SELECT current_setting('quack_authentication_function');
+----
+quack_check_token
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+42
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+----
+Authentication failed
+
+statement ok con1
+CALL quack_stop('quack:localhost');

--- a/test/sql/authn_swap.test
+++ b/test/sql/authn_swap.test
@@ -1,5 +1,5 @@
 # name: test/sql/authn_swap.test
-# description: swap quack_authentication_function at runtime
+# description: swap quack_authentication_function and quack_authorization_function at runtime
 # group: [quack]
 
 require quack
@@ -98,6 +98,101 @@ statement error con2
 FROM quack_query('quack:localhost', 'select 42', token='fdsa');
 ----
 Authentication failed
+
+# Phase 6: non-trivial authn — accept iff the client-supplied token equals
+# 'duck', ignoring sid and the server-configured token.
+# Macro arg order: (sid, client_token, server_token) — arg[1] is the value the
+# client passed as token=..., arg[2] is the server-configured token.
+statement ok con1
+CREATE MACRO authn_duck(sid, client_token, server_token) AS client_token = 'duck';
+
+statement ok con1
+SET quack_authentication_function = 'authn_duck';
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='duck');
+----
+42
+
+# the server-configured token ('asdf') is no longer special — only 'duck' passes
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+Authentication failed
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='quack');
+----
+Authentication failed
+
+statement ok con1
+RESET GLOBAL quack_authentication_function;
+
+####################
+# quack_authorization_function — authn stays at default (quack_check_token)
+####################
+
+statement ok con1
+CREATE MACRO authz_no(sid, query)  AS false;
+
+statement ok con1
+CREATE MACRO authz_yes(sid, query) AS true;
+
+# Phase A: deny-all — even an authenticated request is rejected
+statement ok con1
+SET quack_authorization_function = 'authz_no';
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+Authorization failed
+
+# Phase B: allow-all (default-equivalent)
+statement ok con1
+SET quack_authorization_function = 'quack_nop_authorization';
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+42
+
+# Phase C: explicit authz_yes
+statement ok con1
+SET quack_authorization_function = 'authz_yes';
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+42
+
+# Authn still gates: wrong token fails before authz runs
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+----
+Authentication failed
+
+# Phase D: non-existent function — authz path fails closed
+statement ok con1
+SET quack_authorization_function = 'authz_does_not_exist';
+
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+Authorization failed
+
+# Phase E: RESET GLOBAL restores the default (quack_nop_authorization)
+statement ok con1
+RESET GLOBAL quack_authorization_function;
+
+query I con1
+SELECT current_setting('quack_authorization_function');
+----
+quack_nop_authorization
+
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token='asdf');
+----
+42
 
 statement ok con1
 CALL quack_stop('quack:localhost');


### PR DESCRIPTION
Also adding a test that might serve as documentation on how to set authn custom functionality via SQL.

@guillesd, would you mind taking a look?