### PR TITLE
More catalog fixes & implement views

### DIFF
--- a/src/include/storage/quack_catalog_set.hpp
+++ b/src/include/storage/quack_catalog_set.hpp
@@ -28,7 +28,7 @@ public:
 	optional_ptr<CatalogEntry> GetEntry(const string &entry_name);
 	void DropEntry(const string &entry_name);
 	vector<reference<CatalogEntry>> GetAllCatalogEntries();
-	optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry);
+	optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry, OnCreateConflict on_conflict);
 
 protected:
 	QuackCatalog &catalog;

--- a/src/include/storage/quack_schema.hpp
+++ b/src/include/storage/quack_schema.hpp
@@ -27,6 +27,7 @@ public:
 
 class QuackSchemaCatalogEntry : public SchemaCatalogEntry {
 public:
+	QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p);
 	QuackSchemaCatalogEntry(ClientContext &context, Catalog &catalog_p, CreateSchemaInfo &info_p,
 	                        const QuackLoadCatalogData &load_data);
 	~QuackSchemaCatalogEntry() override;

--- a/src/include/storage/quack_view.hpp
+++ b/src/include/storage/quack_view.hpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/quack_view.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+
+namespace duckdb {
+class QuackCatalog;
+class QuackSchemaCatalogEntry;
+
+class QuackViewCatalogEntry : public ViewCatalogEntry {
+public:
+	QuackViewCatalogEntry(Catalog &catalog_p, SchemaCatalogEntry &schema_p, CreateViewInfo &info_p);
+
+	//! Generate SQL for querying a view from quack
+	//! This SQL will always be "FROM {catalog}.query('FROM {view_name}');"
+	//! Ensuring the view is executed remotely
+	static string CreateViewSQL(const string &catalog_name, const string &schema_name, const string &view_name);
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(
   quack_schema.cpp
   quack_transaction.cpp
   quack_transaction.cpp
-  quack_transaction_manager.cpp)
+  quack_transaction_manager.cpp
+  quack_view.cpp)
 set(EXTENSION_SOURCES
     ${EXTENSION_SOURCES} $<TARGET_OBJECTS:quack_storage>
     PARENT_SCOPE)

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -99,15 +99,12 @@ const string &QuackCatalog::GetConnectionId() {
 }
 
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
-	throw InternalException("FIXME: create schema");
-	// auto create_schema_info = info.Copy();
-	// // TODO this does not make too much sense?
-	// create_schema_info->catalog = "memory";
-	//
-	// auto create_request = make_uniq<PrepareRequestMessage>(GetConnectionId(), create_schema_info->ToString());
-	// auto create_respose = GetRawClient().Request<PrepareResponseMessage>(std::move(create_request));
-	// return make_uniq_base<CatalogEntry, QuackSchemaCatalogEntry>(*this,
-	// create_schema_info->Cast<CreateSchemaInfo>()); return nullptr;
+	auto &quack_transaction = QuackTransaction::Get(transaction);
+	// create schema remotely
+	quack_transaction.Query(info.ToString());
+	// register schema locally
+	auto schema_entry = make_uniq<QuackSchemaCatalogEntry>(*this, info);
+	return schemas->CreateEntry(std::move(schema_entry), info.on_conflict);
 }
 
 void QuackCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {

--- a/src/storage/quack_catalog_set.cpp
+++ b/src/storage/quack_catalog_set.cpp
@@ -35,11 +35,16 @@ void QuackCatalogSet::DropEntry(const string &entry_name) {
 	entries.erase(entry_name);
 }
 
-optional_ptr<CatalogEntry> QuackCatalogSet::CreateEntry(unique_ptr<CatalogEntry> entry) {
+optional_ptr<CatalogEntry> QuackCatalogSet::CreateEntry(unique_ptr<CatalogEntry> entry, OnCreateConflict on_conflict) {
 	lock_guard<mutex> l(entry_lock);
 	auto &entry_name = entry->name;
-	auto inserted_entry = entries.insert(make_pair(entry_name, std::move(entry)));
-	return inserted_entry.first->second.get();
+	if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		entries[entry_name] = std::move(entry);
+		return entries[entry_name].get();
+	} else {
+		auto inserted_entry = entries.insert(make_pair(entry_name, std::move(entry)));
+		return inserted_entry.first->second.get();
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -44,7 +44,6 @@ unique_ptr<GlobalSinkState> QuackInsert::GetGlobalSinkState(ClientContext &conte
 	auto &quack_catalog = quack_schema.catalog.Cast<QuackCatalog>();
 
 	auto entry = quack_schema.CreateTable(CatalogTransaction(quack_catalog, context), *info);
-	;
 	return make_uniq<QuackInsertGlobalState>(entry->Cast<QuackTableCatalogEntry>());
 }
 

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -18,7 +18,7 @@ QuackSchemaSet::QuackSchemaSet(ClientContext &context, QuackCatalog &catalog, co
 		info.schema = row.GetValue(1).GetValue<string>();
 		// TODO this will fail if there are two schemas with the same name in different catalogs :/
 		auto schema = make_uniq<QuackSchemaCatalogEntry>(context, catalog, info, load_data);
-		CreateEntry(std::move(schema));
+		CreateEntry(std::move(schema), OnCreateConflict::REPLACE_ON_CONFLICT);
 	}
 }
 
@@ -80,7 +80,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransacti
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	quack_transaction.Query(create_table_info->ToString());
 	auto quack_entry = make_uniq<QuackTableCatalogEntry>(catalog, *this, create_table_info->Cast<CreateTableInfo>());
-	return tables->CreateEntry(std::move(quack_entry));
+	return tables->CreateEntry(std::move(quack_entry), info.Base().on_conflict);
 }
 
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -3,10 +3,11 @@
 #include "storage/quack_table.hpp"
 #include "quack_client.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/catalog/catalog_entry/table_macro_catalog_entry.hpp"
 #include "storage/quack_transaction.hpp"
+#include "storage/quack_view.hpp"
 
 namespace duckdb {
 
@@ -52,6 +53,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::LookupEntry(CatalogTransacti
 	case CatalogType::TABLE_FUNCTION_ENTRY:
 		return TryLoadBuiltInFunction(entry_name);
 	case CatalogType::TABLE_ENTRY:
+	case CatalogType::VIEW_ENTRY:
 		return tables->GetEntry(lookup_info.GetEntryName());
 	default:
 		return nullptr;
@@ -88,7 +90,20 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransacti
 }
 
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
-	throw NotImplementedException("CreateView not implemented yet");
+	auto create_view_info = info.Copy();
+	create_view_info->catalog = GetInfo()->catalog;
+	create_view_info->schema = GetInfo()->schema;
+
+	// create the view verbatim in the serer
+	auto &quack_transaction = QuackTransaction::Get(transaction);
+	quack_transaction.Query(create_view_info->ToString());
+
+	// locally, override the query with a remote procedure call to ensure the view is evaluated remotely
+	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName(), name, info.view_name);
+	info.query = CreateViewInfo::ParseSelect(info.sql);
+
+	auto quack_entry = make_uniq<QuackViewCatalogEntry>(catalog, *this, info);
+	return tables->CreateEntry(std::move(quack_entry), info.on_conflict);
 }
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateSequence(CatalogTransaction transaction,
                                                                    CreateSequenceInfo &info) {
@@ -118,9 +133,10 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateType(CatalogTransactio
 void QuackSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) {
 	auto drop_info = info_p.Copy();
 	drop_info->catalog = GetInfo()->catalog;
-	drop_info->schema = GetInfo()->schema;
+	drop_info->schema = name;
 	switch (drop_info->type) {
 	case CatalogType::TABLE_ENTRY:
+	case CatalogType::VIEW_ENTRY:
 		break;
 	default:
 		throw NotImplementedException("Drop not supported yet for this entry");

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -31,6 +31,10 @@ ORDER BY ALL
 	)";
 }
 
+QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p)
+    : SchemaCatalogEntry(catalog_p, info_p) {
+}
+
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(ClientContext &context, Catalog &catalog_p, CreateSchemaInfo &info_p,
                                                  const QuackLoadCatalogData &load_data)
     : SchemaCatalogEntry(catalog_p, info_p) {

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
+#include "storage/quack_view.hpp"
 
 namespace duckdb {
 
@@ -29,23 +31,43 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			continue;
 		}
 		// parse the SQL to get the table definition
-		auto sql = row.GetValue(1).GetValue<string>();
-		auto info = ParseCreateTable(sql);
-		if (info->type != CatalogType::TABLE_ENTRY) {
-			throw InternalException("Expected a CREATE TABLE");
+		auto type = row.GetValue(2).GetValue<string>();
+		unique_ptr<CatalogEntry> entry;
+		if (type == "table") {
+			auto sql = row.GetValue(1).GetValue<string>();
+			auto info = ParseCreateTable(sql);
+			if (info->type != CatalogType::TABLE_ENTRY) {
+				throw InternalException("Expected a CREATE TABLE");
+			}
+			// bind to resolve the types
+			auto binder = Binder::CreateBinder(context);
+			auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
+			auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());
+			entry = std::move(table);
+		} else {
+			auto view_name = row.GetValue(1).GetValue<string>();
+			// bind a remote procedure call to the view on the server side
+			// we don't actually care what the view contains server-side, we just treat it like an opaque object we can
+			// query
+			CreateViewInfo info(schema, view_name);
+			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName(), schema.name, view_name);
+			info.query = CreateViewInfo::ParseSelect(info.sql);
+
+			// bind to resolve the types
+			auto view = make_uniq<QuackViewCatalogEntry>(catalog, parent, info);
+			entry = std::move(view);
 		}
-		// bind to resolve the types
-		auto binder = Binder::CreateBinder(context);
-		auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
-		auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());
-		CreateEntry(std::move(table), OnCreateConflict::REPLACE_ON_CONFLICT);
+		CreateEntry(std::move(entry), OnCreateConflict::REPLACE_ON_CONFLICT);
 	}
 }
 
 string QuackTableSet::GetLoadQuery() {
 	return R"(
-SELECT schema_name, sql
+SELECT schema_name, sql, 'table'
 FROM duckdb_tables()
+UNION ALL
+SELECT schema_name, view_name, 'view'
+FROM duckdb_views()
 	)";
 }
 

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -38,7 +38,7 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 		auto binder = Binder::CreateBinder(context);
 		auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
 		auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());
-		CreateEntry(std::move(table));
+		CreateEntry(std::move(table), OnCreateConflict::REPLACE_ON_CONFLICT);
 	}
 }
 

--- a/src/storage/quack_view.cpp
+++ b/src/storage/quack_view.cpp
@@ -1,0 +1,17 @@
+#include "storage/quack_view.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+QuackViewCatalogEntry::QuackViewCatalogEntry(Catalog &catalog_p, SchemaCatalogEntry &schema_p, CreateViewInfo &info_p)
+    : ViewCatalogEntry(catalog_p, schema_p, info_p) {
+}
+
+string QuackViewCatalogEntry::CreateViewSQL(const string &catalog_name, const string &schema_name,
+                                            const string &view_name) {
+	//! This SQL will always be "FROM quack_query({catalog}, 'FROM {view_name}');"
+	auto remote_sql = StringUtil::Format("FROM %s.%s", SQLIdentifier(schema_name), SQLIdentifier(view_name));
+	return StringUtil::Format("FROM quack_query_by_name(%s, %s)", SQLString(catalog_name), SQLString(remote_sql));
+}
+
+} // namespace duckdb

--- a/test/sql/attach_views.test
+++ b/test/sql/attach_views.test
@@ -1,0 +1,51 @@
+# name: test/sql/attach_views.test
+# description: test attaching views
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok
+create schema moo;
+
+statement ok
+create view fuu as select 42 i, 'hello world' j
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+query II con2
+from quack_query({server}, 'select * from fuu', token='asdf')
+----
+42	hello world
+
+statement ok con2
+attach {server} as rpc (token 'asdf')
+
+query II
+from rpc.fuu;
+----
+42	hello world
+
+statement ok con2
+create view rpc.fuu2 as select [1, 2, 3] l
+
+query I
+from rpc.fuu2
+----
+[1, 2, 3]
+
+statement ok
+DROP VIEW rpc.fuu;
+
+statement error
+FROM rpc.fuu
+----
+does not exist
+
+endloop


### PR DESCRIPTION
* Correctly handle `CREATE OR REPLACE`
* Implement `CREATE SCHEMA`
* Add support for views

Views are always executed server-side, effectively locally we create a view that looks like this:

```sql
FROM quack_query_by_name('{catalog}', 'FROM {view}');
```

We never bind or evaluate the SQL client-side.