### PR TITLE
Pushdown fixes and QuackClient lifetime issue

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -12,11 +12,11 @@ namespace duckdb {
 
 class QuackClient {
 public:
-	explicit QuackClient(ClientContext &context_p, const QuackUri &uri_p) : context(context_p), uri(uri_p) {};
+	explicit QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_p), uri(uri_p) {};
 
 	template <class TARGET>
-	unique_ptr<TARGET> Request(unique_ptr<QuackMessage> request_message) {
-		auto response_message = RequestInternal(std::move(request_message)).release();
+	unique_ptr<TARGET> Request(optional_ptr<ClientContext> context, unique_ptr<QuackMessage> request_message) {
+		auto response_message = RequestInternal(context, std::move(request_message));
 		if (response_message->Type() != TARGET::TYPE) {
 			if (response_message->Type() == MessageType::ERROR_RESPONSE) {
 				throw IOException("Expected %s message, got error message instead: %s",
@@ -26,9 +26,10 @@ public:
 			throw IOException("Expected %s message, got %s instead", MessageTypeToString(TARGET::TYPE),
 			                  MessageTypeToString(response_message->Type()));
 		}
-		return unique_ptr<TARGET>(reinterpret_cast<TARGET *>(response_message));
+		return unique_ptr_cast<QuackMessage, TARGET>(std::move(response_message));
 	}
 
+	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
 	virtual ~QuackClient() {};
@@ -36,20 +37,22 @@ public:
 protected:
 	mutex request_mutex;
 	MemoryStream read_stream, write_stream;
-	ClientContext &context;
+	DatabaseInstance &db;
 	QuackUri uri;
 
 private:
-	virtual unique_ptr<QuackMessage> RequestInternal(unique_ptr<QuackMessage> request_message) = 0;
+	virtual unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
+	                                                 unique_ptr<QuackMessage> request_message) = 0;
 };
 
 class HttpsQuackClient : public QuackClient {
 public:
-	HttpsQuackClient(ClientContext &context, const QuackUri &uri_p);
+	HttpsQuackClient(DatabaseInstance &db, const QuackUri &uri_p);
 	~HttpsQuackClient() override;
 
 private:
-	unique_ptr<QuackMessage> RequestInternal(unique_ptr<QuackMessage> request_message) override;
+	unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
+	                                         unique_ptr<QuackMessage> request_message) override;
 
 private:
 	unique_ptr<HTTPParams> http_params;

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -52,7 +52,7 @@ public:
 	bool InMemory() override;
 	string GetDBPath() override;
 
-	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(const string &query);
+	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(const string &query, optional_ptr<ClientContext> context);
 	const QuackUri &GetServerUri();
 	const string &GetConnectionId();
 
@@ -61,7 +61,7 @@ public:
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 
-	QuackLoadCatalogData LoadCatalog();
+	QuackLoadCatalogData LoadCatalog(ClientContext &context);
 
 private:
 	QuackUri server_uri;

--- a/src/include/storage/quack_table.hpp
+++ b/src/include/storage/quack_table.hpp
@@ -18,6 +18,7 @@ class QuackSchemaCatalogEntry;
 class QuackTableSet : public QuackCatalogSet {
 public:
 	QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &parent, const QuackLoadCatalogData &load_data);
+	explicit QuackTableSet(QuackSchemaCatalogEntry &parent);
 
 	static string GetLoadQuery();
 

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -14,22 +14,25 @@ string GetUriPart(T ele) {
 	return string(ele.first, ele.afterLast - ele.first);
 }
 
-HttpsQuackClient::HttpsQuackClient(ClientContext &context, const QuackUri &uri_p) : QuackClient(context, uri_p) {};
+HttpsQuackClient::HttpsQuackClient(DatabaseInstance &db, const QuackUri &uri_p) : QuackClient(db, uri_p) {};
 
 HttpsQuackClient::~HttpsQuackClient() {
 }
 
-unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(unique_ptr<QuackMessage> request_message) {
+unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientContext> context,
+                                                           unique_ptr<QuackMessage> request_message) {
 	D_ASSERT(request_message);
 
 	lock_guard<mutex> guard(request_mutex);
 
-	auto &db = *context.db;
-
 	auto &http_util = HTTPUtil::Get(db);
 	auto request_url = uri.Http() + "/quack";
 	if (!http_params) {
-		http_params = http_util.InitializeParameters(context, request_url);
+		if (context) {
+			http_params = http_util.InitializeParameters(*context, request_url);
+		} else {
+			http_params = http_util.InitializeParameters(db, request_url);
+		}
 	}
 
 	HTTPHeaders headers;
@@ -88,9 +91,8 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(unique_ptr<QuackMessa
 		// Guard against reading the active query during transaction start itself
 		// (e.g. BEGIN TRANSACTION via QuackCatalog::ExecuteCommand), where the
 		// transaction isn't yet installed on the TransactionContext.
-
-		if (context.transaction.HasActiveTransaction()) {
-			auto raw_query_id = context.transaction.GetActiveQuery();
+		if (context && context->transaction.HasActiveTransaction()) {
+			auto raw_query_id = context->transaction.GetActiveQuery();
 			if (raw_query_id != DConstants::INVALID_INDEX) {
 				client_query_id = raw_query_id;
 				request_message->SetClientQueryId(client_query_id);
@@ -98,7 +100,7 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(unique_ptr<QuackMessa
 		}
 
 		// Log RPC message
-		auto &logger = Logger::Get(context);
+		auto &logger = context ? Logger::Get(*context) : Logger::Get(db);
 		if (logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
 			string error;
 			if (response_message->Type() == MessageType::ERROR_RESPONSE) {
@@ -114,12 +116,15 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(unique_ptr<QuackMessa
 	return response_message;
 }
 
-unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const QuackUri &uri) {
-	auto &db = *context.db;
+unique_ptr<QuackClient> QuackClient::GetClient(DatabaseInstance &db, const QuackUri &uri) {
 	ExtensionHelper::AutoLoadExtension(db, "httpfs");
 	if (!db.ExtensionIsLoaded("httpfs")) {
 		throw MissingExtensionException("The rpc extension requires the httpfs extension to be loaded!");
 	}
 
-	return make_uniq<HttpsQuackClient>(context, uri);
+	return make_uniq<HttpsQuackClient>(db, uri);
+}
+
+unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const QuackUri &uri) {
+	return GetClient(*context.db, uri);
 }

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -54,9 +54,9 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 	// from scan thread clients can deadlock waiting for threads held by the
 	// catalog clients that are in turn waiting for the scan to complete.
 	server->new_task_queue = [] {
-		return new duckdb_httplib::ThreadPool(128);
+		return new duckdb_httplib::ThreadPool(4);
 	};
-	server->set_keep_alive_max_count(128);
+	server->set_keep_alive_max_count(4);
 	server->set_keep_alive_timeout(10);
 	server->set_tcp_nodelay(true);
 

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -58,11 +58,11 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	}
 
 	auto connection_request_response =
-	    initial_client->Request<ConnectionResponseMessage>(make_uniq<ConnectionRequestMessage>(token));
+	    initial_client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
 	bind_data->connection_id = connection_request_response->ConnectionId();
 
 	auto bind_response = initial_client->Request<PrepareResponseMessage>(
-	    make_uniq<PrepareRequestMessage>(bind_data->connection_id, query));
+	    context, make_uniq<PrepareRequestMessage>(bind_data->connection_id, query));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -110,7 +110,7 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 	bind_data->connection_id = catalog.GetConnectionId();
 
 	auto bind_response = catalog.GetRawClient().Request<PrepareResponseMessage>(
-	    make_uniq<PrepareRequestMessage>(bind_data->connection_id, query));
+	    context, make_uniq<PrepareRequestMessage>(bind_data->connection_id, query));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -182,36 +182,6 @@ private:
 	mutex lock;
 	vector<ChunkResult> results;
 };
-
-static bool CanPushdownFilter(const TableFilter &filter) {
-	switch (filter.filter_type) {
-	case TableFilterType::CONSTANT_COMPARISON:
-	case TableFilterType::IS_NULL:
-	case TableFilterType::IS_NOT_NULL:
-	case TableFilterType::IN_FILTER:
-		return true;
-	case TableFilterType::CONJUNCTION_AND: {
-		auto &conjunction = filter.Cast<ConjunctionAndFilter>();
-		for (auto &child : conjunction.child_filters) {
-			if (!CanPushdownFilter(*child)) {
-				return false;
-			}
-		}
-		return true;
-	}
-	case TableFilterType::CONJUNCTION_OR: {
-		auto &conjunction = filter.Cast<ConjunctionOrFilter>();
-		for (auto &child : conjunction.child_filters) {
-			if (!CanPushdownFilter(*child)) {
-				return false;
-			}
-		}
-		return true;
-	}
-	default:
-		return false;
-	}
-}
 
 static string BuildPushdownQuery(const QuackScanBindData &bind_data, const TableFunctionInitInput &input) {
 	string query;
@@ -295,8 +265,8 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
 		auto client = QuackClient::GetClient(context, bind_data.server_uri);
-		auto response_message =
-		    client->Request<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(bind_data.connection_id, query));
+		auto response_message = client->Request<PrepareResponseMessage>(
+		    context, make_uniq<PrepareRequestMessage>(bind_data.connection_id, query));
 		needs_more_fetch = response_message->NeedsMoreFetch();
 		// fetch the result
 		for (auto &chunk_ref : response_message->MutableResults()) {
@@ -368,7 +338,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		// if that did not work, we request more results
 		if (local_state.results.empty() && global_state.needs_more_fetch) {
 			auto fetch_response = local_state.client->Request<FetchResponseMessage>(
-			    make_uniq<FetchRequestMessage>(bind_data.connection_id));
+			    context, make_uniq<FetchRequestMessage>(bind_data.connection_id));
 
 			if (fetch_response->MutableResults().empty()) {
 				// server is done, we are done

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -225,12 +225,19 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 				query += ", ";
 			}
 			if (col_id.IsVirtualColumn()) {
-				query += "NULL";
+				auto virtual_column = col_id.GetPrimaryIndex();
+				if (virtual_column == COLUMN_IDENTIFIER_EMPTY) {
+					query += "NULL::BIGINT";
+				} else if (virtual_column == COLUMN_IDENTIFIER_ROW_ID) {
+					query += "rowid::BIGINT";
+				} else {
+					throw InternalException("Unsupported virtual column index");
+				}
 			} else {
 				query += "#" + to_string(col_id.GetPrimaryIndex() + 1);
 			}
 		}
-		query = "SELECT " + query;
+		query = "SELECT " + query + " ";
 	}
 	// 	vector<string> selected_columns;
 	// 	if (!input.projection_ids.empty()) {

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -226,10 +226,8 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 			}
 			if (col_id.IsVirtualColumn()) {
 				auto virtual_column = col_id.GetPrimaryIndex();
-				if (virtual_column == COLUMN_IDENTIFIER_EMPTY) {
+				if (virtual_column == COLUMN_IDENTIFIER_EMPTY || virtual_column == COLUMN_IDENTIFIER_ROW_ID) {
 					query += "NULL::BIGINT";
-				} else if (virtual_column == COLUMN_IDENTIFIER_ROW_ID) {
-					query += "rowid::BIGINT";
 				} else {
 					throw InternalException("Unsupported virtual column index");
 				}

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -37,18 +37,19 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p,
 		    "Could not find token for ATTACH 'quack:...' - Please create a secret first or pass directly");
 	}
 
-	auto connection_response = client->Request<ConnectionResponseMessage>(make_uniq<ConnectionRequestMessage>(token));
+	auto connection_response =
+	    client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
 	connection_id = connection_response->ConnectionId();
 
 	// load the entire catalog up-front
-	auto load_info = LoadCatalog();
+	auto load_info = LoadCatalog(context);
 	schemas = make_uniq<QuackSchemaSet>(context, *this, load_info);
 }
 
-QuackLoadCatalogData QuackCatalog::LoadCatalog() {
+QuackLoadCatalogData QuackCatalog::LoadCatalog(ClientContext &context) {
 	QuackLoadCatalogData result;
-	result.schemas = ExecuteCommandInternal(QuackSchemaSet::GetLoadQuery());
-	result.tables = ExecuteCommandInternal(QuackTableSet::GetLoadQuery());
+	result.schemas = ExecuteCommandInternal(QuackSchemaSet::GetLoadQuery(), context);
+	result.tables = ExecuteCommandInternal(QuackTableSet::GetLoadQuery(), context);
 	return result;
 }
 
@@ -79,10 +80,12 @@ const QuackUri &QuackCatalog::GetServerUri() {
 	return server_uri;
 }
 
-unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(const string &query) {
+unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(const string &query,
+                                                                      optional_ptr<ClientContext> context) {
 	// FIXME this will break with many results!
 	auto chunk_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
-	auto response = client->Request<PrepareResponseMessage>(make_uniq<PrepareRequestMessage>(connection_id, query));
+	auto response =
+	    client->Request<PrepareResponseMessage>(context, make_uniq<PrepareRequestMessage>(connection_id, query));
 	chunk_collection->Initialize(response->Types());
 	for (auto &chunk : response->MutableResults()) {
 		chunk_collection->Append(chunk->Chunk());

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -60,7 +60,7 @@ SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	auto chunk_wrapper = make_uniq<DataChunkWrapper>(*append_chunk);
 	auto append_message = make_uniq<AppendRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name, tbl.name,
 	                                                      std::move(chunk_wrapper));
-	quack_catalog.GetRawClient().Request<AppendResponseMessage>(std::move(append_message));
+	quack_catalog.GetRawClient().Request<AppendResponseMessage>(context.client, std::move(append_message));
 	global_state.insert_count += chunk.size();
 	return SinkResultType::NEED_MORE_INPUT;
 }

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -34,6 +34,7 @@ ORDER BY ALL
 
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p)
     : SchemaCatalogEntry(catalog_p, info_p) {
+	tables = make_uniq<QuackTableSet>(*this);
 }
 
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(ClientContext &context, Catalog &catalog_p, CreateSchemaInfo &info_p,

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -61,6 +61,10 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 	}
 }
 
+QuackTableSet::QuackTableSet(QuackSchemaCatalogEntry &parent)
+    : QuackCatalogSet(parent.ParentCatalog().Cast<QuackCatalog>()), schema(parent) {
+}
+
 string QuackTableSet::GetLoadQuery() {
 	return R"(
 SELECT schema_name, sql, 'table'

--- a/src/storage/quack_transaction.cpp
+++ b/src/storage/quack_transaction.cpp
@@ -52,7 +52,8 @@ QuackTransaction &QuackTransaction::Get(CatalogTransaction transaction) {
 
 unique_ptr<ColumnDataCollection> QuackTransaction::Query(const string &query) {
 	ForceStart();
-	return quack_catalog.ExecuteCommandInternal(query);
+	auto context_ref = context.lock();
+	return quack_catalog.ExecuteCommandInternal(query, context_ref.get());
 }
 
 } // namespace duckdb


### PR DESCRIPTION
* Several minor pushdown fixes (just always push `NULL` for virtual columns for now, fix spacing)
* Allocate empty table set for newly created schema
* Do not hold onto `ClientContext &` in the `QuackClient`. This lives in the attached database and there is no guarantee the client that attached the database outlives the attached database itself. Instead hold a reference to the `DatabaseInstance` and optionally pass in the client context to `Request`.