### PR TITLE
auth_token is always emitted on server, independently of authn setting

### DIFF
--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -10,7 +10,6 @@ struct QuackStartStopFunctionData : public TableFunctionData {
 	}
 
 	bool finished = false;
-	bool auth_is_default = false;
 	QuackUri listen_uri;
 	string token;
 };
@@ -36,25 +35,22 @@ static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunc
 
 	return_types.emplace_back(LogicalType::VARCHAR);
 	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::VARCHAR);
 	names.emplace_back("listen_uri");
 	names.emplace_back("listen_url");
+	names.emplace_back("auth_token");
 
-	auto &config = DBConfig::GetConfig(context);
-	Value default_auth_val;
-	auto lookup_result_token = config.TryGetCurrentSetting("quack_authentication_function", default_auth_val);
-	bind_data->auth_is_default =
-	    lookup_result_token && !default_auth_val.IsNull() && default_auth_val.GetValue<string>() == "quack_check_token";
-
-	if (bind_data->auth_is_default) {
-		if (input.named_parameters.find("token") != input.named_parameters.end()) {
-			bind_data->token = input.named_parameters["token"].GetValue<string>();
-		} else {
-			bind_data->token = QuackServer::GenerateRandomToken(*context.db);
-		}
-		QuackServer::ValidateToken(bind_data->token);
-		return_types.emplace_back(LogicalType::VARCHAR);
-		names.emplace_back("auth_token");
+	// Every server has a token: either user-supplied or auto-generated. The
+	// authn callback (default token-check or a user-defined function) decides
+	// what to do with it; the server itself doesn't care which path is in use.
+	if (input.named_parameters.find("token") != input.named_parameters.end()) {
+		bind_data->token = input.named_parameters["token"].GetValue<string>();
+	} else {
+		bind_data->token = QuackServer::GenerateRandomToken(*context.db);
 	}
+	// Validate at bind-time: a length error here fails before the listener
+	// thread is spawned, instead of leaving a half-built server behind.
+	QuackServer::ValidateToken(bind_data->token);
 
 	return std::move(bind_data);
 }
@@ -69,9 +65,7 @@ static void QuackServe(ClientContext &context, TableFunctionInput &data_p, DataC
 	    QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
 	output.SetValue(0, 0, bind_data.listen_uri.Uri());
 	output.SetValue(1, 0, bind_data.listen_uri.Http());
-	if (bind_data.auth_is_default) {
-		output.SetValue(2, 0, bind_data.token);
-	}
+	output.SetValue(2, 0, bind_data.token);
 
 	output.SetCardinality(1);
 	bind_data.finished = true;

--- a/test/sql/authn_swap.test
+++ b/test/sql/authn_swap.test
@@ -196,3 +196,67 @@ FROM quack_query('quack:localhost', 'select 42', token='asdf');
 
 statement ok con1
 CALL quack_stop('quack:localhost');
+
+####################
+# Combined: custom authn + custom authz, server starts with a long token.
+# Regression: previously the token= parameter was silently dropped when
+# quack_authentication_function != quack_check_token, then the empty token
+# tripped ValidateToken with "must be at least 4 characters."
+####################
+
+statement ok con1
+CREATE MACRO check_token(sid, auth_string, token) AS auth_string = token;
+
+statement ok con1
+CREATE MACRO read_only(sid, query) AS regexp_matches(upper(ltrim(query)), '^(SELECT|PRAGMA|CALL|EXPLAIN|DESCRIBE|SHOW)\b');
+
+statement ok con1
+SET GLOBAL quack_authentication_function = 'check_token';
+
+statement ok con1
+SET GLOBAL quack_authorization_function = 'read_only';
+
+query III con1
+CALL quack_serve('quack:localhost', token => 'analytics-team-token');
+----
+quack:localhost	http://localhost:9494	analytics-team-token
+
+sleep 100 millisecond
+
+# Authn happy path with the configured token
+query I con2
+FROM quack_query('quack:localhost', 'select 42', token => 'analytics-team-token');
+----
+42
+
+# Authn rejects wrong token
+statement error con2
+FROM quack_query('quack:localhost', 'select 42', token => 'wrong-token');
+----
+Authentication failed
+
+# Authz allows SELECT
+query I con2
+FROM quack_query('quack:localhost', 'select 1+1', token => 'analytics-team-token');
+----
+2
+
+# Authz blocks writes
+statement error con2
+FROM quack_query('quack:localhost', 'CREATE TABLE t(x INT)', token => 'analytics-team-token');
+----
+Authorization failed
+
+statement error con2
+FROM quack_query('quack:localhost', 'INSERT INTO t VALUES (1)', token => 'analytics-team-token');
+----
+Authorization failed
+
+statement ok con1
+RESET GLOBAL quack_authentication_function;
+
+statement ok con1
+RESET GLOBAL quack_authorization_function;
+
+statement ok con1
+CALL quack_stop('quack:localhost');


### PR DESCRIPTION
Based on test provided by @guillesd, basically:
```
SET GLOBAL quack_authentication_function = 'check_token';
SET GLOBAL quack_authorization_function  = 'read_only';

CALL quack_serve('quack:localhost', token => 'analytics-team-token');
```
would not save the explicitly provided `token`.