### PR TITLE
Avoid issueing Queries if ClientContext is not valid anymore

### DIFF
--- a/src/storage/quack_transaction.cpp
+++ b/src/storage/quack_transaction.cpp
@@ -1,6 +1,7 @@
 #include "storage/quack_transaction.hpp"
 
 #include "duckdb/common/printer.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "storage/quack_catalog.hpp"
 
 namespace duckdb {
@@ -53,6 +54,11 @@ QuackTransaction &QuackTransaction::Get(CatalogTransaction transaction) {
 unique_ptr<ColumnDataCollection> QuackTransaction::Query(const string &query) {
 	ForceStart();
 	auto context_ref = context.lock();
+	if (!context_ref) {
+		// Note: we are in a destructor, there is not much that we can do, queries can't
+		// go on the wire in any case, just NOP it is
+		return nullptr;
+	}
 	return quack_catalog.ExecuteCommandInternal(query, context_ref.get());
 }
 


### PR DESCRIPTION
Note: this silently shallows the queries, but there are no other available course of action I think.

I have seen failures in ROLLBACK, I am not sure if this is now impossible, but I think we can as well add the check.

One question: on the state machine TRANSACTION_STARTED/TRANSACTION_NOT_YET_STARTED/TRANSACTION_FINISHED: what happens if a ROLLBACK or COMMIT are issued SQL side? That I don't currently see.