### PR TITLE
Wrap listen_after_bind in try catch, to cover for failures in httplib's ThreadPool constructor

### DIFF
--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -8,6 +8,7 @@
 
 namespace duckdb {
 
+
 void HttpQuackServer::StopAccepting() {
 	// Closes the listening socket only. Idempotent. Safe to call from a
 	// request-handler thread.
@@ -40,8 +41,14 @@ HttpQuackServer::~HttpQuackServer() {
 void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port) {
 	D_ASSERT(server->server);
 	D_ASSERT(listen_port > 1 && listen_port < 65535);
-	// Socket is already bound (synchronously, in the constructor)
-	server->server->listen_after_bind();
+	// Socket is already bound (synchronously, in the constructor).
+	// Catch everything so the listener thread never lets an exception escape — that
+	// would call std::terminate and abort the host process.
+	try {
+		server->server->listen_after_bind();
+	} catch (...) {
+		server->is_running = false;
+	}
 }
 
 HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)


### PR DESCRIPTION
This might happen if close to machine thread limit, httplib's ThreadPool constructor will not properly handle that. Catch and just fail.