### PR TITLE
Keep track of connections to a specific `ConnectionId` in the `QuackClientConnection`, and send a `DisconnectMessage` when a connection is no longer required

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -9,10 +9,14 @@
 #include "quack_uri.hpp"
 
 namespace duckdb {
+class QuackClientConnection;
 
 class QuackClient {
 public:
-	explicit QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_p), uri(uri_p) {};
+	explicit QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_p), uri(uri_p) {
+	}
+	virtual ~QuackClient() {
+	}
 
 	template <class TARGET>
 	unique_ptr<TARGET> Request(optional_ptr<ClientContext> context, unique_ptr<QuackMessage> request_message) {
@@ -32,7 +36,7 @@ public:
 	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
-	virtual ~QuackClient() {};
+	static shared_ptr<QuackClientConnection> ConnectToServer(ClientContext &context, const QuackUri &uri, string token);
 
 protected:
 	mutex request_mutex;
@@ -43,6 +47,30 @@ protected:
 private:
 	virtual unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
 	                                                 unique_ptr<QuackMessage> request_message) = 0;
+};
+
+class QuackClientConnection {
+public:
+	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p);
+	~QuackClientConnection();
+
+	const string &ConnectionId() const {
+		return connection_id;
+	}
+	const QuackUri &ServerURI() const {
+		return uri;
+	}
+
+	//! Get a client (either a cached one, or open a new one if required)
+	unique_ptr<QuackClient> GetClient(ClientContext &context) const;
+	//! Return a client back to the cache
+	void StoreClient(unique_ptr<QuackClient> client_p);
+
+private:
+	QuackUri uri;
+	string connection_id;
+	mutable mutex lock;
+	mutable vector<unique_ptr<QuackClient>> cached_clients;
 };
 
 class HttpsQuackClient : public QuackClient {

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -14,7 +14,8 @@ enum class MessageType : uint8_t {
 	FETCH_REQUEST = 7,
 	FETCH_RESPONSE = 8,
 	APPEND_REQUEST = 9,
-	APPEND_RESPONSE = 10,
+	SUCCESS_RESPONSE = 10,
+	DISCONNECT_MESSAGE = 11,
 	ERROR_RESPONSE = 100
 };
 
@@ -291,14 +292,28 @@ private:
 	unique_ptr<DataChunkWrapper> append_chunk;
 };
 
-class AppendResponseMessage : public QuackMessage {
+class DisconnectMessage : public QuackMessage {
 public:
-	static constexpr MessageType TYPE = MessageType::APPEND_RESPONSE;
+	static constexpr MessageType TYPE = MessageType::DISCONNECT_MESSAGE;
 
-	explicit AppendResponseMessage() : QuackMessage(TYPE) {};
+	explicit DisconnectMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {};
 
 	void Serialize(Serializer &serializer) const override;
-	static unique_ptr<AppendResponseMessage> Deserialize(Deserializer &deserializer);
+	static unique_ptr<DisconnectMessage> Deserialize(Deserializer &deserializer);
+
+protected:
+	DisconnectMessage() : QuackMessage(TYPE) {
+	}
+};
+
+class SuccessResponse : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::SUCCESS_RESPONSE;
+
+	explicit SuccessResponse() : QuackMessage(TYPE) {};
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<SuccessResponse> Deserialize(Deserializer &deserializer);
 };
 
 class ErrorResponse : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -52,7 +52,11 @@
     ]
   },
   {
-    "class": "AppendResponseMessage",
+    "class": "SuccessResponse",
+    "members": []
+  },
+  {
+    "class": "DisconnectMessage",
     "members": []
   },
   {

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -9,8 +9,9 @@ struct QuackScanBindData : FunctionData {
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<QuackScanBindData>();
 		return other.client_connection->ConnectionId() == client_connection->ConnectionId() &&
-		       other.client_connection->ServerURI() == client_connection->ServerURI() && other.table_name == table_name &&
-		       other.column_names == column_names && other.column_types == column_types;
+		       other.client_connection->ServerURI() == client_connection->ServerURI() &&
+		       other.table_name == table_name && other.column_names == column_names &&
+		       other.column_types == column_types;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackScanBindData>();

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -8,13 +8,13 @@ namespace duckdb {
 struct QuackScanBindData : FunctionData {
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<QuackScanBindData>();
-		return other.client->ConnectionId() == client->ConnectionId() &&
-		       other.client->ServerURI() == client->ServerURI() && other.table_name == table_name &&
+		return other.client_connection->ConnectionId() == client_connection->ConnectionId() &&
+		       other.client_connection->ServerURI() == client_connection->ServerURI() && other.table_name == table_name &&
 		       other.column_names == column_names && other.column_types == column_types;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackScanBindData>();
-		result->client = client;
+		result->client_connection = client_connection;
 		result->table_name = table_name;
 		result->column_names = column_names;
 		result->column_types = column_types;
@@ -25,7 +25,7 @@ struct QuackScanBindData : FunctionData {
 	vector<string> column_names;
 	vector<LogicalType> column_types;
 	vector<unique_ptr<DataChunkWrapper>> results;
-	shared_ptr<QuackClientConnection> client;
+	shared_ptr<QuackClientConnection> client_connection;
 	bool needs_more_fetch = true;
 };
 

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -8,40 +8,25 @@ namespace duckdb {
 struct QuackScanBindData : FunctionData {
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<QuackScanBindData>();
-		return other.connection_id == connection_id && other.server_uri == server_uri &&
-		       other.table_name == table_name && other.column_names == column_names &&
-		       other.column_types == column_types;
+		return other.client->ConnectionId() == client->ConnectionId() &&
+		       other.client->ServerURI() == client->ServerURI() && other.table_name == table_name &&
+		       other.column_names == column_names && other.column_types == column_types;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackScanBindData>();
-		result->connection_id = connection_id;
-		result->server_uri = server_uri;
+		result->client = client;
 		result->table_name = table_name;
 		result->column_names = column_names;
 		result->column_types = column_types;
 		return std::move(result);
 	}
 
-	string connection_id;
-	QuackUri server_uri;
 	string table_name;
 	vector<string> column_names;
 	vector<LogicalType> column_types;
 	vector<unique_ptr<DataChunkWrapper>> results;
+	shared_ptr<QuackClientConnection> client;
 	bool needs_more_fetch = true;
-
-	unique_ptr<QuackClient> TryGetInitialClient() const {
-		lock_guard<mutex> guard(lock);
-		return std::move(initial_client);
-	}
-	void SetInitialClient(unique_ptr<QuackClient> initial_client_p) {
-		lock_guard<mutex> guard(lock);
-		initial_client = std::move(initial_client_p);
-	}
-
-private:
-	mutable mutex lock;
-	mutable unique_ptr<QuackClient> initial_client;
 };
 
 class TableFunction;

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -21,11 +21,15 @@ class PreparedStatement;
 class EncryptionState;
 
 struct QuackConnection {
+	explicit QuackConnection(string session_id_p);
+	~QuackConnection();
+
 	mutex lock;
 	unique_ptr<Connection> duckdb_connection;
 	unique_ptr<QueryResult> duckdb_query_result;
 	//! Monotonic counter assigned per FETCH batch — enables order-preserving parallel scans on
 	idx_t next_batch_index = 0;
+	string session_id;
 };
 
 class QuackServer {
@@ -43,8 +47,9 @@ public:
 	//! listen-loop teardown joins all workers, which would deadlock.
 	virtual void Close() {};
 
-	optional_ptr<QuackConnection> GetConnection(const string &connection_id);
+	shared_ptr<QuackConnection> GetConnection(const string &connection_id);
 	string CreateNewConnection(const string &session_id);
+	bool DisconnectConnection(const string &session_id);
 	// TODO need something to destroy connections
 
 	string GenerateSessionId();
@@ -71,7 +76,7 @@ protected:
 
 	weak_ptr<DatabaseInstance> db_ptr;
 	mutex active_connections_mutex;
-	unordered_map<string, unique_ptr<QuackConnection>> active_connections;
+	unordered_map<string, shared_ptr<QuackConnection>> active_connections;
 
 	mutex session_id_rng_mutex;
 	shared_ptr<EncryptionState> session_id_rng;

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -53,12 +53,11 @@ public:
 	bool InMemory() override;
 	string GetDBPath() override;
 
-	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(const string &query, optional_ptr<ClientContext> context);
+	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(ClientContext &context, const string &query);
 	const QuackUri &GetServerUri();
 	const string &GetConnectionId();
 
-	QuackClient &GetRawClient();
-	shared_ptr<QuackClientConnection> GetClient();
+	shared_ptr<QuackClientConnection> GetClientConnection();
 
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
@@ -67,7 +66,6 @@ private:
 
 private:
 	shared_ptr<QuackClientConnection> client_connection;
-	unique_ptr<QuackClient> client;
 	unique_ptr<QuackSchemaSet> schemas;
 };
 

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -16,6 +16,7 @@ namespace duckdb {
 
 class QuackCatalog;
 class QuackClient;
+class QuackClientConnection;
 
 class QuackCatalog : public Catalog {
 public:
@@ -57,6 +58,7 @@ public:
 	const string &GetConnectionId();
 
 	QuackClient &GetRawClient();
+	shared_ptr<QuackClientConnection> GetClient();
 
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
@@ -64,10 +66,9 @@ private:
 	QuackLoadCatalogData LoadCatalog(ClientContext &context);
 
 private:
-	QuackUri server_uri;
+	shared_ptr<QuackClientConnection> client_connection;
 	unique_ptr<QuackClient> client;
 	unique_ptr<QuackSchemaSet> schemas;
-	string connection_id;
 };
 
 } // namespace duckdb

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -29,7 +29,7 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 	auto &http_util = HTTPUtil::Get(db);
 	auto request_url = uri.Http() + "/quack";
 	if (!http_params) {
-		if (context) {
+		if (context && context->transaction.HasActiveTransaction() ) {
 			http_params = http_util.InitializeParameters(*context, request_url);
 		} else {
 			http_params = http_util.InitializeParameters(db, request_url);
@@ -138,6 +138,7 @@ QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, Q
 }
 
 QuackClientConnection::~QuackClientConnection() {
+	Printer::PrintF("Closed client connection with %d connections in cache", cached_clients.size());
 }
 
 shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &context, const QuackUri &uri,

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -29,7 +29,7 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 	auto &http_util = HTTPUtil::Get(db);
 	auto request_url = uri.Http() + "/quack";
 	if (!http_params) {
-		if (context && context->transaction.HasActiveTransaction() ) {
+		if (context && context->transaction.HasActiveTransaction()) {
 			http_params = http_util.InitializeParameters(*context, request_url);
 		} else {
 			http_params = http_util.InitializeParameters(db, request_url);
@@ -138,7 +138,13 @@ QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, Q
 }
 
 QuackClientConnection::~QuackClientConnection() {
-	Printer::PrintF("Closed client connection with %d connections in cache", cached_clients.size());
+	if (!cached_clients.empty()) {
+		try {
+			auto &client = cached_clients.back();
+			client->Request<SuccessResponse>(nullptr, make_uniq<DisconnectMessage>(connection_id));
+		} catch (...) {
+		}
+	}
 }
 
 shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &context, const QuackUri &uri,

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -1,10 +1,11 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 
 #include "quack_client.hpp"
 #include "quack_uri.hpp"
 
-using namespace duckdb;
+namespace duckdb {
 
 template <class T>
 string GetUriPart(T ele) {
@@ -128,3 +129,59 @@ unique_ptr<QuackClient> QuackClient::GetClient(DatabaseInstance &db, const Quack
 unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const QuackUri &uri) {
 	return GetClient(*context.db, uri);
 }
+
+QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p)
+    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)) {
+	if (client_p) {
+		cached_clients.push_back(std::move(client_p));
+	}
+}
+
+QuackClientConnection::~QuackClientConnection() {
+}
+
+shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &context, const QuackUri &uri,
+                                                               string token) {
+	// if no token is provided fetch it from the secret manager
+	if (token.empty()) {
+		auto &secret_manager = SecretManager::Get(context);
+		auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+		auto match = secret_manager.LookupSecret(transaction, uri.Uri(), "quack");
+		if (match.HasMatch()) {
+			const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
+			token = kv.TryGetValue("token", true).ToString();
+		}
+	}
+	if (token.empty()) {
+		throw InvalidInputException("Could not find a Quack authentication token");
+	}
+
+	// open a HTTP client to the server
+	auto client = QuackClient::GetClient(context, uri);
+
+	// submit the connection request
+	auto connection_request_response =
+	    client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
+	// success! we got a connection id
+	// construct the client connection and return it
+	auto connection_id = connection_request_response->ConnectionId();
+	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id));
+}
+
+unique_ptr<QuackClient> QuackClientConnection::GetClient(ClientContext &context) const {
+	lock_guard<mutex> guard(lock);
+	if (!cached_clients.empty()) {
+		auto result = std::move(cached_clients.back());
+		cached_clients.pop_back();
+		return result;
+	}
+	// instantiate a new client and return it
+	return QuackClient::GetClient(context, uri);
+}
+
+void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) {
+	lock_guard<mutex> guard(lock);
+	cached_clients.push_back(std::move(client_p));
+}
+
+} // namespace duckdb

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -54,9 +54,9 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 	// from scan thread clients can deadlock waiting for threads held by the
 	// catalog clients that are in turn waiting for the scan to complete.
 	server->new_task_queue = [] {
-		return new duckdb_httplib::ThreadPool(4);
+		return new duckdb_httplib::ThreadPool(128);
 	};
-	server->set_keep_alive_max_count(4);
+	server->set_keep_alive_max_count(128);
 	server->set_keep_alive_timeout(10);
 	server->set_tcp_nodelay(true);
 

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -42,8 +42,11 @@ MessageType EnumUtil::FromString<MessageType>(const char *value) {
 	if (StringUtil::Equals(value, "APPEND_REQUEST")) {
 		return MessageType::APPEND_REQUEST;
 	}
-	if (StringUtil::Equals(value, "APPEND_RESPONSE")) {
-		return MessageType::APPEND_RESPONSE;
+	if (StringUtil::Equals(value, "SUCCESS_RESPONSE")) {
+		return MessageType::SUCCESS_RESPONSE;
+	}
+	if (StringUtil::Equals(value, "DISCONNECT_MESSAGE")) {
+		return MessageType::DISCONNECT_MESSAGE;
 	}
 	if (StringUtil::Equals(value, "ERROR_RESPONSE")) {
 		return MessageType::ERROR_RESPONSE;
@@ -69,8 +72,10 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 		return "FETCH_RESPONSE";
 	case MessageType::APPEND_REQUEST:
 		return "APPEND_REQUEST";
-	case MessageType::APPEND_RESPONSE:
-		return "APPEND_RESPONSE";
+	case MessageType::SUCCESS_RESPONSE:
+		return "SUCCESS_RESPONSE";
+	case MessageType::DISCONNECT_MESSAGE:
+		return "DISCONNECT_MESSAGE";
 	case MessageType::ERROR_RESPONSE:
 		return "ERROR_RESPONSE";
 
@@ -112,8 +117,10 @@ unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, M
 		return FetchResponseMessage::Deserialize(deserializer);
 	case MessageType::APPEND_REQUEST:
 		return AppendRequestMessage::Deserialize(deserializer);
-	case MessageType::APPEND_RESPONSE:
-		return AppendResponseMessage::Deserialize(deserializer);
+	case MessageType::SUCCESS_RESPONSE:
+		return SuccessResponse::Deserialize(deserializer);
+	case MessageType::DISCONNECT_MESSAGE:
+		return DisconnectMessage::Deserialize(deserializer);
 	case MessageType::ERROR_RESPONSE:
 		return ErrorResponse::Deserialize(deserializer);
 	default:

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -40,12 +40,13 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	if (input.named_parameters.find("token") != input.named_parameters.end()) {
 		token = input.named_parameters["token"].GetValue<string>();
 	}
-	bind_data->client = QuackClient::ConnectToServer(context, server_uri, token);
+	bind_data->client_connection = QuackClient::ConnectToServer(context, server_uri, token);
+	auto &client_connection = *bind_data->client_connection;
 
-	auto client = bind_data->client->GetClient(context);
+	auto client = client_connection.GetClient(context);
 
 	auto bind_response = client->Request<PrepareResponseMessage>(
-	    context, make_uniq<PrepareRequestMessage>(bind_data->client->ConnectionId(), query));
+	    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(), query));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -54,7 +55,7 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	bind_data->needs_more_fetch = bind_response->NeedsMoreFetch();
 
 	// store the initial client for later re-use
-	bind_data->client->StoreClient(std::move(client));
+	client_connection.StoreClient(std::move(client));
 
 	return bind_data;
 }
@@ -89,10 +90,11 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 
 	auto query = input.inputs[1].GetValue<string>();
 	auto bind_data = make_uniq<QuackScanBindData>();
-	bind_data->client = catalog.GetClient();
-
-	auto bind_response = catalog.GetRawClient().Request<PrepareResponseMessage>(
-	    context, make_uniq<PrepareRequestMessage>(bind_data->client->ConnectionId(), query));
+	bind_data->client_connection = catalog.GetClientConnection();
+	auto client = bind_data->client_connection->GetClient(context);
+	auto bind_response = client->Request<PrepareResponseMessage>(
+	    context, make_uniq<PrepareRequestMessage>(bind_data->client_connection->ConnectionId(), query));
+	bind_data->client_connection->StoreClient(std::move(client));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -246,16 +248,17 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	if (!bind_data.table_name.empty()) {
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
-		auto client = bind_data.client->GetClient(context);
+		auto &client_connection = *bind_data.client_connection;
+		auto client = client_connection.GetClient(context);
 		auto response_message = client->Request<PrepareResponseMessage>(
-		    context, make_uniq<PrepareRequestMessage>(bind_data.client->ConnectionId(), query));
+		    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(), query));
 		needs_more_fetch = response_message->NeedsMoreFetch();
 		// fetch the result
 		for (auto &chunk_ref : response_message->MutableResults()) {
 			auto &chunk = chunk_ref->Chunk();
 			results.emplace_back(chunk, ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
 		}
-		bind_data.client->StoreClient(std::move(client));
+		client_connection.StoreClient(std::move(client));
 	} else {
 		for (auto &chunk_ref : bind_data.results) {
 			auto &chunk = chunk_ref->Chunk();
@@ -275,7 +278,7 @@ unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context
 	auto local_state = make_uniq<QuackScanLocalState>();
 
 	// re-use initial client from bind if possible
-	local_state->client = bind_data.client->GetClient(context.client);
+	local_state->client = bind_data.client_connection->GetClient(context.client);
 	auto results = global_state.TryGetResults();
 	for (auto &chunk : results) {
 		local_state->results.push(std::move(chunk));
@@ -318,7 +321,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		// if that did not work, we request more results
 		if (local_state.results.empty() && global_state.needs_more_fetch) {
 			auto fetch_response = local_state.client->Request<FetchResponseMessage>(
-			    context, make_uniq<FetchRequestMessage>(bind_data.client->ConnectionId()));
+			    context, make_uniq<FetchRequestMessage>(bind_data.client_connection->ConnectionId()));
 
 			if (fetch_response->MutableResults().empty()) {
 				// server is done, we are done
@@ -349,7 +352,7 @@ static OperatorPartitionData QuackScanGetPartitionData(ClientContext &, TableFun
 InsertionOrderPreservingMap<string> QuackScanToString(TableFunctionToStringInput &input) {
 	auto &bind_data = input.bind_data->Cast<QuackScanBindData>();
 	InsertionOrderPreservingMap<string> result;
-	result["Server"] = bind_data.client->ServerURI().Uri();
+	result["Server"] = bind_data.client_connection->ServerURI().Uri();
 	return result;
 }
 

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -2,7 +2,6 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/secret/secret.hpp"
-#include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 
@@ -33,36 +32,20 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	}
 
 	auto bind_data = make_uniq<QuackScanBindData>();
-	bind_data->server_uri = QuackUri(initial_uri.Uri(), enable_ssl);
-	auto initial_client = QuackClient::GetClient(context, bind_data->server_uri);
+	auto server_uri = QuackUri(initial_uri.Uri(), enable_ssl);
 
 	// Resolve auth token: prefer a quack secret scoped to this URI; fall back to the
 	// global rpc_default_token setting. Mirrors the logic in QuackCatalog::QuackCatalog.
 	string token;
-
 	if (input.named_parameters.find("token") != input.named_parameters.end()) {
 		token = input.named_parameters["token"].GetValue<string>();
 	}
+	bind_data->client = QuackClient::ConnectToServer(context, server_uri, token);
 
-	if (token.empty()) {
-		auto &secret_manager = SecretManager::Get(context);
-		auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
-		auto match = secret_manager.LookupSecret(transaction, bind_data->server_uri.Uri(), "quack");
-		if (match.HasMatch()) {
-			const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
-			token = kv.TryGetValue("token", true).ToString();
-		}
-	}
-	if (token.empty()) {
-		throw InvalidInputException("Could not find a Quack authentication token");
-	}
+	auto client = bind_data->client->GetClient(context);
 
-	auto connection_request_response =
-	    initial_client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
-	bind_data->connection_id = connection_request_response->ConnectionId();
-
-	auto bind_response = initial_client->Request<PrepareResponseMessage>(
-	    context, make_uniq<PrepareRequestMessage>(bind_data->connection_id, query));
+	auto bind_response = client->Request<PrepareResponseMessage>(
+	    context, make_uniq<PrepareRequestMessage>(bind_data->client->ConnectionId(), query));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -71,7 +54,7 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	bind_data->needs_more_fetch = bind_response->NeedsMoreFetch();
 
 	// store the initial client for later re-use
-	bind_data->SetInitialClient(std::move(initial_client));
+	bind_data->client->StoreClient(std::move(client));
 
 	return bind_data;
 }
@@ -106,11 +89,10 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 
 	auto query = input.inputs[1].GetValue<string>();
 	auto bind_data = make_uniq<QuackScanBindData>();
-	bind_data->server_uri = catalog.GetServerUri();
-	bind_data->connection_id = catalog.GetConnectionId();
+	bind_data->client = catalog.GetClient();
 
 	auto bind_response = catalog.GetRawClient().Request<PrepareResponseMessage>(
-	    context, make_uniq<PrepareRequestMessage>(bind_data->connection_id, query));
+	    context, make_uniq<PrepareRequestMessage>(bind_data->client->ConnectionId(), query));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -264,15 +246,16 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	if (!bind_data.table_name.empty()) {
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
-		auto client = QuackClient::GetClient(context, bind_data.server_uri);
+		auto client = bind_data.client->GetClient(context);
 		auto response_message = client->Request<PrepareResponseMessage>(
-		    context, make_uniq<PrepareRequestMessage>(bind_data.connection_id, query));
+		    context, make_uniq<PrepareRequestMessage>(bind_data.client->ConnectionId(), query));
 		needs_more_fetch = response_message->NeedsMoreFetch();
 		// fetch the result
 		for (auto &chunk_ref : response_message->MutableResults()) {
 			auto &chunk = chunk_ref->Chunk();
 			results.emplace_back(chunk, ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
 		}
+		bind_data.client->StoreClient(std::move(client));
 	} else {
 		for (auto &chunk_ref : bind_data.results) {
 			auto &chunk = chunk_ref->Chunk();
@@ -292,10 +275,7 @@ unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context
 	auto local_state = make_uniq<QuackScanLocalState>();
 
 	// re-use initial client from bind if possible
-	local_state->client = bind_data.TryGetInitialClient();
-	if (!local_state->client) {
-		local_state->client = QuackClient::GetClient(context.client, bind_data.server_uri);
-	}
+	local_state->client = bind_data.client->GetClient(context.client);
 	auto results = global_state.TryGetResults();
 	for (auto &chunk : results) {
 		local_state->results.push(std::move(chunk));
@@ -338,7 +318,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		// if that did not work, we request more results
 		if (local_state.results.empty() && global_state.needs_more_fetch) {
 			auto fetch_response = local_state.client->Request<FetchResponseMessage>(
-			    context, make_uniq<FetchRequestMessage>(bind_data.connection_id));
+			    context, make_uniq<FetchRequestMessage>(bind_data.client->ConnectionId()));
 
 			if (fetch_response->MutableResults().empty()) {
 				// server is done, we are done
@@ -369,7 +349,7 @@ static OperatorPartitionData QuackScanGetPartitionData(ClientContext &, TableFun
 InsertionOrderPreservingMap<string> QuackScanToString(TableFunctionToStringInput &input) {
 	auto &bind_data = input.bind_data->Cast<QuackScanBindData>();
 	InsertionOrderPreservingMap<string> result;
-	result["Server"] = bind_data.server_uri.Uri();
+	result["Server"] = bind_data.client->ServerURI().Uri();
 	return result;
 }
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -14,7 +14,12 @@
 #include "quack_log.hpp"
 #include "quack_storage.hpp"
 
-using namespace duckdb;
+namespace duckdb {
+QuackConnection::QuackConnection(string session_id_p) : session_id(std::move(session_id_p)) {
+}
+
+QuackConnection::~QuackConnection() {
+}
 
 void QuackServer::ValidateToken(const string &token) {
 	if (token.size() < 4) {
@@ -30,11 +35,11 @@ QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const 
 QuackServer::~QuackServer() {
 }
 
-optional_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_id) {
+shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_id) {
 	std::lock_guard<std::mutex> lock(active_connections_mutex);
 	auto it = active_connections.find(connection_id);
 	if (it != active_connections.end()) {
-		return it->second.get();
+		return it->second;
 	}
 	return nullptr;
 }
@@ -48,12 +53,24 @@ string QuackServer::CreateNewConnection(const string &session_id) {
 	if (!db) {
 		throw InternalException("Database was closed");
 	}
-	auto new_connection = make_uniq<QuackConnection>();
+	auto new_connection = make_shared_ptr<QuackConnection>(session_id);
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
 	// new_connection->duckdb_connection->context->config.streaming_buffer_size = 10 * 1000000; // 10 MB
 	active_connections[session_id] = std::move(new_connection);
 	return session_id;
+}
+
+bool QuackServer::DisconnectConnection(const string &session_id) {
+	std::lock_guard<std::mutex> lock(active_connections_mutex);
+
+	auto entry = active_connections.find(session_id);
+	if (entry == active_connections.end()) {
+		// unknown client
+		return false;
+	}
+	active_connections.erase(entry);
+	return true;
 }
 
 static string GetSettingString(DatabaseInstance &db, const string &setting_name) {
@@ -137,6 +154,7 @@ bool ServerSupportsMessage(MessageType type) {
 	case MessageType::PREPARE_REQUEST:
 	case MessageType::FETCH_REQUEST:
 	case MessageType::APPEND_REQUEST:
+	case MessageType::DISCONNECT_MESSAGE:
 		return true;
 	default:
 		return false;
@@ -182,7 +200,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 
 	// if the message requires it, obtain a connection
 	// these are basically all messages aside from connect request
-	optional_ptr<QuackConnection> connection;
+	shared_ptr<QuackConnection> connection;
 	if (MessageRequiresConnection(header.type)) {
 		connection = GetConnection(header.connection_id);
 		if (!connection) {
@@ -246,6 +264,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>("Authentication failed");
 		}
 		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id));
+	}
+	case MessageType::DISCONNECT_MESSAGE: {
+		auto &connection = *connection_p;
+		if (!DisconnectConnection(connection.session_id)) {
+			return make_uniq<ErrorResponse>("Connection does not exist / already disconnected");
+		}
+		return make_uniq<SuccessResponse>();
 	}
 	case MessageType::PREPARE_REQUEST: {
 		auto &prepare_request_message = received_message.Cast<PrepareRequestMessage>();
@@ -351,7 +376,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		ColumnDataCollection collection(Allocator::Get(context), append_request_message.AppendChunk().GetTypes());
 		collection.Append(append_request_message.AppendChunk());
 		connection.duckdb_connection->Append(*table_info, collection);
-		return make_uniq<AppendResponseMessage>();
+		return make_uniq<SuccessResponse>();
 	}
 	default: {
 		return make_uniq<ErrorResponse>(
@@ -359,3 +384,4 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	}
 	}
 }
+} // namespace duckdb

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -23,14 +23,6 @@ unique_ptr<AppendRequestMessage> AppendRequestMessage::Deserialize(Deserializer 
 	return result;
 }
 
-void AppendResponseMessage::Serialize(Serializer &serializer) const {
-}
-
-unique_ptr<AppendResponseMessage> AppendResponseMessage::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<AppendResponseMessage>(new AppendResponseMessage());
-	return result;
-}
-
 void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "auth_string", auth_string);
 }
@@ -46,6 +38,14 @@ void ConnectionResponseMessage::Serialize(Serializer &serializer) const {
 
 unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ConnectionResponseMessage>(new ConnectionResponseMessage());
+	return result;
+}
+
+void DisconnectMessage::Serialize(Serializer &serializer) const {
+}
+
+unique_ptr<DisconnectMessage> DisconnectMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<DisconnectMessage>(new DisconnectMessage());
 	return result;
 }
 
@@ -116,6 +116,14 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(3, "needs_more_fetch");
 	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results");
 	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch));
+	return result;
+}
+
+void SuccessResponse::Serialize(Serializer &serializer) const {
+}
+
+unique_ptr<SuccessResponse> SuccessResponse::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<SuccessResponse>(new SuccessResponse());
 	return result;
 }
 

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -25,8 +25,6 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
     : Catalog(db_p) {
 	// connect to the server
 	client_connection = QuackClient::ConnectToServer(context, server_uri, token);
-	// create a client connection and keep it stored in the catalog
-	client = client_connection->GetClient(context);
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);
@@ -35,8 +33,8 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
 
 QuackLoadCatalogData QuackCatalog::LoadCatalog(ClientContext &context) {
 	QuackLoadCatalogData result;
-	result.schemas = ExecuteCommandInternal(QuackSchemaSet::GetLoadQuery(), context);
-	result.tables = ExecuteCommandInternal(QuackTableSet::GetLoadQuery(), context);
+	result.schemas = ExecuteCommandInternal(context, QuackSchemaSet::GetLoadQuery());
+	result.tables = ExecuteCommandInternal(context, QuackTableSet::GetLoadQuery());
 	return result;
 }
 
@@ -67,25 +65,24 @@ const QuackUri &QuackCatalog::GetServerUri() {
 	return client_connection->ServerURI();
 }
 
-unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(const string &query,
-                                                                      optional_ptr<ClientContext> context) {
+unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(ClientContext &context, const string &query) {
 	// FIXME this will break with many results!
 	auto chunk_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
+	// get a client to query
+	auto client = client_connection->GetClient(context);
 	auto response =
 	    client->Request<PrepareResponseMessage>(context, make_uniq<PrepareRequestMessage>(GetConnectionId(), query));
 	chunk_collection->Initialize(response->Types());
 	for (auto &chunk : response->MutableResults()) {
 		chunk_collection->Append(chunk->Chunk());
 	}
+	// move the client back to the connection cache
+	client_connection->StoreClient(std::move(client));
 	return chunk_collection;
 }
 
-shared_ptr<QuackClientConnection> QuackCatalog::GetClient() {
+shared_ptr<QuackClientConnection> QuackCatalog::GetClientConnection() {
 	return client_connection;
-}
-
-QuackClient &QuackCatalog::GetRawClient() {
-	return *client;
 }
 
 const string &QuackCatalog::GetConnectionId() {

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -20,26 +20,13 @@
 
 namespace duckdb {
 
-QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p, ClientContext &context,
-                           const string &token_p)
-    : Catalog(db_p), server_uri(server_uri_p), client(QuackClient::GetClient(context, server_uri)) {
-	auto &secret_manager = SecretManager::Get(context);
-	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
-	auto match = secret_manager.LookupSecret(transaction, server_uri.Uri(), "quack");
-	string token = token_p;
-	if (token.empty() && match.HasMatch()) {
-		const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
-		token = kv.TryGetValue("token", true).ToString();
-	}
-
-	if (token.empty()) {
-		throw InvalidInputException(
-		    "Could not find token for ATTACH 'quack:...' - Please create a secret first or pass directly");
-	}
-
-	auto connection_response =
-	    client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
-	connection_id = connection_response->ConnectionId();
+QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, ClientContext &context,
+                           const string &token)
+    : Catalog(db_p) {
+	// connect to the server
+	client_connection = QuackClient::ConnectToServer(context, server_uri, token);
+	// create a client connection and keep it stored in the catalog
+	client = client_connection->GetClient(context);
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);
@@ -77,7 +64,7 @@ optional_ptr<SchemaCatalogEntry> QuackCatalog::LookupSchema(CatalogTransaction t
 }
 
 const QuackUri &QuackCatalog::GetServerUri() {
-	return server_uri;
+	return client_connection->ServerURI();
 }
 
 unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(const string &query,
@@ -85,7 +72,7 @@ unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(const stri
 	// FIXME this will break with many results!
 	auto chunk_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
 	auto response =
-	    client->Request<PrepareResponseMessage>(context, make_uniq<PrepareRequestMessage>(connection_id, query));
+	    client->Request<PrepareResponseMessage>(context, make_uniq<PrepareRequestMessage>(GetConnectionId(), query));
 	chunk_collection->Initialize(response->Types());
 	for (auto &chunk : response->MutableResults()) {
 		chunk_collection->Append(chunk->Chunk());
@@ -93,12 +80,16 @@ unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(const stri
 	return chunk_collection;
 }
 
+shared_ptr<QuackClientConnection> QuackCatalog::GetClient() {
+	return client_connection;
+}
+
 QuackClient &QuackCatalog::GetRawClient() {
 	return *client;
 }
 
 const string &QuackCatalog::GetConnectionId() {
-	return connection_id;
+	return client_connection->ConnectionId();
 }
 
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -60,7 +60,13 @@ SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	auto chunk_wrapper = make_uniq<DataChunkWrapper>(*append_chunk);
 	auto append_message = make_uniq<AppendRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name, tbl.name,
 	                                                      std::move(chunk_wrapper));
-	quack_catalog.GetRawClient().Request<AppendResponseMessage>(context.client, std::move(append_message));
+
+	auto client_connection = quack_catalog.GetClientConnection();
+	auto client = client_connection->GetClient(context.client);
+	client->Request<AppendResponseMessage>(context.client, std::move(append_message));
+	client_connection->StoreClient(std::move(client));
+
+
 	global_state.insert_count += chunk.size();
 	return SinkResultType::NEED_MORE_INPUT;
 }

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -63,9 +63,8 @@ SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 
 	auto client_connection = quack_catalog.GetClientConnection();
 	auto client = client_connection->GetClient(context.client);
-	client->Request<AppendResponseMessage>(context.client, std::move(append_message));
+	client->Request<SuccessResponse>(context.client, std::move(append_message));
 	client_connection->StoreClient(std::move(client));
-
 
 	global_state.insert_count += chunk.size();
 	return SinkResultType::NEED_MORE_INPUT;

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -78,7 +78,7 @@ FROM duckdb_views()
 TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data_p) {
 	auto &quack_catalog = catalog.Cast<QuackCatalog>();
 	auto bind_data = make_uniq<QuackScanBindData>();
-	bind_data->client = quack_catalog.GetClient();
+	bind_data->client_connection = quack_catalog.GetClientConnection();
 	bind_data->table_name = name;
 	for (auto &col : GetColumns().Physical()) {
 		bind_data->column_names.push_back(col.Name());

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -78,8 +78,7 @@ FROM duckdb_views()
 TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data_p) {
 	auto &quack_catalog = catalog.Cast<QuackCatalog>();
 	auto bind_data = make_uniq<QuackScanBindData>();
-	bind_data->server_uri = quack_catalog.GetServerUri();
-	bind_data->connection_id = quack_catalog.GetConnectionId();
+	bind_data->client = quack_catalog.GetClient();
 	bind_data->table_name = name;
 	for (auto &col : GetColumns().Physical()) {
 		bind_data->column_names.push_back(col.Name());

--- a/src/storage/quack_transaction.cpp
+++ b/src/storage/quack_transaction.cpp
@@ -53,7 +53,11 @@ QuackTransaction &QuackTransaction::Get(CatalogTransaction transaction) {
 unique_ptr<ColumnDataCollection> QuackTransaction::Query(const string &query) {
 	ForceStart();
 	auto context_ref = context.lock();
-	return quack_catalog.ExecuteCommandInternal(query, context_ref.get());
+	if (!context_ref) {
+		// context has been destroyed - silently ignore the query
+		return nullptr;
+	}
+	return quack_catalog.ExecuteCommandInternal(*context_ref, query);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
This is a follow-up to https://github.com/duckdb/duckdb-quack/pull/74, with this PR we can finally shut down servers - at least if clients are "well behaved".

Client-side this PR introduces a `QuackClientConnection`. This is effectively a wrapper for managing clients that want to send requests to a specific `ConnectionId` server-side. We keep this around both (1) in the `QuackCatalog`, and (2) in the `QuackScanBindData`. We can use this class as a client cache as well - and this class supersedes the two instances of client caches we had (the "raw client" sitting in the `QuackCatalog`, and the "initial_client" in the bind data).

The idea is that we manage whether or not we need a specific connection through the lifetime of the `QuackClientConnection`. When the `QuackClientConnection` goes out of scope, it tries to play nice by sending a `DisconnectMessage` to the server. We only do this if we have a client sitting around we can use to send the message - we don't create a new connection just to send the disconnect message.

By doing this we can finally automatically close the server when the database instance goes out of scope. The reason this was not possible before is that the server keeps the database alive through this reference cycle:

* `QuackServer -> QuackConnection`
* `QuackConnection -> DatabaseInstance`
* `DatabaseInstance -> QuackServer`

So as long as there are any connections still alive, the `QuackServer` will never be destroyed (unless the entire database goes out of scope). When running many tests in our test runner this pops up as the OS running out of threads after ~100 tests (hitting a 10K thread limit as every server starts 128 threads).