### PR TITLE
Use a client wrapper to ensure all quack clients are returned to the cache

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -10,13 +10,12 @@
 
 namespace duckdb {
 class QuackClientConnection;
+struct QuackClientWrapper;
 
 class QuackClient {
 public:
-	explicit QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_p), uri(uri_p) {
-	}
-	virtual ~QuackClient() {
-	}
+	explicit QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p);
+	virtual ~QuackClient();
 
 	template <class TARGET>
 	unique_ptr<TARGET> Request(optional_ptr<ClientContext> context, unique_ptr<QuackMessage> request_message) {
@@ -49,9 +48,10 @@ private:
 	                                                 unique_ptr<QuackMessage> request_message) = 0;
 };
 
-class QuackClientConnection {
+class QuackClientConnection : public enable_shared_from_this<QuackClientConnection> {
 public:
-	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p);
+	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
+	                               idx_t max_connections_cached = 1);
 	~QuackClientConnection();
 
 	const string &ConnectionId() const {
@@ -62,15 +62,27 @@ public:
 	}
 
 	//! Get a client (either a cached one, or open a new one if required)
-	unique_ptr<QuackClient> GetClient(ClientContext &context) const;
+	unique_ptr<QuackClientWrapper> GetClient(ClientContext &context) const;
 	//! Return a client back to the cache
-	void StoreClient(unique_ptr<QuackClient> client_p);
+	void StoreClient(unique_ptr<QuackClient> client_p) const;
 
 private:
 	QuackUri uri;
 	string connection_id;
 	mutable mutex lock;
 	mutable vector<unique_ptr<QuackClient>> cached_clients;
+	idx_t max_connections_cached;
+};
+
+struct QuackClientWrapper {
+	QuackClientWrapper(unique_ptr<QuackClient> client, shared_ptr<const QuackClientConnection> client_connection);
+	~QuackClientWrapper();
+
+	QuackClient &GetClient();
+
+private:
+	unique_ptr<QuackClient> client;
+	shared_ptr<const QuackClientConnection> client_connection;
 };
 
 class HttpsQuackClient : public QuackClient {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -35,6 +35,7 @@ struct QuackConnection {
 class QuackServer {
 public:
 	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
+	virtual ~QuackServer();
 
 	//! Stop accepting new connections (close the listener socket) without
 	//! joining listener threads. Safe to call from a request-handler thread —
@@ -63,8 +64,6 @@ public:
 	const string &Token() {
 		return token;
 	}
-
-	virtual ~QuackServer();
 
 protected:
 	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -6,13 +6,18 @@
 #include "quack_uri.hpp"
 
 namespace duckdb {
-
 template <class T>
 string GetUriPart(T ele) {
 	if (ele.afterLast - ele.first < 1) {
 		throw InvalidInputException("Invalid URI");
 	}
 	return string(ele.first, ele.afterLast - ele.first);
+}
+
+QuackClient::QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_p), uri(uri_p) {
+}
+
+QuackClient::~QuackClient() {
 }
 
 HttpsQuackClient::HttpsQuackClient(DatabaseInstance &db, const QuackUri &uri_p) : QuackClient(db, uri_p) {};
@@ -130,10 +135,11 @@ unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const Qua
 	return GetClient(*context.db, uri);
 }
 
-QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p)
-    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)) {
+QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
+                                             idx_t max_connections_cached)
+    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)), max_connections_cached(max_connections_cached) {
 	if (client_p) {
-		cached_clients.push_back(std::move(client_p));
+		StoreClient(std::move(client_p));
 	}
 }
 
@@ -175,20 +181,40 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id));
 }
 
-unique_ptr<QuackClient> QuackClientConnection::GetClient(ClientContext &context) const {
+unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &context) const {
 	lock_guard<mutex> guard(lock);
+	unique_ptr<QuackClient> result;
 	if (!cached_clients.empty()) {
-		auto result = std::move(cached_clients.back());
+		// use client from the cache
+		result = std::move(cached_clients.back());
 		cached_clients.pop_back();
-		return result;
+	} else {
+		// instantiate a new client
+		result = QuackClient::GetClient(context, uri);
 	}
-	// instantiate a new client and return it
-	return QuackClient::GetClient(context, uri);
+	return make_uniq<QuackClientWrapper>(std::move(result), shared_from_this());
 }
 
-void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) {
+void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) const {
 	lock_guard<mutex> guard(lock);
+	if (cached_clients.size() >= max_connections_cached) {
+		// already exceeded max cache size
+		return;
+	}
 	cached_clients.push_back(std::move(client_p));
+}
+
+QuackClientWrapper::QuackClientWrapper(unique_ptr<QuackClient> client_p,
+                                       shared_ptr<const QuackClientConnection> client_connection_p)
+    : client(std::move(client_p)), client_connection(std::move(client_connection_p)) {
+}
+
+QuackClientWrapper::~QuackClientWrapper() {
+	client_connection->StoreClient(std::move(client));
+}
+
+QuackClient &QuackClientWrapper::GetClient() {
+	return *client;
 }
 
 } // namespace duckdb

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -43,9 +43,10 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	bind_data->client_connection = QuackClient::ConnectToServer(context, server_uri, token);
 	auto &client_connection = *bind_data->client_connection;
 
-	auto client = client_connection.GetClient(context);
+	auto client_wrapper = client_connection.GetClient(context);
+	auto &client = client_wrapper->GetClient();
 
-	auto bind_response = client->Request<PrepareResponseMessage>(
+	auto bind_response = client.Request<PrepareResponseMessage>(
 	    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(), query));
 
 	return_types = bind_response->Types();
@@ -53,9 +54,6 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 
 	bind_data->results = std::move(bind_response->MutableResults());
 	bind_data->needs_more_fetch = bind_response->NeedsMoreFetch();
-
-	// store the initial client for later re-use
-	client_connection.StoreClient(std::move(client));
 
 	return bind_data;
 }
@@ -91,10 +89,10 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 	auto query = input.inputs[1].GetValue<string>();
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = catalog.GetClientConnection();
-	auto client = bind_data->client_connection->GetClient(context);
-	auto bind_response = client->Request<PrepareResponseMessage>(
+	auto client_wrapper = bind_data->client_connection->GetClient(context);
+	auto &client = client_wrapper->GetClient();
+	auto bind_response = client.Request<PrepareResponseMessage>(
 	    context, make_uniq<PrepareRequestMessage>(bind_data->client_connection->ConnectionId(), query));
-	bind_data->client_connection->StoreClient(std::move(client));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -127,7 +125,7 @@ private:
 };
 
 struct QuackScanLocalState : public LocalTableFunctionState {
-	unique_ptr<QuackClient> client;
+	unique_ptr<QuackClientWrapper> client_wrapper;
 	//! batch_index of the batch that `fetched_results` currently holds chunks from (server-assigned).
 	//! Surfaced to DuckDB via get_partition_data so downstream order-preserving operators
 	//! (CTAS, COPY TO, INSERT SELECT) can run the scan in parallel without losing order.
@@ -249,8 +247,9 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
 		auto &client_connection = *bind_data.client_connection;
-		auto client = client_connection.GetClient(context);
-		auto response_message = client->Request<PrepareResponseMessage>(
+		auto client_wrapper = client_connection.GetClient(context);
+		auto &client = client_wrapper->GetClient();
+		auto response_message = client.Request<PrepareResponseMessage>(
 		    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(), query));
 		needs_more_fetch = response_message->NeedsMoreFetch();
 		// fetch the result
@@ -258,7 +257,6 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 			auto &chunk = chunk_ref->Chunk();
 			results.emplace_back(chunk, ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
 		}
-		client_connection.StoreClient(std::move(client));
 	} else {
 		for (auto &chunk_ref : bind_data.results) {
 			auto &chunk = chunk_ref->Chunk();
@@ -278,7 +276,7 @@ unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context
 	auto local_state = make_uniq<QuackScanLocalState>();
 
 	// re-use initial client from bind if possible
-	local_state->client = bind_data.client_connection->GetClient(context.client);
+	local_state->client_wrapper = bind_data.client_connection->GetClient(context.client);
 	auto results = global_state.TryGetResults();
 	for (auto &chunk : results) {
 		local_state->results.push(std::move(chunk));
@@ -320,7 +318,8 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 
 		// if that did not work, we request more results
 		if (local_state.results.empty() && global_state.needs_more_fetch) {
-			auto fetch_response = local_state.client->Request<FetchResponseMessage>(
+			auto &client = local_state.client_wrapper->GetClient();
+			auto fetch_response = client.Request<FetchResponseMessage>(
 			    context, make_uniq<FetchRequestMessage>(bind_data.client_connection->ConnectionId()));
 
 			if (fetch_response->MutableResults().empty()) {

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -69,15 +69,14 @@ unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(ClientCont
 	// FIXME this will break with many results!
 	auto chunk_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
 	// get a client to query
-	auto client = client_connection->GetClient(context);
+	auto client_wrapper = client_connection->GetClient(context);
+	auto &client = client_wrapper->GetClient();
 	auto response =
-	    client->Request<PrepareResponseMessage>(context, make_uniq<PrepareRequestMessage>(GetConnectionId(), query));
+	    client.Request<PrepareResponseMessage>(context, make_uniq<PrepareRequestMessage>(GetConnectionId(), query));
 	chunk_collection->Initialize(response->Types());
 	for (auto &chunk : response->MutableResults()) {
 		chunk_collection->Append(chunk->Chunk());
 	}
-	// move the client back to the connection cache
-	client_connection->StoreClient(std::move(client));
 	return chunk_collection;
 }
 

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -62,9 +62,9 @@ SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	                                                      std::move(chunk_wrapper));
 
 	auto client_connection = quack_catalog.GetClientConnection();
-	auto client = client_connection->GetClient(context.client);
-	client->Request<SuccessResponse>(context.client, std::move(append_message));
-	client_connection->StoreClient(std::move(client));
+	auto client_wrapper = client_connection->GetClient(context.client);
+	auto &client = client_wrapper->GetClient();
+	client.Request<SuccessResponse>(context.client, std::move(append_message));
 
 	global_state.insert_count += chunk.size();
 	return SinkResultType::NEED_MORE_INPUT;


### PR DESCRIPTION
Follow-up to https://github.com/duckdb/duckdb-quack/pull/80

We use a client wrapper to avoid having to manually call `StoreClient` - this ensures all opened clients are returned to the cache. In order to avoid the caches from growing indefinitely we limit the size explicitly (default to 1 client).