### PR TITLE
Add quack_server_list table function (list locally available servers)

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -65,6 +65,15 @@ public:
 		return token;
 	}
 
+	const QuackUri &ListenUri() const {
+		return uri;
+	}
+
+	idx_t ActiveConnectionCount() {
+		std::lock_guard<std::mutex> lock(active_connections_mutex);
+		return active_connections.size();
+	}
+
 protected:
 	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);
 	unique_ptr<QuackMessage> HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
@@ -102,6 +111,5 @@ private:
 	unique_ptr<duckdb_httplib::Server> server;
 	bool is_running = false;
 };
-;
 
 } // namespace duckdb

--- a/src/include/quack_startstop.hpp
+++ b/src/include/quack_startstop.hpp
@@ -14,4 +14,9 @@ public:
 	static TableFunction GetFunction();
 };
 
+class QuackServerListFunction {
+public:
+	static TableFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/src/include/quack_storage.hpp
+++ b/src/include/quack_storage.hpp
@@ -20,6 +20,16 @@ public:
 	QuackServer &CreateServer(ClientContext &context, const QuackUri &listen_uri, const string &token);
 	bool StopServer(ClientContext &context, const QuackUri &listen_uri);
 
+	struct ServerSnapshot {
+		string listen_uri;
+		string listen_url;
+		string host;
+		uint16_t port;
+		idx_t active_connections;
+		vector<std::pair<string, string>> info;
+	};
+	vector<ServerSnapshot> ListServers();
+
 	static constexpr const char *STORAGE_EXTENSION_KEY = "quack";
 
 private:

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -114,6 +114,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackScanByNameFunction::GetFunction());
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());
+	loader.RegisterFunction(QuackServerListFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
 
 	// the default authentication function

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -119,3 +119,57 @@ static void QuackStop(ClientContext &context, TableFunctionInput &data_p, DataCh
 TableFunction QuackStopFunction::GetFunction() {
 	return TableFunction("quack_stop", {LogicalType::VARCHAR}, QuackStop, QuackStopBind);
 }
+
+struct QuackServerListFunctionData : public TableFunctionData {
+	bool finished = false;
+};
+
+static unique_ptr<FunctionData> QuackServerListBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("listen_uri");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("listen_url");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("host");
+	return_types.emplace_back(LogicalType::USMALLINT);
+	names.emplace_back("port");
+	return_types.emplace_back(LogicalType::UBIGINT);
+	names.emplace_back("active_connections");
+	return_types.emplace_back(LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR));
+	names.emplace_back("info");
+	return make_uniq<QuackServerListFunctionData>();
+}
+
+static void QuackServerList(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->CastNoConst<QuackServerListFunctionData>();
+	if (bind_data.finished) {
+		return;
+	}
+	auto snapshots = QuackStorageExtensionInfo::GetState(*context.db).ListServers();
+	idx_t row = 0;
+	for (auto &s : snapshots) {
+		output.SetValue(0, row, Value(s.listen_uri));
+		output.SetValue(1, row, Value(s.listen_url));
+		output.SetValue(2, row, Value(s.host));
+		output.SetValue(3, row, Value::USMALLINT(s.port));
+		output.SetValue(4, row, Value::UBIGINT(s.active_connections));
+		vector<Value> keys;
+		vector<Value> values;
+		keys.reserve(s.info.size());
+		values.reserve(s.info.size());
+		for (auto &kv : s.info) {
+			keys.emplace_back(Value(kv.first));
+			values.emplace_back(Value(kv.second));
+		}
+		output.SetValue(5, row,
+		                Value::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR, std::move(keys), std::move(values)));
+		row++;
+	}
+	output.SetCardinality(row);
+	bind_data.finished = true;
+}
+
+TableFunction QuackServerListFunction::GetFunction() {
+	return TableFunction("quack_server_list", {}, QuackServerList, QuackServerListBind);
+}

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -32,6 +32,24 @@ QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, con
 	return *servers[key];
 }
 
+vector<QuackStorageExtensionInfo::ServerSnapshot> QuackStorageExtensionInfo::ListServers() {
+	vector<ServerSnapshot> result;
+	std::lock_guard<std::mutex> lock(servers_mutex);
+	result.reserve(servers.size());
+	for (auto &kv : servers) {
+		auto &uri = kv.second->ListenUri();
+		ServerSnapshot snap;
+		snap.listen_uri = uri.Uri();
+		snap.listen_url = uri.Http();
+		snap.host = uri.Host();
+		snap.port = uri.Port();
+		snap.active_connections = kv.second->ActiveConnectionCount();
+		snap.info.emplace_back("ipv6", uri.IPv6() ? "true" : "false");
+		result.push_back(std::move(snap));
+	}
+	return result;
+}
+
 bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUri &listen_uri) {
 	unique_ptr<QuackServer> to_destroy;
 	{

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -1,0 +1,63 @@
+# name: test/sql/server_list.test
+# description: quack_server_list returns rows for active servers
+# group: [quack]
+
+require quack
+
+require httpfs
+
+# empty initially
+query I
+SELECT count(*) FROM quack_server_list();
+----
+0
+
+# one server
+statement ok
+FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+1
+
+query IIIII
+SELECT listen_uri, listen_url, host, port, active_connections FROM quack_server_list();
+----
+quack:127.0.0.1:9494	http://127.0.0.1:9494	127.0.0.1	9494	0
+
+# info map carries ipv6 flag
+query I
+SELECT info['ipv6'] FROM quack_server_list();
+----
+false
+
+# add a second server, verify count and ordering-agnostic content
+statement ok
+FROM quack_serve('quack:127.0.0.1:9495', token='abcd');
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+2
+
+query I
+SELECT count(*) FROM quack_server_list() WHERE listen_uri = 'quack:127.0.0.1:9494';
+----
+1
+
+query I
+SELECT count(*) FROM quack_server_list() WHERE listen_uri = 'quack:127.0.0.1:9495';
+----
+1
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:9494');
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:9495');
+
+query I
+SELECT count(*) FROM quack_server_list();
+----
+0


### PR DESCRIPTION
Simpler version than https://github.com/duckdb/duckdb-quack/pull/65, no table-in-out machinery.