### PR TITLE
Make INSERT with default expressions and `INSERT BY NAME` work

### DIFF
--- a/src/include/storage/quack_insert.hpp
+++ b/src/include/storage/quack_insert.hpp
@@ -16,8 +16,7 @@ namespace duckdb {
 class QuackInsert : public PhysicalOperator {
 public:
 	//! INSERT INTO
-	QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table,
-	            physical_index_vector_t<idx_t> column_index_map);
+	QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table);
 	//! CREATE TABLE AS
 	QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
 	            unique_ptr<BoundCreateTableInfo> info);
@@ -28,8 +27,6 @@ public:
 	optional_ptr<SchemaCatalogEntry> schema;
 	//! Create table info, in case of CREATE TABLE AS
 	unique_ptr<BoundCreateTableInfo> info;
-	//! column_index_map
-	physical_index_vector_t<idx_t> column_index_map;
 	//! Whether we can keep the copy alive during Sink calls
 	bool keep_copy_alive = true;
 

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -11,10 +11,8 @@
 
 using namespace duckdb;
 
-QuackInsert::QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table,
-                         physical_index_vector_t<idx_t> column_index_map_p)
-    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, op.types, 1), table(&table), schema(nullptr),
-      column_index_map(std::move(column_index_map_p)) {
+QuackInsert::QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, op.types, 1), table(&table), schema(nullptr) {
 }
 
 QuackInsert::QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
@@ -106,7 +104,10 @@ InsertionOrderPreservingMap<string> QuackInsert::ParamsToString() const {
 PhysicalOperator &QuackCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
                                            optional_ptr<PhysicalOperator> plan) {
 	D_ASSERT(plan);
-	auto &insert = planner.Make<QuackInsert>(op, op.table, op.column_index_map);
+	if (!op.column_index_map.empty()) {
+		plan = planner.ResolveDefaultsProjection(op, *plan);
+	}
+	auto &insert = planner.Make<QuackInsert>(op, op.table);
 	insert.children.push_back(*plan);
 	return insert;
 }


### PR DESCRIPTION
Currently `column_index_map` is ignored which leads to an internal server error when running any insert statement with missing columns. This PR fixes that by calling `ResolveDefaultsProjection` which pushes a projection that resolves default expressions prior to the `INSERT`, making e.g. `INSERT BY NAME` and also `INSERT tbl (col) ...` work correctly.