### PR TITLE
Start batch numbers at 1 (otherwise we get a conflict with the initial batch)

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -28,7 +28,7 @@ struct QuackConnection {
 	unique_ptr<Connection> duckdb_connection;
 	unique_ptr<QueryResult> duckdb_query_result;
 	//! Monotonic counter assigned per FETCH batch — enables order-preserving parallel scans on
-	idx_t next_batch_index = 0;
+	idx_t next_batch_index = 1;
 	string session_id;
 };
 

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -125,6 +125,11 @@ private:
 };
 
 struct QuackScanLocalState : public LocalTableFunctionState {
+	explicit QuackScanLocalState() {
+	}
+	~QuackScanLocalState() override {
+	}
+
 	unique_ptr<QuackClientWrapper> client_wrapper;
 	//! batch_index of the batch that `fetched_results` currently holds chunks from (server-assigned).
 	//! Surfaced to DuckDB via get_partition_data so downstream order-preserving operators
@@ -133,11 +138,6 @@ struct QuackScanLocalState : public LocalTableFunctionState {
 
 	queue<ChunkResult> results;
 	ColumnDataScanState scan_state;
-
-	explicit QuackScanLocalState() {
-	}
-	~QuackScanLocalState() override {
-	}
 };
 
 struct QuackScanGlobalState : GlobalTableFunctionState {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -299,7 +299,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		}
 		// Fresh query → restart batch numbering. Clients' local state is re-initialized on
 		// a new PREPARE, so indices start at 0 again.
-		connection.next_batch_index = 0;
+		connection.next_batch_index = 1;
 
 		Value max_chunks_val;
 		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-quack/issues/67

The initial batch we send implicitly gets batch number 1 - if we start counting at 0 we will hit batch number 1 again, potentially leading to this error if a different thread grabs the second batch in parallel.