### PR TITLE
When we get an error from the server - directly throw that error, instead of wrapping it in an IO error with the expected response

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -22,9 +22,8 @@ public:
 		auto response_message = RequestInternal(context, std::move(request_message));
 		if (response_message->Type() != TARGET::TYPE) {
 			if (response_message->Type() == MessageType::ERROR_RESPONSE) {
-				throw IOException("Expected %s message, got error message instead: %s",
-				                  MessageTypeToString(TARGET::TYPE),
-				                  response_message->Cast<ErrorResponse>().ErrorMessage());
+				// if we get an error throw it immediately
+				response_message->Cast<ErrorResponse>().Error().Throw();
 			}
 			throw IOException("Expected %s message, got %s instead", MessageTypeToString(TARGET::TYPE),
 			                  MessageTypeToString(response_message->Type()));

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -321,7 +321,7 @@ public:
 	static constexpr MessageType TYPE = MessageType::ERROR_RESPONSE;
 	explicit ErrorResponse(ErrorData error_p) : QuackMessage(TYPE), error(std::move(error_p)) {
 	}
-	explicit ErrorResponse(const string &error_p) : QuackMessage(TYPE), error(error_p) {
+	explicit ErrorResponse(const string &error_p) : QuackMessage(TYPE), error(ExceptionType::INVALID_INPUT, error_p) {
 	}
 	template <typename... ARGS>
 	explicit ErrorResponse(const string &msg, ARGS &&...params)

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -65,8 +65,7 @@ static void QuackServe(ClientContext &context, TableFunctionInput &data_p, DataC
 		return;
 	}
 
-	auto &server =
-	    QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
+	QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
 	output.SetValue(0, 0, bind_data.listen_uri.Uri());
 	output.SetValue(1, 0, bind_data.listen_uri.Http());
 	if (bind_data.auth_is_default) {


### PR DESCRIPTION
Currently any error from the server is wrapped into `Expected PREPARE_RESPONSE message, got error message instead: %s`. This can be triggered for many reasons - many directly caused by invalid input from the user. I think we want to just throw the error directly in this case.

Also avoid creating invalid exceptions and instead create `InvalidInputException` when returning an `ErrorResponse` directly.