### PR TITLE
When we trigger an error during append, forward that error to the user - instead of returning a 500 error code

### DIFF
--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -323,7 +323,6 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	}
 
 	case MessageType::FETCH_REQUEST: {
-		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
 		auto &connection = *connection_p;
 		std::unique_lock<std::mutex> lock(connection.lock);
 
@@ -355,8 +354,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 
 		// we never execute this query, but throw it at the authorization function so it can check if this user gets to
 		// insert into this table
-		auto dummy_insert_query = "INSERT INTO " + append_request_message.SchemaName() + "." +
-		                          append_request_message.TableName() + " VALUES (NULL)";
+		auto dummy_insert_query =
+		    StringUtil::Format("INSERT INTO %s.%s VALUES (NULL)", SQLIdentifier(append_request_message.SchemaName()),
+		                       SQLIdentifier(append_request_message.TableName()));
 
 		// TODO do not do this if there is no fun set
 		if (!EvaluateAuthQuery(
@@ -373,9 +373,14 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			                                SQLIdentifier(append_request_message.SchemaName()),
 			                                SQLIdentifier(append_request_message.TableName()));
 		}
-		ColumnDataCollection collection(Allocator::Get(context), append_request_message.AppendChunk().GetTypes());
-		collection.Append(append_request_message.AppendChunk());
-		connection.duckdb_connection->Append(*table_info, collection);
+		try {
+			ColumnDataCollection collection(Allocator::Get(context), append_request_message.AppendChunk().GetTypes());
+			collection.Append(append_request_message.AppendChunk());
+			connection.duckdb_connection->Append(*table_info, collection);
+		} catch (std::exception &ex) {
+			// apend failed - directly pass error to user
+			return make_uniq<ErrorResponse>(ErrorData(ex));
+		}
 		return make_uniq<SuccessResponse>();
 	}
 	default: {

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -1,6 +1,6 @@
 # name: test/sql/server_list.test
 # description: quack_server_list returns rows for active servers
-# group: [quack]
+# group: [sql]
 
 require quack
 


### PR DESCRIPTION
Currently when an append fails for "expected" reasons (e.g. a constraint violation) - we return an error 500 code:

```sql
IO Error: Failed to send message: HTTP Error: Request returned HTTP 500 for HTTP POST to 'http://localhost:9494/quack'
```

This PR changes this so we just directly forward the underlying error to the client.