### PR TITLE
Throw an error when we encounter multiple streaming scans or a streaming scan + insert / CTAS on the same connection id (for now)

### DIFF
--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -28,6 +28,7 @@ public:
 	string GetCatalogType() override {
 		return "quack";
 	}
+	static bool IsQuackScan(const string &name);
 	void Initialize(bool load_builtin) override;
 
 	optional_ptr<CatalogEntry> CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) override;

--- a/src/include/storage/quack_optimizer.hpp
+++ b/src/include/storage/quack_optimizer.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/quack_optimizer.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/config.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
+
+namespace duckdb {
+
+class QuackOptimizer {
+public:
+	static void Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan);
+};
+
+} // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "storage/quack_optimizer.hpp"
 
 #include "include/storage/quack_catalog.hpp"
 #include "quack_extension.hpp"
@@ -195,6 +196,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	};
 	auto whoami_info = DefaultTableFunctionGenerator::CreateTableMacroInfo(whoami_macro);
 	loader.RegisterFunction(*whoami_info);
+
+	OptimizerExtension quack_optimizer;
+	quack_optimizer.optimize_function = QuackOptimizer::Optimize;
+	OptimizerExtension::Register(config, std::move(quack_optimizer));
 }
 
 void QuackExtension::Load(ExtensionLoader &loader) {

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -263,7 +263,6 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 			results.emplace_back(chunk, ChunkResultPushdownType::REQUIRES_PUSHDOWN);
 		}
 	}
-
 	// we only multithread if there is more to fetch
 	return make_uniq<QuackScanGlobalState>(input.column_indexes, input.projection_ids, std::move(results),
 	                                       needs_more_fetch);
@@ -392,4 +391,9 @@ TableFunction QuackScanByNameFunction::GetFunction() {
 	// fun.filter_prune = true;
 	return fun;
 }
+
+bool QuackCatalog::IsQuackScan(const string &name) {
+	return name == "quack_query" || name == "quack_query_by_name";
+}
+
 } // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   quack_catalog.cpp
   quack_catalog_set.cpp
   quack_insert.cpp
+  quack_optimizer.cpp
   quack_table.cpp
   quack_schema.cpp
   quack_transaction.cpp

--- a/src/storage/quack_optimizer.cpp
+++ b/src/storage/quack_optimizer.cpp
@@ -1,0 +1,77 @@
+#include "storage/quack_optimizer.hpp"
+#include "storage/quack_catalog.hpp"
+#include "quack_scan.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_insert.hpp"
+#include "duckdb/planner/operator/logical_create_table.hpp"
+
+namespace duckdb {
+
+struct QuackOperatorInfo {
+	vector<reference<LogicalGet>> scans;
+	idx_t insert_count = 0;
+};
+
+struct QuackOperators {
+	// map of connection id -> operator info
+	unordered_map<string, QuackOperatorInfo> op_info;
+};
+
+void GatherQuackScans(LogicalOperator &op, QuackOperators &result) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		auto &get = op.Cast<LogicalGet>();
+		auto &table_scan = get.function;
+		if (QuackCatalog::IsQuackScan(table_scan.name)) {
+			// add a quack scan
+			auto &bind_data = get.bind_data->Cast<QuackScanBindData>();
+			auto connection_id = bind_data.client_connection->ConnectionId();
+			result.op_info[connection_id].scans.push_back(get);
+		}
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_CREATE_TABLE) {
+		auto &insert = op.Cast<LogicalCreateTable>();
+		auto &catalog = insert.schema.ParentCatalog();
+		if (catalog.GetCatalogType() == "quack") {
+			auto &quack_catalog = catalog.Cast<QuackCatalog>();
+			auto connection_id = quack_catalog.GetConnectionId();
+			result.op_info[connection_id].insert_count += 1;
+		}
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_INSERT) {
+		auto &insert = op.Cast<LogicalInsert>();
+		auto &catalog = insert.table.ParentCatalog();
+		if (catalog.GetCatalogType() == "quack") {
+			auto &quack_catalog = catalog.Cast<QuackCatalog>();
+			auto connection_id = quack_catalog.GetConnectionId();
+			result.op_info[connection_id].insert_count += 1;
+		}
+	}
+	// recurse into children
+	for (auto &child : op.children) {
+		GatherQuackScans(*child, result);
+	}
+}
+
+void QuackOptimizer::Optimize(OptimizerExtensionInput &input, unique_ptr<LogicalOperator> &plan) {
+	// look at the query plan and check if we can enable streaming query scans
+	QuackOperators operators;
+	GatherQuackScans(*plan, operators);
+	if (operators.op_info.empty()) {
+		// no scans
+		return;
+	}
+	for (auto &entry : operators.op_info) {
+		auto &op_info = entry.second;
+		auto multiple_scans = (op_info.scans.size() + op_info.insert_count) > 1;
+		if (!multiple_scans) {
+			continue;
+		}
+		for (auto &_ : op_info.scans) {
+			throw NotImplementedException("Multiple streaming scans or streaming scans + CTAS / insert in the same "
+			                              "query are not currently supported");
+		}
+	}
+}
+
+} // namespace duckdb

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -145,6 +145,5 @@ call quack_stop({server});
 statement error con2
 attach {server} as rpc
 ----
-Database was closed
 
 endloop

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -145,6 +145,6 @@ call quack_stop({server});
 statement error con2
 attach {server} as rpc
 ----
-IO Error
+Database was closed
 
 endloop

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -43,10 +43,10 @@ select count(j) from rpc.main.t2;
 # Two RPC tables in the same query: both call LookupEntry on the same
 # connection_id during planning. The second PREPARE overwrites the first's
 # server-side query result, so the first table's scan fetches 0 rows.
-query II
+statement error
 select count(t1.i), count(t2.j) from rpc.main.t1, rpc.main.t2;
 ----
-20000	20000
+not currently supported
 
 statement ok con2
 detach rpc;


### PR DESCRIPTION
Currently when we do multiple operators that each run a query server-side on the same connection id, we silently allow the query to go through and return incorrect results as queries get short-circuited by other queries. 

This PR fixes this by detecting in the plan if this situation is happening and then throws an error instead.