### PR TITLE
Add a UUID to result sets, and use that in Fetch

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -142,9 +143,10 @@ public:
 	static constexpr MessageType TYPE = MessageType::PREPARE_RESPONSE;
 
 	PrepareResponseMessage(const vector<LogicalType> &types_p, const vector<string> &names_p,
-	                       vector<unique_ptr<DataChunkWrapper>> results_p, bool needs_more_fetch_p)
+	                       vector<unique_ptr<DataChunkWrapper>> results_p, bool needs_more_fetch_p,
+	                       hugeint_t result_uuid)
 	    : QuackMessage(TYPE), result_types(types_p), result_names(names_p), results(std::move(results_p)),
-	      needs_more_fetch(needs_more_fetch_p) {
+	      needs_more_fetch(needs_more_fetch_p), result_uuid(result_uuid) {
 	}
 
 public:
@@ -163,6 +165,9 @@ public:
 	bool NeedsMoreFetch() const {
 		return needs_more_fetch;
 	}
+	hugeint_t ResultUUID() const {
+		return result_uuid;
+	}
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<PrepareResponseMessage> Deserialize(Deserializer &deserializer);
@@ -176,6 +181,7 @@ private:
 	vector<string> result_names;
 	vector<unique_ptr<DataChunkWrapper>> results;
 	bool needs_more_fetch = false;
+	hugeint_t result_uuid;
 };
 
 // TODO this is where auth goes
@@ -221,7 +227,8 @@ class FetchRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_REQUEST;
 
-	explicit FetchRequestMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {
+	explicit FetchRequestMessage(string connection_id_p, hugeint_t uuid)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), uuid(uuid) {
 	}
 
 protected:
@@ -231,6 +238,8 @@ protected:
 public:
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<FetchRequestMessage> Deserialize(Deserializer &deserializer);
+
+	hugeint_t uuid;
 };
 
 class FetchResponseMessage : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -49,6 +49,11 @@
   {
     "class": "FetchRequestMessage",
     "members": [
+      {
+        "id": 1,
+        "name": "uuid",
+        "type": "hugeint_t"
+      }
     ]
   },
   {
@@ -81,9 +86,14 @@
         "id": 4,
         "name": "results",
         "type": "vector<unique_ptr<DataChunkWrapper>>"
+      },
+      {
+        "id": 5,
+        "name": "result_uuid",
+        "type": "hugeint_t"
       }
     ],
-    "constructor": ["result_types", "result_names",  "results", "needs_more_fetch"]
+    "constructor": ["result_types", "result_names",  "results", "needs_more_fetch", "result_uuid"]
   },
   {
     "class": "AppendRequestMessage",

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -28,6 +28,7 @@ struct QuackScanBindData : FunctionData {
 	vector<unique_ptr<DataChunkWrapper>> results;
 	shared_ptr<QuackClientConnection> client_connection;
 	bool needs_more_fetch = true;
+	hugeint_t result_uuid;
 };
 
 class TableFunction;

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -29,6 +29,8 @@ struct QuackConnection {
 	unique_ptr<QueryResult> duckdb_query_result;
 	//! Monotonic counter assigned per FETCH batch — enables order-preserving parallel scans on
 	idx_t next_batch_index = 1;
+	//! Current result UUID
+	hugeint_t result_uuid;
 	string session_id;
 };
 

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -54,6 +54,7 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 
 	bind_data->results = std::move(bind_response->MutableResults());
 	bind_data->needs_more_fetch = bind_response->NeedsMoreFetch();
+	bind_data->result_uuid = bind_response->ResultUUID();
 
 	return bind_data;
 }
@@ -319,7 +320,8 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		if (local_state.results.empty() && global_state.needs_more_fetch) {
 			auto &client = local_state.client_wrapper->GetClient();
 			auto fetch_response = client.Request<FetchResponseMessage>(
-			    context, make_uniq<FetchRequestMessage>(bind_data.client_connection->ConnectionId()));
+			    context,
+			    make_uniq<FetchRequestMessage>(bind_data.client_connection->ConnectionId(), bind_data.result_uuid));
 
 			if (fetch_response->MutableResults().empty()) {
 				// server is done, we are done

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -300,6 +300,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		// Fresh query → restart batch numbering. Clients' local state is re-initialized on
 		// a new PREPARE, so indices start at 0 again.
 		connection.next_batch_index = 1;
+		// generate a random UUID to uniquely identify the result
+		connection.result_uuid = UUID::GenerateRandomUUID();
 
 		Value max_chunks_val;
 		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);
@@ -317,15 +319,18 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(std::move(error_message));
 		}
 		auto needs_more_fetch = results.size() == max_chunks_per_batch;
-		return make_uniq<PrepareResponseMessage>(types, names,
-
-		                                         std::move(results), needs_more_fetch);
+		return make_uniq<PrepareResponseMessage>(types, names, std::move(results), needs_more_fetch,
+		                                         connection.result_uuid);
 	}
 
 	case MessageType::FETCH_REQUEST: {
+		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
 		auto &connection = *connection_p;
 		std::unique_lock<std::mutex> lock(connection.lock);
 
+		if (connection.result_uuid != fetch_request_message.uuid) {
+			return make_uniq<ErrorResponse>("Result has been closed");
+		}
 		if (!connection.duckdb_query_result) {
 			return make_uniq<FetchResponseMessage>();
 		}

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -60,10 +60,12 @@ unique_ptr<ErrorResponse> ErrorResponse::Deserialize(Deserializer &deserializer)
 }
 
 void FetchRequestMessage::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<hugeint_t>(1, "uuid", uuid);
 }
 
 unique_ptr<FetchRequestMessage> FetchRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FetchRequestMessage>(new FetchRequestMessage());
+	deserializer.ReadProperty<hugeint_t>(1, "uuid", result->uuid);
 	return result;
 }
 
@@ -108,6 +110,7 @@ void PrepareResponseMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<string>>(2, "result_names", result_names);
 	serializer.WritePropertyWithDefault<bool>(3, "needs_more_fetch", needs_more_fetch);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results", results);
+	serializer.WriteProperty<hugeint_t>(5, "result_uuid", result_uuid);
 }
 
 unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deserializer &deserializer) {
@@ -115,7 +118,8 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	auto result_names = deserializer.ReadPropertyWithDefault<vector<string>>(2, "result_names");
 	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(3, "needs_more_fetch");
 	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results");
-	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch));
+	auto result_uuid = deserializer.ReadProperty<hugeint_t>(5, "result_uuid");
+	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
 	return result;
 }
 


### PR DESCRIPTION
This is a follow-up fix to https://github.com/duckdb/duckdb-quack/pull/93, to protect against this type of error in the protocol

Essentially when sending a fetch message we have no idea which result set we are fetching from. By adding a `UUID` that is included in the `PrepareResponseMessage`, and then including that UUID again in the `FetchRequestMessage`, the server can know that the fetch was made for an invalid or already closed result set (and could in theory also support keeping around multiple result sets, but not for now).