### PR TITLE
Add DuckDB version and quack version to connect request and response

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -189,12 +189,23 @@ class ConnectionRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_REQUEST;
 
-	explicit ConnectionRequestMessage(const string &auth_string_p) : QuackMessage(TYPE), auth_string(auth_string_p) {
-	}
+	explicit ConnectionRequestMessage(const string &auth_string_p);
 
 public:
 	const string &AuthString() const {
 		return auth_string;
+	}
+	const string &ClientVersion() const {
+		return client_duckdb_version;
+	}
+	const string &ClientPlatform() const {
+		return client_platform;
+	}
+	const idx_t MinimumSupportedQuackVersion() const {
+		return min_supported_quack_version;
+	}
+	const idx_t MaximumSupportedQuackVersion() const {
+		return max_supported_quack_version;
 	}
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ConnectionRequestMessage> Deserialize(Deserializer &deserializer);
@@ -205,22 +216,40 @@ protected:
 
 private:
 	string auth_string;
+	string client_duckdb_version;
+	string client_platform;
+	idx_t min_supported_quack_version;
+	idx_t max_supported_quack_version;
 };
 
 class ConnectionResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_RESPONSE;
 
-	explicit ConnectionResponseMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {
-	}
+	explicit ConnectionResponseMessage(string connection_id_p);
 
 protected:
 	ConnectionResponseMessage() : QuackMessage(TYPE) {
 	}
 
 public:
+	const string &ServerVersion() const {
+		return server_duckdb_version;
+	}
+	const string &ServerPlatform() const {
+		return server_platform;
+	}
+	idx_t QuackVersion() const {
+		return quack_version;
+	}
+
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ConnectionResponseMessage> Deserialize(Deserializer &deserializer);
+
+private:
+	string server_duckdb_version;
+	string server_platform;
+	idx_t quack_version;
 };
 
 class FetchRequestMessage : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -137,12 +137,47 @@
         "id": 1,
         "name": "auth_string",
         "type": "string"
+      },
+      {
+        "id": 2,
+        "name": "client_duckdb_version",
+        "type": "string"
+      },
+      {
+        "id": 3,
+        "name": "client_platform",
+        "type": "string"
+      },
+      {
+        "id": 4,
+        "name": "min_supported_quack_version",
+        "type": "idx_t"
+      },
+      {
+        "id": 5,
+        "name": "max_supported_quack_version",
+        "type": "idx_t"
       }
     ]
   },
   {
     "class": "ConnectionResponseMessage",
     "members": [
+      {
+        "id": 1,
+        "name": "server_duckdb_version",
+        "type": "string"
+      },
+      {
+        "id": 2,
+        "name": "server_platform",
+        "type": "string"
+      },
+      {
+        "id": 3,
+        "name": "quack_version",
+        "type": "idx_t"
+      }
     ]
   }
 ]

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -36,6 +36,9 @@ struct QuackConnection {
 
 class QuackServer {
 public:
+	static constexpr const idx_t QUACK_VERSION = 1;
+
+public:
 	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
 	virtual ~QuackServer();
 

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -5,6 +5,9 @@
 
 #include "quack_message.hpp"
 
+#include "quack_server.hpp"
+#include "duckdb/main/database.hpp"
+
 namespace duckdb {
 
 QuackMessage::QuackMessage(MessageType type) : header(type, string()) {
@@ -142,6 +145,17 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 	result->SetHeader(std::move(header));
 	deserializer.End();
 	return result;
+}
+
+ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p)
+    : QuackMessage(TYPE), auth_string(auth_string_p), client_duckdb_version(DuckDB::LibraryVersion()),
+      client_platform(DuckDB::Platform()), min_supported_quack_version(QuackServer::QUACK_VERSION),
+      max_supported_quack_version(QuackServer::QUACK_VERSION) {
+}
+
+ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p)
+    : QuackMessage(TYPE, std::move(connection_id_p)), server_duckdb_version(DuckDB::LibraryVersion()),
+      server_platform(DuckDB::Platform()), quack_version(QuackServer::QUACK_VERSION) {
 }
 
 unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_stream) {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -257,6 +257,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();
+		if (connection_request_message.MinimumSupportedQuackVersion() > 1ULL) {
+			return make_uniq<ErrorResponse>("Unsupported Quack version - server only supports version 1 of quack");
+		}
 		string session_id = GenerateSessionId();
 		if (!EvaluateAuthQuery(
 		        db, StringUtil::Format("SELECT %s(?, ?, ?)", GetSettingString(db, "quack_authentication_function")),

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -25,19 +25,33 @@ unique_ptr<AppendRequestMessage> AppendRequestMessage::Deserialize(Deserializer 
 
 void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "auth_string", auth_string);
+	serializer.WritePropertyWithDefault<string>(2, "client_duckdb_version", client_duckdb_version);
+	serializer.WritePropertyWithDefault<string>(3, "client_platform", client_platform);
+	serializer.WritePropertyWithDefault<idx_t>(4, "min_supported_quack_version", min_supported_quack_version);
+	serializer.WritePropertyWithDefault<idx_t>(5, "max_supported_quack_version", max_supported_quack_version);
 }
 
 unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ConnectionRequestMessage>(new ConnectionRequestMessage());
 	deserializer.ReadPropertyWithDefault<string>(1, "auth_string", result->auth_string);
+	deserializer.ReadPropertyWithDefault<string>(2, "client_duckdb_version", result->client_duckdb_version);
+	deserializer.ReadPropertyWithDefault<string>(3, "client_platform", result->client_platform);
+	deserializer.ReadPropertyWithDefault<idx_t>(4, "min_supported_quack_version", result->min_supported_quack_version);
+	deserializer.ReadPropertyWithDefault<idx_t>(5, "max_supported_quack_version", result->max_supported_quack_version);
 	return result;
 }
 
 void ConnectionResponseMessage::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(1, "server_duckdb_version", server_duckdb_version);
+	serializer.WritePropertyWithDefault<string>(2, "server_platform", server_platform);
+	serializer.WritePropertyWithDefault<idx_t>(3, "quack_version", quack_version);
 }
 
 unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<ConnectionResponseMessage>(new ConnectionResponseMessage());
+	deserializer.ReadPropertyWithDefault<string>(1, "server_duckdb_version", result->server_duckdb_version);
+	deserializer.ReadPropertyWithDefault<string>(2, "server_platform", result->server_platform);
+	deserializer.ReadPropertyWithDefault<idx_t>(3, "quack_version", result->quack_version);
 	return result;
 }
 


### PR DESCRIPTION
Implements https://github.com/duckdb/duckdb-quack/issues/92

We extend the connect message to contain the following information, in addition to the auth string:

```cpp
string client_duckdb_version; // e.g. v1.5.2
string client_platform; // e.g. "linux_arm64"
idx_t min_supported_quack_version; // e.g. 1
idx_t max_supported_quack_version; // e.g. 1
```

The server rejects any messages that have `min_supported_quack_version > 1`, and ignores all other fields. The connect response is extended to include:

```cpp
string server_duckdb_version; // e.g. v1.5.2
string server_platform; // e.g. "linux_arm64"
idx_t quack_version; // the quack version the server has decided on using, currently always 1
```
