### PR TITLE
Add serialization negotiation

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -19,6 +19,11 @@ public:
 
 	template <class TARGET>
 	unique_ptr<TARGET> Request(optional_ptr<ClientContext> context, unique_ptr<QuackMessage> request_message) {
+		// Stamp the per-connection negotiated version on the outgoing message. The
+		// CONNECTION_REQUEST branch in ToMemoryStream ignores this and always uses
+		// HANDSHAKE_SERIALIZATION_VERSION, so a freshly-constructed QuackClient with
+		// the default value still produces a decodable handshake.
+		request_message->SetOutgoingSerializationVersion(negotiated_serialization_version);
 		auto response_message = RequestInternal(context, std::move(request_message));
 		if (response_message->Type() != TARGET::TYPE) {
 			if (response_message->Type() == MessageType::ERROR_RESPONSE) {
@@ -31,6 +36,10 @@ public:
 		return unique_ptr_cast<QuackMessage, TARGET>(std::move(response_message));
 	}
 
+	void SetNegotiatedSerializationVersion(idx_t version) {
+		negotiated_serialization_version = version;
+	}
+
 	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
@@ -41,6 +50,7 @@ protected:
 	MemoryStream read_stream, write_stream;
 	DatabaseInstance &db;
 	QuackUri uri;
+	idx_t negotiated_serialization_version = QuackMessage::HANDSHAKE_SERIALIZATION_VERSION;
 
 private:
 	virtual unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
@@ -50,6 +60,7 @@ private:
 class QuackClientConnection : public enable_shared_from_this<QuackClientConnection> {
 public:
 	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
+	                               idx_t negotiated_serialization_version_p,
 	                               idx_t max_connections_cached = 1);
 	~QuackClientConnection();
 
@@ -58,6 +69,9 @@ public:
 	}
 	const QuackUri &ServerURI() const {
 		return uri;
+	}
+	idx_t NegotiatedSerializationVersion() const {
+		return negotiated_serialization_version;
 	}
 
 	//! Get a client (either a cached one, or open a new one if required)
@@ -68,6 +82,7 @@ public:
 private:
 	QuackUri uri;
 	string connection_id;
+	idx_t negotiated_serialization_version;
 	mutable mutex lock;
 	mutable vector<unique_ptr<QuackClient>> cached_clients;
 	idx_t max_connections_cached;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -60,8 +60,21 @@ struct MessageHeader {
 
 class QuackMessage {
 public:
+	//! Highest serialization version v1.5.x supports. CONNECTION_REQUEST is always
+	//! encoded at this version so a v1.5.x peer can decode the handshake before any
+	//! version negotiation has happened.
+	static constexpr idx_t HANDSHAKE_SERIALIZATION_VERSION = 7;
+
 	void ToMemoryStream(MemoryStream &write_stream) const;
 	static unique_ptr<QuackMessage> FromMemoryStream(MemoryStream &read_stream);
+
+	//! Per-message override of the serialization version used by ToMemoryStream.
+	void SetOutgoingSerializationVersion(idx_t version) {
+		outgoing_serialization_version = version;
+	}
+	idx_t OutgoingSerializationVersion() const {
+		return outgoing_serialization_version;
+	}
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -113,6 +126,7 @@ protected:
 
 private:
 	MessageHeader header;
+	idx_t outgoing_serialization_version = HANDSHAKE_SERIALIZATION_VERSION;
 };
 
 class PrepareRequestMessage : public QuackMessage {
@@ -207,6 +221,9 @@ public:
 	const idx_t MaximumSupportedQuackVersion() const {
 		return max_supported_quack_version;
 	}
+	idx_t ClientMaxSerializationVersion() const {
+		return client_max_serialization_version;
+	}
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ConnectionRequestMessage> Deserialize(Deserializer &deserializer);
 
@@ -220,13 +237,14 @@ private:
 	string client_platform;
 	idx_t min_supported_quack_version;
 	idx_t max_supported_quack_version;
+	idx_t client_max_serialization_version;
 };
 
 class ConnectionResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_RESPONSE;
 
-	explicit ConnectionResponseMessage(string connection_id_p);
+	ConnectionResponseMessage(string connection_id_p, idx_t negotiated_serialization_version_p);
 
 protected:
 	ConnectionResponseMessage() : QuackMessage(TYPE) {
@@ -242,6 +260,9 @@ public:
 	idx_t QuackVersion() const {
 		return quack_version;
 	}
+	idx_t NegotiatedSerializationVersion() const {
+		return negotiated_serialization_version;
+	}
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ConnectionResponseMessage> Deserialize(Deserializer &deserializer);
@@ -250,6 +271,7 @@ private:
 	string server_duckdb_version;
 	string server_platform;
 	idx_t quack_version;
+	idx_t negotiated_serialization_version;
 };
 
 class FetchRequestMessage : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -157,6 +157,11 @@
         "id": 5,
         "name": "max_supported_quack_version",
         "type": "idx_t"
+      },
+      {
+        "id": 6,
+        "name": "client_max_serialization_version",
+        "type": "idx_t"
       }
     ]
   },
@@ -176,6 +181,11 @@
       {
         "id": 3,
         "name": "quack_version",
+        "type": "idx_t"
+      },
+      {
+        "id": 4,
+        "name": "negotiated_serialization_version",
         "type": "idx_t"
       }
     ]

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 
+#include "quack_message.hpp"
 #include "quack_uri.hpp"
 
 #include "httplib.hpp" // TODO forward declare
@@ -32,6 +33,9 @@ struct QuackConnection {
 	//! Current result UUID
 	hugeint_t result_uuid;
 	string session_id;
+	//! Negotiated DuckDB serialization version for all post-handshake messages on this
+	//! connection (= min(client_max, server_max), where server_max = SerializationCompatibility::Latest()).
+	idx_t negotiated_serialization_version = QuackMessage::HANDSHAKE_SERIALIZATION_VERSION;
 };
 
 class QuackServer {
@@ -54,7 +58,7 @@ public:
 	virtual void Close() {};
 
 	shared_ptr<QuackConnection> GetConnection(const string &connection_id);
-	string CreateNewConnection(const string &session_id);
+	string CreateNewConnection(const string &session_id, idx_t negotiated_serialization_version);
 	bool DisconnectConnection(const string &session_id);
 	// TODO need something to destroy connections
 

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -137,9 +137,13 @@ unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const Qua
 }
 
 QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
+                                             idx_t negotiated_serialization_version_p,
                                              idx_t max_connections_cached)
-    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)), max_connections_cached(max_connections_cached) {
+    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)),
+      negotiated_serialization_version(negotiated_serialization_version_p),
+      max_connections_cached(max_connections_cached) {
 	if (client_p) {
+		client_p->SetNegotiatedSerializationVersion(negotiated_serialization_version);
 		StoreClient(std::move(client_p));
 	}
 }
@@ -179,7 +183,9 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	// success! we got a connection id
 	// construct the client connection and return it
 	auto connection_id = connection_request_response->ConnectionId();
-	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id));
+	auto negotiated_serialization_version = connection_request_response->NegotiatedSerializationVersion();
+	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id),
+	                                              negotiated_serialization_version);
 }
 
 unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &context) const {
@@ -193,6 +199,7 @@ unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &c
 		// instantiate a new client
 		result = QuackClient::GetClient(context, uri);
 	}
+	result->SetNegotiatedSerializationVersion(negotiated_serialization_version);
 	return make_uniq<QuackClientWrapper>(std::move(result), shared_from_this());
 }
 

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -91,7 +91,12 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	write_stream.Rewind();
 	SerializationOptions options;
-	options.serialization_compatibility = SerializationCompatibility::FromIndex(10);
+	// CONNECTION_REQUEST is always encoded at HANDSHAKE_SERIALIZATION_VERSION so an
+	// older peer can decode the handshake; everything else uses the per-connection
+	// negotiated version that the sender stamped on the message before serializing.
+	idx_t version = header.type == MessageType::CONNECTION_REQUEST ? HANDSHAKE_SERIALIZATION_VERSION
+	                                                               : outgoing_serialization_version;
+	options.serialization_compatibility = SerializationCompatibility::FromIndex(version);
 	BinarySerializer serializer(write_stream, options);
 
 	// write the header
@@ -150,12 +155,15 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p)
     : QuackMessage(TYPE), auth_string(auth_string_p), client_duckdb_version(DuckDB::LibraryVersion()),
       client_platform(DuckDB::Platform()), min_supported_quack_version(QuackServer::QUACK_VERSION),
-      max_supported_quack_version(QuackServer::QUACK_VERSION) {
+      max_supported_quack_version(QuackServer::QUACK_VERSION),
+      client_max_serialization_version(SerializationCompatibility::Latest().serialization_version) {
 }
 
-ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p)
+ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p,
+                                                     idx_t negotiated_serialization_version_p)
     : QuackMessage(TYPE, std::move(connection_id_p)), server_duckdb_version(DuckDB::LibraryVersion()),
-      server_platform(DuckDB::Platform()), quack_version(QuackServer::QUACK_VERSION) {
+      server_platform(DuckDB::Platform()), quack_version(QuackServer::QUACK_VERSION),
+      negotiated_serialization_version(negotiated_serialization_version_p) {
 }
 
 unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_stream) {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -44,7 +44,7 @@ shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_
 	return nullptr;
 }
 
-string QuackServer::CreateNewConnection(const string &session_id) {
+string QuackServer::CreateNewConnection(const string &session_id, idx_t negotiated_serialization_version) {
 	std::lock_guard<std::mutex> lock(active_connections_mutex);
 
 	D_ASSERT(active_connections.find(session_id) == active_connections.end());
@@ -56,6 +56,7 @@ string QuackServer::CreateNewConnection(const string &session_id) {
 	auto new_connection = make_shared_ptr<QuackConnection>(session_id);
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
+	new_connection->negotiated_serialization_version = negotiated_serialization_version;
 	// new_connection->duckdb_connection->context->config.streaming_buffer_size = 10 * 1000000; // 10 MB
 	active_connections[session_id] = std::move(new_connection);
 	return session_id;
@@ -214,6 +215,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	// process the message
 	auto response = HandleMessageInternal(*db, *received_message, connection);
 
+	// Stamp the negotiated serialization version on the response so it is sent at the
+	// per-connection version. CONNECTION_REQUEST handling stamps the response itself
+	if (connection) {
+		response->SetOutgoingSerializationVersion(connection->negotiated_serialization_version);
+	}
+
 	if (should_log) {
 		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 		                       .time_since_epoch()
@@ -266,7 +273,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		        Value(session_id), Value(connection_request_message.AuthString()), Value(Token()))) {
 			return make_uniq<ErrorResponse>("Authentication failed");
 		}
-		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id));
+		idx_t server_max = SerializationCompatibility::Latest().serialization_version;
+		idx_t negotiated = MinValue<idx_t>(connection_request_message.ClientMaxSerializationVersion(), server_max);
+		auto response = make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id, negotiated), negotiated);
+		response->SetOutgoingSerializationVersion(negotiated);
+		return response;
 	}
 	case MessageType::DISCONNECT_MESSAGE: {
 		auto &connection = *connection_p;

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -29,6 +29,7 @@ void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(3, "client_platform", client_platform);
 	serializer.WritePropertyWithDefault<idx_t>(4, "min_supported_quack_version", min_supported_quack_version);
 	serializer.WritePropertyWithDefault<idx_t>(5, "max_supported_quack_version", max_supported_quack_version);
+	serializer.WritePropertyWithDefault<idx_t>(6, "client_max_serialization_version", client_max_serialization_version);
 }
 
 unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -38,6 +39,7 @@ unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deser
 	deserializer.ReadPropertyWithDefault<string>(3, "client_platform", result->client_platform);
 	deserializer.ReadPropertyWithDefault<idx_t>(4, "min_supported_quack_version", result->min_supported_quack_version);
 	deserializer.ReadPropertyWithDefault<idx_t>(5, "max_supported_quack_version", result->max_supported_quack_version);
+	deserializer.ReadPropertyWithDefault<idx_t>(6, "client_max_serialization_version", result->client_max_serialization_version);
 	return result;
 }
 
@@ -45,6 +47,7 @@ void ConnectionResponseMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "server_duckdb_version", server_duckdb_version);
 	serializer.WritePropertyWithDefault<string>(2, "server_platform", server_platform);
 	serializer.WritePropertyWithDefault<idx_t>(3, "quack_version", quack_version);
+	serializer.WritePropertyWithDefault<idx_t>(4, "negotiated_serialization_version", negotiated_serialization_version);
 }
 
 unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Deserializer &deserializer) {
@@ -52,6 +55,7 @@ unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Des
 	deserializer.ReadPropertyWithDefault<string>(1, "server_duckdb_version", result->server_duckdb_version);
 	deserializer.ReadPropertyWithDefault<string>(2, "server_platform", result->server_platform);
 	deserializer.ReadPropertyWithDefault<idx_t>(3, "quack_version", result->quack_version);
+	deserializer.ReadPropertyWithDefault<idx_t>(4, "negotiated_serialization_version", result->negotiated_serialization_version);
 	return result;
 }
 


### PR DESCRIPTION
Idea is changing from a fixed serialization version (hardcoded in the extension, and potentially different between server and client) to negotiating the minimum. 

On the 1st request  (`CONNECT_REQUEST`, sent by the client): serialization version is fixed to 7, and as additional payload the max_supported_client (say 7 for `v1.5.2`, but 8 for current `main`) is also sent
On the 1st response (`CONNECTION_RESPONSE`, sent by the server): the negotiaded one (that is min(max_supported_client, max_supported_server)), is used to serialize the message, that does contain explicitly the negotiated version
Following requests (`*_REQUEST | *_RESPONSES`): the negotiated one is used, that should then be compatible.

Note, even on repeated contact to the same server, negotiation happens on every CONNECT, and 7 is used. As an optimization, one can opt-in to a higher version caching by endpoint, but that's not done.