### PR TITLE
Restore skipped test, and avoid test/sql/server_list.test in Windows

### DIFF
--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -2,6 +2,8 @@
 # description: quack_server_list returns rows for active servers
 # group: [sql]
 
+require notwindows
+
 require quack
 
 require httpfs

--- a/test/sql/whoami.test
+++ b/test/sql/whoami.test
@@ -2,8 +2,6 @@
 # description: whoami() / quack_identify contract
 # group: [sql]
 
-mode skip
-
 require quack
 
 require json


### PR DESCRIPTION
…(to be investigated)

I am not sure why `test/sql/server_list.test` seems to block somehow in Windows. Needs review, but that should not block publishing.