### PR TITLE
Force SerializationCompatibility to 7 (compatible with >= v1.5.0)

### DIFF
--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -91,7 +91,7 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	write_stream.Rewind();
 	SerializationOptions options;
-	options.serialization_compatibility = SerializationCompatibility::FromIndex(10);
+	options.serialization_compatibility = SerializationCompatibility::FromIndex(7);
 	BinarySerializer serializer(write_stream, options);
 
 	// write the header


### PR DESCRIPTION
This makes so `quack` is properly compatible cross duckdb versions, by using the common denominator that is the SerializationCompatibility version for v1.5.0.

Note: this would need to become a function of quack version, but while understanding what's the proper shape, let's keep it simple.