### PR TITLE
No excluded platforms

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,7 +19,6 @@ jobs:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
       extension_name: quack
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
 
   code-quality-check:
     name: Code Quality Check
@@ -39,6 +38,5 @@ jobs:
       extension_name: quack
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
-      exclude_archs: 'windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Note: I have NOT tested this, it would be handy to do so before merge (possibly pushing on a duckdb-quack branch, and then deleting it).