### PR TITLE
Add `whoami_random_name()` to generate random readable name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   quack_http_server.cpp
   quack_log.cpp
   quack_message.cpp
+  quack_namegen.cpp
   quack_scan.cpp
   quack_server.cpp
   quack_start_stop.cpp

--- a/src/include/quack_namegen.hpp
+++ b/src/include/quack_namegen.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+string GenerateWhoamiName();
+
+ScalarFunction GetWhoamiRandomNameFunction();
+
+} // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -15,6 +15,7 @@
 #include "include/storage/quack_catalog.hpp"
 #include "quack_extension.hpp"
 #include "quack_log.hpp"
+#include "quack_namegen.hpp"
 #include "quack_scan.hpp"
 #include "quack_startstop.hpp"
 #include "quack_storage.hpp"
@@ -134,6 +135,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(rpc_authorization);
 
 	loader.RegisterFunction(QuackParseUriFunction::GetFunction());
+	loader.RegisterFunction(GetWhoamiRandomNameFunction());
 
 	RegisterQuackSecretType(loader);
 
@@ -161,7 +163,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	// whoami() identity fields — global settings so they propagate across all sessions
 	// (quack_query creates fresh server-side sessions that wouldn't see per-connection state).
-	config.AddExtensionOption("whoami_name", "Human-readable name for this node", LogicalType::VARCHAR, Value(""));
+	config.AddExtensionOption("whoami_name", "Human-readable name for this node", LogicalType::VARCHAR,
+	                          Value(GenerateWhoamiName()));
 	config.AddExtensionOption("whoami_provider", "Deployment provider (ec2, docker, local, ...)", LogicalType::VARCHAR,
 	                          Value(""));
 	config.AddExtensionOption("whoami_hostname", "Network hostname / public address", LogicalType::VARCHAR, Value(""));

--- a/src/quack_namegen.cpp
+++ b/src/quack_namegen.cpp
@@ -1,0 +1,55 @@
+#include "quack_namegen.hpp"
+
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+
+#include <cstdio>
+#include <random>
+
+namespace duckdb {
+
+namespace {
+
+constexpr const char *ADJECTIVES[] = {
+    "brave",   "bold",   "swift",  "sleek",  "gentle", "jolly",  "merry",  "plucky",
+    "scrappy", "hardy",  "sturdy", "witty",  "clever", "quick",  "sharp",  "eager",
+    "glossy",  "downy",  "dapper", "jaunty", "cheery", "mellow", "snug",   "crisp",
+    "golden",  "silver", "copper", "sunny",  "sleepy", "dreamy", "zesty",  "bright"};
+
+constexpr const char *DUCKS[] = {
+    "mallard",   "pintail",  "wigeon",   "teal",      "shoveler",  "gadwall",
+    "canvasback","scaup",    "goldeneye","bufflehead","merganser", "eider",
+    "mandarin",  "muscovy",  "pochard",  "smew",      "garganey",  "ringneck",
+    "redhead",   "harlequin","shelduck", "whistler",  "steamer",   "torrent",
+    "drake",     "rouen",    "cayuga",   "aylesbury", "nivis",     "eatoni",
+    "andium",    "variegata"};
+
+constexpr size_t N_ADJ = sizeof(ADJECTIVES) / sizeof(ADJECTIVES[0]);
+constexpr size_t N_DUCK = sizeof(DUCKS) / sizeof(DUCKS[0]);
+
+} // namespace
+
+string GenerateWhoamiName() {
+	std::random_device rd;
+	const char *adj = ADJECTIVES[rd() % N_ADJ];
+	const char *duck = DUCKS[rd() % N_DUCK];
+	char suffix[3];
+	snprintf(suffix, sizeof(suffix), "%02x", static_cast<unsigned>(rd() & 0xFFu));
+	return string(adj) + "-" + duck + "-" + suffix;
+}
+
+static void WhoamiRandomNameFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	const auto count = args.size();
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto out = FlatVector::GetData<string_t>(result);
+	for (idx_t i = 0; i < count; i++) {
+		out[i] = StringVector::AddString(result, GenerateWhoamiName());
+	}
+}
+
+ScalarFunction GetWhoamiRandomNameFunction() {
+	ScalarFunction fn("whoami_random_name", {}, LogicalType::VARCHAR, WhoamiRandomNameFunction);
+	fn.SetVolatile();
+	return fn;
+}
+
+} // namespace duckdb


### PR DESCRIPTION
```sql
SELECT whoami_random_name() FROM range(10);
```
will generate a list resembling:
```
quick-eider-56
copper-wigeon-64
snug-rouen-66
dreamy-ringneck-eb
sunny-canvasback-ce
sturdy-steamer-cd
sturdy-shelduck-74
crisp-mallard-89
jaunty-eatoni-42
witty-torrent-81
```
And now, without user input:
```sql
FROM whoami();
```
```
┌──────────────────┬──────────┬──────────┬─────────┬─────────────────┬───────────────────────────────┬────────────────────────────────────────────────────┐
│       name       │ provider │ hostname │ region  │     uptime      │            ts_now             │                        meta                        │
│     varchar      │ varchar  │ varchar  │ varchar │    interval     │   timestamp with time zone    │                        json                        │
├──────────────────┼──────────┼──────────┼─────────┼─────────────────┼───────────────────────────────┼────────────────────────────────────────────────────┤
│ dreamy-eatoni-de │ NULL     │ NULL     │ NULL    │ 00:00:01.115181 │ 2026-05-10 07:41:10.939381+00 │ {"duckdb_version":"v1.5.2","platform":"osx_arm64"} │
└──────────────────┴──────────┴──────────┴─────────┴─────────────────┴───────────────────────────────┴────────────────────────────────────────────────────┘
```
User that want to opt-out can already to so via `SET GLOBAL whoami_name = ''` or `SET GLOBAL whoami_name = 'my-custom-name';`


This is mostly for the cuteness, clearly NOT load-bearing, but it's a sort of common convention when managing different compute instances have names assigned to them in a readable way. Docker / Tailscale / Heroku / GitHub Codespaces all have conventions converging to `adjective - noun [-hex digits]`.

In our case, noun had to be duck-related, with adjective being nice / friendly and avoiding any negative connotation.

Implementation: one of 32 adjectives - one of 32 duck-themed nouns - 2 hex cypher

I made a pass trying to remove any negative association from both sides (and when combined), but improvements are welcome (also, no need to stick to power of 2).

Adjectives:
```
  bold        brave       bright      cheery      clever      copper      crisp       dapper
  downy       dreamy      eager       gentle      glossy      golden      hardy       jaunty
  jolly       mellow      merry       plucky      quick       scrappy     sharp       silver
  sleek       sleepy      snug        sturdy      sunny       swift       witty       zesty
```
Nouns:
```
  andium      aylesbury   bufflehead  canvasback  cayuga      drake       eatoni      eider
  gadwall     garganey    goldeneye   harlequin   mallard     mandarin    merganser   muscovy
  nivis       pintail     pochard     redhead     ringneck    rouen       scaup       shelduck
  shoveler    smew        steamer     teal        torrent     variegata   whistler    wigeon
```