### PR TITLE
Skip test/sql/self_stop.test on windows

### DIFF
--- a/test/sql/self_stop.test
+++ b/test/sql/self_stop.test
@@ -2,6 +2,8 @@
 # description: A client may instruct a quack server to stop itself via `CALL quack_stop(...)` over RPC. Must not deadlock or crash.
 # group: [sql]
 
+require notwindows
+
 require quack
 
 require httpfs


### PR DESCRIPTION
I am not sure which test randomly corrupt state (possibly with collaboration of `unittest`) and then timeouts.