### PR TITLE
Add quack_clear_cache that clears and reloads the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,45 @@
-# Rpc
+# The Quack Client/Server Protocol for DuckDB
 
-This repository is based on https://github.com/duckdb/extension-template, check it out if you want to build and ship your own DuckDB extension.
+The `quack` extension adds a client-server protocol to DuckDB. With this extension, DuckDB can act as both a server and a client to communicate over network. For more details, please see the announcement and the DuckDB documentation. 
 
----
+## Usage Example
 
-This extension, Rpc, allow you to ... <extension_goal>.
+We have to install the extension in all involved DuckDB instances
+```SQL
+INSTALL quack FROM core_nightly;
+```
+
+Then, we can use one DuckDB instance a s a server like so:
+
+```SQL
+LOAD quack;
+CALL quack_serve('quack:localhost', token = 'super_secret');
+CREATE TABLE hello AS FROM VALUES ('world') v(s);
+```
+
+And talk to this server from another instance:
+
+```SQL
+LOAD quack;
+CREATE SECRET (TYPE quack, TOKEN 'super_secret');
+ATTACH 'quack:localhost' AS remote;
+FROM remote.hello;
+```
+
+This should show the content of the remote table `hello` on the client-side.
+
+We can also copy data from client to server:
+```SQL
+-- on client
+CREATE TABLE remote.hello2 AS FROM VALUES ('world2')v(s);
+```
+```SQL
+-- on server
+FROM hello2;
+```
 
 
-## Building
+## Development
 ### Managing dependencies
 DuckDB extensions uses VCPKG for dependency management. Enabling VCPKG is very simple: follow the [installation instructions](https://vcpkg.io/en/getting-started) or just run the following:
 ```shell
@@ -26,61 +58,15 @@ The main binaries that will be built are:
 ```sh
 ./build/release/duckdb
 ./build/release/test/unittest
-./build/release/extension/rpc/rpc.duckdb_extension
+./build/release/extension/quack/quack.duckdb_extension
 ```
 - `duckdb` is the binary for the duckdb shell with the extension code automatically loaded.
 - `unittest` is the test runner of duckdb. Again, the extension is already linked into the binary.
-- `rpc.duckdb_extension` is the loadable binary as it would be distributed.
+- `quack.duckdb_extension` is the loadable binary as it would be distributed.
 
-## Running the extension
-To run the extension code, simply start the shell with `./build/release/duckdb`.
-
-Now we can use the features from the extension directly in DuckDB. The template contains a single scalar function `rpc()` that takes a string arguments and returns a string:
-```
-D select rpc('Jane') as result;
-┌───────────────┐
-│    result     │
-│    varchar    │
-├───────────────┤
-│ Rpc Jane 🐥 │
-└───────────────┘
-```
-
-## Running the tests
+### Running the tests
 Different tests can be created for DuckDB extensions. The primary way of testing DuckDB extensions should be the SQL tests in `./test/sql`. These SQL tests can be run using:
 ```sh
 make test
 ```
 
-### Installing the deployed binaries
-To install your extension binaries from S3, you will need to do two things. Firstly, DuckDB should be launched with the
-`allow_unsigned_extensions` option set to true. How to set this will depend on the client you're using. Some examples:
-
-CLI:
-```shell
-duckdb -unsigned
-```
-
-Python:
-```python
-con = duckdb.connect(':memory:', config={'allow_unsigned_extensions' : 'true'})
-```
-
-NodeJS:
-```js
-db = new duckdb.Database(':memory:', {"allow_unsigned_extensions": "true"});
-```
-
-Secondly, you will need to set the repository endpoint in DuckDB to the HTTP url of your bucket + version of the extension
-you want to install. To do this run the following SQL query in DuckDB:
-```sql
-SET custom_extension_repository='bucket.s3.eu-west-1.amazonaws.com/<your_extension_name>/latest';
-```
-Note that the `/latest` path will allow you to install the latest extension version available for your current version of
-DuckDB. To specify a specific version, you can pass the version instead.
-
-After running these steps, you can install and load your extension using the regular INSTALL/LOAD commands in DuckDB:
-```sql
-INSTALL rpc
-LOAD rpc
-```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Quack Client/Server Protocol for DuckDB
 
+> Quack is released as a pre-release extension and is currently experimental. If you encounter any issues, please file them [here](https://github.com/duckdb/duckdb-quack/issues).
+
 The `quack` extension adds a client-server protocol to DuckDB. With this extension, DuckDB can act as both a server and a client to communicate over network. For more details, please see the announcement and the DuckDB documentation. 
 
 ## Usage Example

--- a/benchmarks/benchmark-batch.py
+++ b/benchmarks/benchmark-batch.py
@@ -1,0 +1,76 @@
+# DuckDB Quack Client/Server Bulk Benchmark, 2026-05-10, hannes
+import os
+import time
+import math
+import statistics
+import enum
+
+Mode = enum.Enum('Mode', ['QUACK', 'POSTGRES', 'ARROW'])
+
+# change this as desired
+server_hostname = 'localhost'
+benchmark_mode = Mode.QUACK
+
+install_duckdb_extensions = False
+
+def connect(mode):
+    global install_duckdb_extensions
+    match mode:
+        case Mode.QUACK:
+            import duckdb
+            con = duckdb.connect()
+            if install_duckdb_extensions:
+                con.execute(f"""
+FORCE INSTALL httpfs; 
+FORCE INSTALl quack FROM core_nightly; 
+""")
+                install_duckdb_extensions = False
+
+            con.execute(f"""
+LOAD httpfs;
+LOAD quack;
+""")
+        case Mode.POSTGRES:
+            import psycopg2
+            con = psycopg2.connect(f'postgresql://{server_hostname}')
+            con.autocommit = True
+
+        case Mode.ARROW:
+            from adbc_driver_flightsql import dbapi
+            con = dbapi.connect(
+                uri=f'grpc://{server_hostname}:31337',
+                db_kwargs={"username": "gizmosql_user",
+                         "password": "gizmosql_password"},
+                autocommit=True)
+    return con
+
+
+def execute(mode, cursor, sql):
+    match mode:
+        case Mode.QUACK:
+            cursor.execute(f"EXPLAIN ANALYZE FROM quack_query('quack:{server_hostname}', '{sql}', token='asdf')")
+
+        case Mode.POSTGRES:
+            cursor.execute(sql)
+
+        case Mode.ARROW:
+            cursor.execute(sql)
+
+print('method\trows\tmedian_time_seconds')
+
+for rows in [int(math.pow(10,y)) for y in range(2, 8)] + [59986052]:
+	timings = []
+	for rep in range(5):
+		con = connect(benchmark_mode)
+		cursor = con.cursor()
+
+		start = time.time()
+		execute(benchmark_mode, cursor, f'SELECT * FROM lineitem LIMIT {rows}')
+
+		timings.append(time.time() - start)
+		cursor.close()
+		con.close()
+
+	median_time = round(statistics.median(timings), 3)
+	print(f'{benchmark_mode}\t{rows}\t{median_time}')
+

--- a/benchmarks/benchmark-transactions.py
+++ b/benchmarks/benchmark-transactions.py
@@ -1,0 +1,158 @@
+# DuckDB Quack Client/Server Transaction Benchmark, 2026-05-10, hannes
+
+import datetime 
+import enum
+import math
+import os
+import random
+import statistics 
+import string
+import sys
+import threading
+import time
+
+
+Mode = enum.Enum('Mode', ['QUACK', 'POSTGRES', 'ARROW'])
+
+# change this as desired
+server_hostname = 'localhost'
+benchmark_mode = Mode.QUACK
+
+
+# orrrr
+class ReturningThread(threading.Thread):
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs={}, verbose=None):
+        super().__init__(group, target, name, args, kwargs)
+        self._return = None
+
+    def run(self):
+        self._return = self._target(*self._args, **self._kwargs)
+
+    def join(self):
+        super().join()
+        return self._return
+
+install_duckdb_extensions = True
+
+def connect(mode):
+    global install_duckdb_extensions
+    match mode:
+        case Mode.QUACK:
+            import duckdb
+            con = duckdb.connect()
+            if install_duckdb_extensions:
+                con.execute(f"""
+FORCE INSTALL httpfs; 
+FORCE INSTALl quack FROM core_nightly; 
+""")
+                install_duckdb_extensions = False
+
+            con.execute(f"""
+LOAD httpfs;
+LOAD quack;
+ATTACH 'quack:{server_hostname}' as db (DISABLE_SSL true, token 'asdf'); 
+PRAGMA threads=1;
+""")
+        case Mode.POSTGRES:
+            import psycopg2
+            con = psycopg2.connect(f'postgresql://{server_hostname}')
+            con.autocommit = True
+
+        case Mode.ARROW:
+            from adbc_driver_flightsql import dbapi
+            con = dbapi.connect(
+                uri=f'grpc://{server_hostname}:31337',
+                db_kwargs={"username": "gizmosql_user",
+                         "password": "gizmosql_password"},
+                autocommit=True)
+    return con
+
+
+def execute(mode, cursor, sql):
+    match mode:
+        case Mode.QUACK:
+            sql2 = sql.replace("'", "''")
+            cursor.execute(f"CALL db.query('{sql2}');")
+
+        case Mode.POSTGRES:
+            cursor.execute(sql)
+
+        case Mode.ARROW:
+            cursor.execute(sql)
+
+
+def thread_fun(id):
+    con = connect(benchmark_mode)
+    cursor = con.cursor()
+
+    transactions_completed = 0
+    transactions_failed = 0
+    start_date = datetime.datetime.strptime('1992-01-01', '%Y-%m-%d')
+
+    while not stop:
+        # generate lineitem-ish data, just so messages have some weight
+        l_orderkey = random.randint(1, 60000000)
+        l_partkey = random.randint(1, 100000)
+        l_suppkey = random.randint(1, 100000)
+        l_linenumber = random.randint(1, 7)
+        l_quantity = round(random.randint(100, 5000)/100, 2)
+        l_extendedprice = round(random.randint(900,  10000000 )/100, 2)
+        l_discount = round(random.randint(1,  100 ) / 10, 2)
+        l_tax = round(random.randint(1,  100 ) / 10, 2)
+        l_returnflag = random.choice(string.ascii_uppercase)
+        l_linestatus = random.choice(string.ascii_uppercase)
+        l_shipdate = start_date + datetime.timedelta(days=random.randint(0, 3000))
+        l_commitdate = start_date + datetime.timedelta(days=random.randint(0, 3000))
+        l_receiptdate = start_date + datetime.timedelta(days=random.randint(0, 3000))
+        l_shipinstruct = ''.join(random.choices(string.ascii_letters, k=random.randint(10, 20)))
+        l_shipmode = ''.join(random.choices(string.ascii_letters, k=random.randint(5, 10)))
+        l_comment = ''.join(random.choices(string.ascii_letters, k=random.randint(10, 30)))
+
+        sql = f'''
+INSERT INTO lineitem_insert VALUES ({l_orderkey}, {l_partkey}, {l_suppkey}, {l_linenumber}, {l_quantity}, {l_extendedprice}, {l_discount}, {l_tax}, '{l_returnflag}','{l_linestatus}','{l_shipdate}','{l_commitdate}', '{l_receiptdate}', '{l_shipinstruct}', '{l_shipmode}', '{l_comment}');
+'''
+        execute(benchmark_mode, cursor, sql)
+        transactions_completed +=1
+
+    cursor.close()
+    con.close()
+    return transactions_completed
+
+create_sql = '''
+DROP TABLE IF EXISTS lineitem_insert;
+CREATE TABLE lineitem_insert(l_orderkey BIGINT NOT NULL, l_partkey BIGINT NOT NULL, l_suppkey BIGINT NOT NULL, l_linenumber BIGINT NOT NULL, l_quantity DECIMAL(15,2) NOT NULL, l_extendedprice DECIMAL(15,2) NOT NULL, l_discount DECIMAL(15,2) NOT NULL, l_tax DECIMAL(15,2) NOT NULL, l_returnflag VARCHAR NOT NULL, l_linestatus VARCHAR NOT NULL, l_shipdate DATE NOT NULL, l_commitdate DATE NOT NULL, l_receiptdate DATE NOT NULL, l_shipinstruct VARCHAR NOT NULL, l_shipmode VARCHAR NOT NULL, l_comment VARCHAR NOT NULL);
+        '''
+
+duration = 5
+for n_threads in [1 ,2, 4 ,8, 16, 32, 64]:
+    results = []
+    for rep in range(5):
+        con = connect(benchmark_mode)
+        cursor = con.cursor()
+        execute(benchmark_mode, cursor, create_sql)
+        cursor.close()
+        con.close()
+
+        start = time.time()
+        stop = False
+
+        threads = []
+        for i in range(n_threads):
+            t = ReturningThread(target=thread_fun, args=[i])
+            t.start()
+            threads.append(t)
+
+        time.sleep(duration)
+        stop = True
+        total_transactions_completed = 0
+
+        for t in threads:
+            res = t.join()
+            total_transactions_completed += res
+
+        total_time = time.time() - start
+        transactions_per_second = total_transactions_completed/total_time
+        results.append(transactions_per_second)
+
+    median_tps = round(statistics.median(results), 3)
+    print(f'{benchmark_mode}\t{n_threads}\t\t{median_tps}')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(storage)
 
 add_library(
   quack_library OBJECT
+  quack_clear_cache.cpp
   quack_client.cpp
   quack_extension.cpp
   quack_http_server.cpp

--- a/src/include/quack_clear_cache.hpp
+++ b/src/include/quack_clear_cache.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace duckdb {
+
+class TableFunction;
+
+class QuackClearCacheFunction {
+public:
+	static TableFunction GetFunction();
+};
+
+} // namespace duckdb

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -60,6 +60,8 @@ public:
 
 	shared_ptr<QuackClientConnection> GetClientConnection();
 
+	void Refresh(ClientContext &context);
+
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 

--- a/src/include/storage/quack_catalog_set.hpp
+++ b/src/include/storage/quack_catalog_set.hpp
@@ -29,6 +29,7 @@ public:
 	void DropEntry(const string &entry_name);
 	vector<reference<CatalogEntry>> GetAllCatalogEntries();
 	optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry, OnCreateConflict on_conflict);
+	void Clear();
 
 protected:
 	QuackCatalog &catalog;

--- a/src/include/storage/quack_schema.hpp
+++ b/src/include/storage/quack_schema.hpp
@@ -23,6 +23,8 @@ public:
 	QuackSchemaSet(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data);
 
 	static string GetLoadQuery();
+
+	void Reload(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data);
 };
 
 class QuackSchemaCatalogEntry : public SchemaCatalogEntry {

--- a/src/quack_clear_cache.cpp
+++ b/src/quack_clear_cache.cpp
@@ -1,0 +1,48 @@
+#include "quack_clear_cache.hpp"
+
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database_manager.hpp"
+
+#include "storage/quack_catalog.hpp"
+
+namespace duckdb {
+
+struct ClearCacheFunctionData : public TableFunctionData {
+	bool finished = false;
+};
+
+unique_ptr<FunctionData> ClearCacheBind(ClientContext &, TableFunctionBindInput &,
+                                        vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+	return make_uniq<ClearCacheFunctionData>();
+}
+
+void ClearQuackCaches(ClientContext &context) {
+	auto databases = DatabaseManager::Get(context).GetDatabases(context);
+	for (auto &db_ref : databases) {
+		auto &catalog = db_ref->GetCatalog();
+		if (catalog.GetCatalogType() != "quack") {
+			continue;
+		}
+		catalog.Cast<QuackCatalog>().Refresh(context);
+	}
+}
+
+void ClearCacheFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &) {
+	auto &data = data_p.bind_data->CastNoConst<ClearCacheFunctionData>();
+	if (data.finished) {
+		return;
+	}
+	ClearQuackCaches(context);
+	data.finished = true;
+}
+
+
+TableFunction QuackClearCacheFunction::GetFunction() {
+	return TableFunction("quack_clear_cache", {}, ClearCacheFunction, ClearCacheBind);
+}
+
+} // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -13,6 +13,7 @@
 #include "storage/quack_optimizer.hpp"
 
 #include "include/storage/quack_catalog.hpp"
+#include "quack_clear_cache.hpp"
 #include "quack_extension.hpp"
 #include "quack_log.hpp"
 #include "quack_scan.hpp"
@@ -117,6 +118,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());
 	loader.RegisterFunction(QuackServerListFunction::GetFunction());
+	loader.RegisterFunction(QuackClearCacheFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
 
 	// the default authentication function

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -84,6 +84,11 @@ shared_ptr<QuackClientConnection> QuackCatalog::GetClientConnection() {
 	return client_connection;
 }
 
+void QuackCatalog::Refresh(ClientContext &context) {
+	auto load_info = LoadCatalog(context);
+	schemas->Reload(context, *this, load_info);
+}
+
 const string &QuackCatalog::GetConnectionId() {
 	return client_connection->ConnectionId();
 }

--- a/src/storage/quack_catalog_set.cpp
+++ b/src/storage/quack_catalog_set.cpp
@@ -35,6 +35,11 @@ void QuackCatalogSet::DropEntry(const string &entry_name) {
 	entries.erase(entry_name);
 }
 
+void QuackCatalogSet::Clear() {
+	lock_guard<mutex> l(entry_lock);
+	entries.clear();
+}
+
 optional_ptr<CatalogEntry> QuackCatalogSet::CreateEntry(unique_ptr<CatalogEntry> entry, OnCreateConflict on_conflict) {
 	lock_guard<mutex> l(entry_lock);
 	auto &entry_name = entry->name;

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -13,6 +13,11 @@ namespace duckdb {
 
 QuackSchemaSet::QuackSchemaSet(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data)
     : QuackCatalogSet(catalog) {
+	Reload(context, catalog, load_data);
+}
+
+void QuackSchemaSet::Reload(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data) {
+	Clear();
 	for (auto &row : load_data.schemas->Rows()) {
 		CreateSchemaInfo info;
 		info.catalog = row.GetValue(0).GetValue<string>();

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -1,0 +1,76 @@
+# name: test/sql/clear_cache.test
+# description: quack_clear_cache refreshes the cached catalog snapshot after server-side DDL via quack_query_by_name
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+call quack_serve('quack:localhost', token='asdf');
+
+statement ok con2
+create secret (type quack, token 'asdf')
+
+statement ok con2
+attach 'quack:localhost' as rpc
+
+statement ok con2
+call system.main.quack_query_by_name('rpc', 'CREATE TABLE t1(i INTEGER); INSERT INTO t1 VALUES (1),(2),(3);')
+
+statement error con2
+SELECT i FROM rpc.t1
+----
+Table with name t1 does not exist
+
+statement ok con2
+CALL quack_clear_cache()
+
+query I con2
+SELECT i FROM rpc.t1 ORDER BY i
+----
+1
+2
+3
+
+statement ok con2
+call system.main.quack_query_by_name('rpc', 'CREATE TABLE t2(s VARCHAR); INSERT INTO t2 VALUES (''a''),(''b'');')
+
+statement error con2
+SELECT s FROM rpc.t2
+----
+Table with name t2 does not exist
+
+statement ok con2
+CALL quack_clear_cache()
+
+query I con2
+SELECT s FROM rpc.t2 ORDER BY s
+----
+a
+b
+
+statement ok con2
+call system.main.quack_query_by_name('rpc', 'DROP TABLE t1;')
+
+query I con2
+SELECT s FROM rpc.t2 ORDER BY s
+----
+a
+b
+
+statement ok con2
+CALL quack_clear_cache()
+
+statement error con2
+SELECT i FROM rpc.t1
+----
+Table with name t1 does not exist
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop('quack:localhost');

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -61,13 +61,18 @@ SELECT s FROM rpc.t2 ORDER BY s
 a
 b
 
+statement error con2
+SELECT i FROM rpc.t1
+----
+Invalid Input Error: Table with name t1 does not exist
+
 statement ok con2
 CALL quack_clear_cache()
 
 statement error con2
 SELECT i FROM rpc.t1
 ----
-Table with name t1 does not exist
+Catalog Error: Table with name t1 does not exist
 
 statement ok con2
 detach rpc;


### PR DESCRIPTION
We need it for ducklake to be able to batch queries with `quack_query_by_name`. 

I call this function after DDLs the catalog, so in initialization or when inlined tables are created.