### PR TITLE
Strip quack URI scheme as prefix only

### DIFF
--- a/src/quack_uri.cpp
+++ b/src/quack_uri.cpp
@@ -8,15 +8,17 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
 	ipv6 = false;
 	port = 9494;
 	StringUtil::Trim(uri);
-	// first off, lets be tolerant and accept this variant, too
+	// strip the scheme as a prefix only — must not use StringUtil::Replace here,
+	// which replaces every occurrence and would mangle hostnames containing "quack:"
+	// (e.g. quack://ilum-quack:9494)
+	string remainder;
 	if (StringUtil::StartsWith(uri, "quack://")) {
-		uri = StringUtil::Replace(uri, "quack://", "quack:");
-	}
-	if (!StringUtil::StartsWith(uri, "quack:")) {
+		remainder = uri.substr(strlen("quack://"));
+	} else if (StringUtil::StartsWith(uri, "quack:")) {
+		remainder = uri.substr(strlen("quack:"));
+	} else {
 		throw InvalidInputException("Invalid DuckDB Quack RPC URI, needs to start with 'quack:'");
 	}
-
-	auto remainder = StringUtil::Replace(uri, "quack:", "");
 	if (remainder.empty()) {
 		throw InvalidInputException("Missing hostname");
 	}

--- a/test/sql/uri.test
+++ b/test/sql/uri.test
@@ -51,6 +51,27 @@ select unnest(quack_uri_parser('quack:[::1]:1234', true));
 ----
 ::1	1234	true	true	https://[::1]:1234
 
+# hostnames containing the substring "quack" — must not be mangled by scheme stripping
+query IIIII
+select unnest(quack_uri_parser('quack://ilum-quack:9494', false));
+----
+ilum-quack	9494	false	false	http://ilum-quack:9494
+
+query IIIII
+select unnest(quack_uri_parser('quack:ilum-quack:9494', false));
+----
+ilum-quack	9494	false	false	http://ilum-quack:9494
+
+query IIIII
+select unnest(quack_uri_parser('quack://quack:9494', false));
+----
+quack	9494	false	false	http://quack:9494
+
+query IIIII
+select unnest(quack_uri_parser('quack://my-quack-host:9494', false));
+----
+my-quack-host	9494	false	false	http://my-quack-host:9494
+
 
 #failure cases
 


### PR DESCRIPTION
### Bug

`QuackUri::QuackUri` strips the `quack:` scheme with `StringUtil::Replace`, which replaces **every** occurrence, not just the prefix. So any URI whose host part contains a second `quack:` gets mangled:

| input                       | after `Replace(uri, "quack:", "")` | parsed host | parsed port |
|-----------------------------|------------------------------------|-------------|-------------|
| `quack:localhost:9494`      | `localhost:9494`                   | `localhost` | `9494`      |
| `quack:ilum-quack:9494`     | `ilum-9494`                        | `ilum-9494` | `9494` (default) |
| `quack:quack:9494`          | `:9494`                            | `` (empty)  | `9494`      |

The mangled hostnames don't resolve, so `ATTACH` fails. In practice this breaks the Kubernetes Service-name path for any Service named `<x>-quack`, a natural default for a quack pod and forces a brittle ClusterIP workaround that doesn't survive Service rolling restarts.

### Fix

Replace the two `StringUtil::Replace` calls in `src/quack_uri.cpp` with prefix-only `substr` strips. No behavior change for any URI whose host part does not contain `quack:`.