### PR TITLE
`quack_serve()` to return NotImplementedException in wasm

### DIFF
--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -16,6 +16,11 @@ struct QuackStartStopFunctionData : public TableFunctionData {
 
 static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunctionBindInput &input,
                                                vector<LogicalType> &return_types, vector<string> &names) {
+#ifdef __EMSCRIPTEN__
+	throw NotImplementedException("quack_serve is currently not implemented for the wasm platform, consider connecting "
+	                              "to already available endpoint");
+#endif
+
 	auto bind_data = make_uniq<QuackStartStopFunctionData>();
 	string listen_uri;
 	if (input.inputs.empty()) {


### PR DESCRIPTION
The actual setup for spawning httplib server doesn't work at the moment in Wasm. To avoid weird to user-facing errors and non-sensical situation, just forbid the quack_serve entrypoint.

Fixes https://github.com/duckdb/duckdb-quack/issues/125