### PR TITLE
Change default port in URI format examples

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,13 +31,13 @@ need to connect. This token can also be [set](#authentication--authorization).
 
 RPC endpoints use the `quack:` scheme, some examples:
 
-| URI                       | Host        | Port (default 1294) |
+| URI                       | Host        | Port (default 9494) |
 |---------------------------|-------------|---------------------|
-| `quack:localhost`         | `localhost` | `1294`              |
+| `quack:localhost`         | `localhost` | `9494`              |
 | `quack:myhost:9000`       | `myhost`    | `9000`              |
-| `quack:127.0.0.1`         | `127.0.0.1` | `1294`              |
+| `quack:127.0.0.1`         | `127.0.0.1` | `9494`              |
 | `quack:[::1]:1234`        | `::1`       | `1234` (IPv6)       |
-| `quack://localhost`       | `localhost` | `1294`              |
+| `quack://localhost`       | `localhost` | `9494`              |
 
 You can parse and validate a URI with the `rpc_uri_parser(uri, ssl)`
 scalar function.


### PR DESCRIPTION
Updated default port number in URI examples from 1294 to 9494.