### PR TITLE
Add CancelRequest remote command

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -17,6 +17,7 @@ enum class MessageType : uint8_t {
 	APPEND_REQUEST = 9,
 	SUCCESS_RESPONSE = 10,
 	DISCONNECT_MESSAGE = 11,
+	CANCEL_REQUEST = 12,
 	ERROR_RESPONSE = 100
 };
 
@@ -341,6 +342,20 @@ public:
 
 protected:
 	DisconnectMessage() : QuackMessage(TYPE) {
+	}
+};
+
+class CancelRequestMessage : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::CANCEL_REQUEST;
+
+	explicit CancelRequestMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {};
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<CancelRequestMessage> Deserialize(Deserializer &deserializer);
+
+protected:
+	CancelRequestMessage() : QuackMessage(TYPE) {
 	}
 };
 

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -65,6 +65,10 @@
     "members": []
   },
   {
+    "class": "CancelRequestMessage",
+    "members": []
+  },
+  {
     "class": "PrepareResponseMessage",
     "members": [
       {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <atomic>
 #include <thread>
 
+#include "duckdb/common/constants.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 
@@ -32,6 +34,10 @@ struct QuackConnection {
 	//! Current result UUID
 	hugeint_t result_uuid;
 	string session_id;
+	//! client_query_id of the query currently being processed for this connection, or
+	//! INVALID_INDEX when idle. Read by CancelRequest handler without holding `lock`
+	//! so it can race with a PREPARE/FETCH that's holding `lock`.
+	std::atomic<idx_t> active_client_query_id {DConstants::INVALID_INDEX};
 };
 
 class QuackServer {

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -160,8 +160,7 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		// every connection setup / disconnect / append.
 		unique_ptr<InterruptWatchdog> watchdog;
 		if (context && client_query_id.IsValid() && MessageIsCancellable(request_type) && !connection_id.empty()) {
-			watchdog =
-			    make_uniq<InterruptWatchdog>(db, uri, connection_id, *context, client_query_id.GetIndex());
+			watchdog = make_uniq<InterruptWatchdog>(db, uri, connection_id, *context, client_query_id.GetIndex());
 		}
 
 		try {

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -1,3 +1,8 @@
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
@@ -6,6 +11,71 @@
 #include "quack_uri.hpp"
 
 namespace duckdb {
+
+namespace {
+
+// Runs alongside a blocking PREPARE/FETCH HTTP call: polls the local ClientContext's
+// interrupted flag and, on observing an interrupt, opens a fresh client and posts a
+// CancelRequest tagged with the same client_query_id. The server matches that id
+// against its active query and calls Connection::Interrupt(), which lets the
+// blocked HTTP call return with an interrupted-query error.
+class InterruptWatchdog {
+public:
+	InterruptWatchdog(DatabaseInstance &db_p, QuackUri uri_p, string connection_id_p, ClientContext &context_p,
+	                  idx_t client_query_id_p)
+	    : db(db_p), uri(std::move(uri_p)), connection_id(std::move(connection_id_p)), context(context_p),
+	      client_query_id(client_query_id_p), watcher([this] { Run(); }) {
+	}
+
+	~InterruptWatchdog() {
+		stop.store(true);
+		if (watcher.joinable()) {
+			watcher.join();
+		}
+	}
+
+	InterruptWatchdog(const InterruptWatchdog &) = delete;
+	InterruptWatchdog &operator=(const InterruptWatchdog &) = delete;
+
+private:
+	void Run() {
+		while (!stop.load()) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			if (stop.load()) {
+				return;
+			}
+			if (!context.IsInterrupted()) {
+				continue;
+			}
+			// Best-effort: open a sibling client and post the cancel. Any failure here
+			// (network, server gone, auth) is swallowed — the worst case is that the
+			// user's Ctrl-C doesn't take effect, which is the pre-existing behavior.
+			try {
+				auto cancel_client = QuackClient::GetClient(db, uri);
+				auto msg = make_uniq<CancelRequestMessage>(connection_id);
+				msg->SetClientQueryId(client_query_id);
+				cancel_client->Request<SuccessResponse>(nullptr, std::move(msg));
+			} catch (...) {
+			}
+			return;
+		}
+	}
+
+	DatabaseInstance &db;
+	QuackUri uri;
+	string connection_id;
+	ClientContext &context;
+	idx_t client_query_id;
+	std::atomic<bool> stop {false};
+	std::thread watcher;
+};
+
+bool MessageIsCancellable(MessageType type) {
+	return type == MessageType::PREPARE_REQUEST || type == MessageType::FETCH_REQUEST;
+}
+
+} // namespace
+
 template <class T>
 string GetUriPart(T ele) {
 	if (ele.afterLast - ele.first < 1) {
@@ -41,23 +111,65 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		}
 	}
 
-	HTTPHeaders headers;
+	auto request_type = request_message->Type();
+	string connection_id;
+	string query;
+	switch (request_type) {
+	case MessageType::PREPARE_REQUEST: {
+		auto &msg = request_message->Cast<PrepareRequestMessage>();
+		connection_id = msg.ConnectionId();
+		query = msg.Query();
+		break;
+	}
+	case MessageType::FETCH_REQUEST:
+		connection_id = request_message->Cast<FetchRequestMessage>().ConnectionId();
+		break;
+	case MessageType::APPEND_REQUEST:
+		connection_id = request_message->Cast<AppendRequestMessage>().ConnectionId();
+		break;
+	default:
+		break;
+	}
 
+	// Tag the outgoing message with the active local query id, before serializing.
+	// Guard against reading the active query during transaction start itself (e.g.
+	// BEGIN TRANSACTION via QuackCatalog::ExecuteCommand), where the transaction
+	// isn't yet installed on the TransactionContext.
+	optional_idx client_query_id;
+	if (context && context->transaction.HasActiveTransaction()) {
+		auto raw_query_id = context->transaction.GetActiveQuery();
+		if (raw_query_id != DConstants::INVALID_INDEX) {
+			client_query_id = raw_query_id;
+			request_message->SetClientQueryId(client_query_id);
+		}
+	}
+
+	HTTPHeaders headers;
 	request_message->ToMemoryStream(write_stream);
 	PostRequestInfo post_request(request_url, headers, *http_params, write_stream.GetData(),
 	                             write_stream.GetPosition());
 	unique_ptr<HTTPResponse> response;
 
-	// Time the request
 	int64_t start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 	                         .time_since_epoch()
 	                         .count();
 
-	try {
-		response = http_util.Request(post_request);
-	} catch (std::exception &ex) {
-		ErrorData error(ex);
-		throw IOException("Failed to send message: %s", error.Message());
+	{
+		// Only PREPARE/FETCH can hang for long enough that local cancellation matters.
+		// Skipping this for short messages avoids the watchdog thread overhead on
+		// every connection setup / disconnect / append.
+		unique_ptr<InterruptWatchdog> watchdog;
+		if (context && client_query_id.IsValid() && MessageIsCancellable(request_type) && !connection_id.empty()) {
+			watchdog =
+			    make_uniq<InterruptWatchdog>(db, uri, connection_id, *context, client_query_id.GetIndex());
+		}
+
+		try {
+			response = http_util.Request(post_request);
+		} catch (std::exception &ex) {
+			ErrorData error(ex);
+			throw IOException("Failed to send message: %s", error.Message());
+		}
 	}
 	if (!response || !response->Success()) {
 		string error = response ? response->GetError() : "no response";
@@ -67,46 +179,11 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 	MemoryStream non_owning_read_stream((data_ptr_t)post_request.buffer_out.data(), post_request.buffer_out.size());
 	auto response_message = QuackMessage::FromMemoryStream(non_owning_read_stream);
 
-	// logging stuff, own scope
 	{
 		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 		                       .time_since_epoch()
 		                       .count();
 
-		auto request_type = request_message->Type();
-		string connection_id;
-		string query;
-		optional_idx client_query_id;
-		switch (request_type) {
-		case MessageType::PREPARE_REQUEST: {
-			auto &msg = request_message->Cast<PrepareRequestMessage>();
-			connection_id = msg.ConnectionId();
-			query = msg.Query();
-			break;
-		}
-		case MessageType::FETCH_REQUEST:
-			connection_id = request_message->Cast<FetchRequestMessage>().ConnectionId();
-			break;
-		case MessageType::APPEND_REQUEST:
-			connection_id = request_message->Cast<AppendRequestMessage>().ConnectionId();
-			break;
-		default:
-			break;
-		}
-
-		// Inject client_query_id from context into the message before sending.
-		// Guard against reading the active query during transaction start itself
-		// (e.g. BEGIN TRANSACTION via QuackCatalog::ExecuteCommand), where the
-		// transaction isn't yet installed on the TransactionContext.
-		if (context && context->transaction.HasActiveTransaction()) {
-			auto raw_query_id = context->transaction.GetActiveQuery();
-			if (raw_query_id != DConstants::INVALID_INDEX) {
-				client_query_id = raw_query_id;
-				request_message->SetClientQueryId(client_query_id);
-			}
-		}
-
-		// Log RPC message
 		auto &logger = context ? Logger::Get(*context) : Logger::Get(db);
 		if (logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
 			string error;

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -1,5 +1,8 @@
 #define DUCKDB_EXTENSION_MAIN
 
+#include <chrono>
+#include <thread>
+
 #include "duckdb/catalog/default/default_table_functions.hpp"
 #include "duckdb/logging/log_manager.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -110,6 +113,41 @@ static TableFunction GetQuackIdentifyFunction() {
 	return fun;
 }
 
+// Test-only: schedule a one-shot Interrupt() on the current ClientContext after a
+// delay. Used by the cancel sqllogic test to deterministically fire a local
+// interrupt while a slow remote query is in flight — avoiding any dependency on
+// OS-level Ctrl-C delivery. Mirrors DuckDB's convention of always-registered
+// test helpers (test_all_types, force_checkpoint).
+static void TestScheduleInterruptExecFn(ClientContext &, TableFunctionInput &, DataChunk &) {
+	// no-op: side effect is in bind
+}
+
+static unique_ptr<FunctionData> TestScheduleInterruptBindFn(ClientContext &context, TableFunctionBindInput &input,
+                                                            vector<LogicalType> &return_types, vector<string> &names) {
+	auto delay = input.inputs[0].GetValue<int64_t>();
+	// Hold a weak_ptr so we don't keep the ClientContext alive past the user's
+	// session if they exit before the timer fires.
+	weak_ptr<ClientContext> weak_ctx = context.shared_from_this();
+	std::thread([weak_ctx, delay]() mutable {
+		std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+		if (auto ctx = weak_ctx.lock()) {
+			ctx->Interrupt();
+		}
+	}).detach();
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("scheduled");
+	return nullptr;
+}
+
+static TableFunction GetQuackTestScheduleInterruptFunction() {
+	// TEST-ONLY: schedules a delayed Connection::Interrupt() on the calling
+	// ClientContext. Intended for use by cancel-path sqllogic tests; do not
+	// rely on this from application code.
+	TableFunction fun("quack_test_schedule_interrupt", {LogicalType::BIGINT}, TestScheduleInterruptExecFn,
+	                  TestScheduleInterruptBindFn);
+	return fun;
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
 	loader.SetDescription("The DuckDB 'Quack' Client/Server Protocol");
 
@@ -120,6 +158,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackServerListFunction::GetFunction());
 	loader.RegisterFunction(QuackClearCacheFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
+	loader.RegisterFunction(GetQuackTestScheduleInterruptFunction());
 
 	// the default authentication function
 	ScalarFunction quack_check_token("quack_check_token",

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -51,6 +51,9 @@ MessageType EnumUtil::FromString<MessageType>(const char *value) {
 	if (StringUtil::Equals(value, "DISCONNECT_MESSAGE")) {
 		return MessageType::DISCONNECT_MESSAGE;
 	}
+	if (StringUtil::Equals(value, "CANCEL_REQUEST")) {
+		return MessageType::CANCEL_REQUEST;
+	}
 	if (StringUtil::Equals(value, "ERROR_RESPONSE")) {
 		return MessageType::ERROR_RESPONSE;
 	}
@@ -79,6 +82,8 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 		return "SUCCESS_RESPONSE";
 	case MessageType::DISCONNECT_MESSAGE:
 		return "DISCONNECT_MESSAGE";
+	case MessageType::CANCEL_REQUEST:
+		return "CANCEL_REQUEST";
 	case MessageType::ERROR_RESPONSE:
 		return "ERROR_RESPONSE";
 
@@ -124,6 +129,8 @@ unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, M
 		return SuccessResponse::Deserialize(deserializer);
 	case MessageType::DISCONNECT_MESSAGE:
 		return DisconnectMessage::Deserialize(deserializer);
+	case MessageType::CANCEL_REQUEST:
+		return CancelRequestMessage::Deserialize(deserializer);
 	case MessageType::ERROR_RESPONSE:
 		return ErrorResponse::Deserialize(deserializer);
 	default:

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -155,6 +155,7 @@ bool ServerSupportsMessage(MessageType type) {
 	case MessageType::FETCH_REQUEST:
 	case MessageType::APPEND_REQUEST:
 	case MessageType::DISCONNECT_MESSAGE:
+	case MessageType::CANCEL_REQUEST:
 		return true;
 	default:
 		return false;
@@ -169,6 +170,23 @@ bool MessageRequiresConnection(MessageType type) {
 		return true;
 	}
 }
+
+// Publishes a client_query_id into QuackConnection::active_client_query_id for
+// the duration of a query handler so a concurrent CancelRequest can match it.
+struct ActiveQueryScope {
+	std::atomic<idx_t> &slot;
+	bool set;
+	ActiveQueryScope(std::atomic<idx_t> &slot_p, optional_idx query_id) : slot(slot_p), set(query_id.IsValid()) {
+		if (set) {
+			slot.store(query_id.GetIndex());
+		}
+	}
+	~ActiveQueryScope() {
+		if (set) {
+			slot.store(DConstants::INVALID_INDEX);
+		}
+	}
+};
 
 // main switcheroo happens here
 unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
@@ -287,6 +305,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		}
 
 		std::unique_lock<std::mutex> lock(connection.lock);
+		ActiveQueryScope active(connection.active_client_query_id, received_message.ClientQueryId());
 		connection.duckdb_query_result.reset();
 
 		{
@@ -330,6 +349,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
 		auto &connection = *connection_p;
 		std::unique_lock<std::mutex> lock(connection.lock);
+		ActiveQueryScope active(connection.active_client_query_id, received_message.ClientQueryId());
 
 		if (connection.result_uuid != fetch_request_message.uuid) {
 			return make_uniq<ErrorResponse>("Result has been closed");
@@ -389,6 +409,22 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			// apend failed - directly pass error to user
 			return make_uniq<ErrorResponse>(ErrorData(ex));
 		}
+		return make_uniq<SuccessResponse>();
+	}
+
+	case MessageType::CANCEL_REQUEST: {
+		// Deliberately does NOT acquire connection.lock — that lock is held by the
+		// PREPARE/FETCH we're trying to cancel. We just read the atomic and, if it
+		// matches the targeted client_query_id, flip the interrupt flag on the
+		// query's ClientContext. The blocked PREPARE/FETCH then bails on its own.
+		auto &connection = *connection_p;
+		auto requested = received_message.ClientQueryId();
+		auto active = connection.active_client_query_id.load();
+		if (requested.IsValid() && active != DConstants::INVALID_INDEX && requested.GetIndex() == active) {
+			connection.duckdb_connection->Interrupt();
+		}
+		// Always succeed: cancel is idempotent — a no-op when the target query
+		// already finished is a legitimate outcome, not an error.
 		return make_uniq<SuccessResponse>();
 	}
 	default: {

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -23,6 +23,14 @@ unique_ptr<AppendRequestMessage> AppendRequestMessage::Deserialize(Deserializer 
 	return result;
 }
 
+void CancelRequestMessage::Serialize(Serializer &serializer) const {
+}
+
+unique_ptr<CancelRequestMessage> CancelRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<CancelRequestMessage>(new CancelRequestMessage());
+	return result;
+}
+
 void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "auth_string", auth_string);
 	serializer.WritePropertyWithDefault<string>(2, "client_duckdb_version", client_duckdb_version);
@@ -133,8 +141,7 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(3, "needs_more_fetch");
 	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results");
 	auto result_uuid = deserializer.ReadProperty<hugeint_t>(5, "result_uuid");
-	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(
-	    std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
+	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
 	return result;
 }
 

--- a/test/sql/cancel.test
+++ b/test/sql/cancel.test
@@ -1,0 +1,51 @@
+# name: test/sql/cancel.test
+# description: CancelRequest interrupts an in-flight remote query
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+CALL quack_serve('quack:localhost', token='asdf');
+
+sleep 100 millisecond
+
+statement ok con2
+CREATE SECRET (TYPE quack, TOKEN 'asdf');
+
+# Sanity: a normal short query still works.
+query I con2
+FROM quack_query('quack:localhost', 'SELECT 42')
+----
+42
+
+# Schedule a one-shot local Interrupt() to fire ~500ms from now. By then the
+# next statement (a slow remote query) is in flight; the client-side watchdog
+# inside HttpsQuackClient::RequestInternal should observe IsInterrupted()=true,
+# post a CancelRequest with the matching client_query_id, and the server's
+# CancelRequest handler should call Connection::Interrupt() on the running
+# duckdb_connection. The remote query then aborts and the client surfaces an
+# Interrupted! error.
+statement ok con2
+CALL quack_test_schedule_interrupt(500);
+
+# Query shape matters: simpler "slow" queries (count(*) FROM range, ORDER BY ...
+# LIMIT 1, etc.) get constant-folded or pushed down by the optimizer and finish
+# in well under our 500ms window, defeating the test. hash() over a billion-row
+# range is genuinely CPU-bound and can't be shortcut.
+statement error con2
+FROM quack_query('quack:localhost', 'SELECT sum(hash(i)) FROM range(1_000_000_000) t(i)')
+----
+Interrupted!
+
+# Connection survives a cancel — a follow-up query on the same client works.
+query I con2
+FROM quack_query('quack:localhost', 'SELECT 43')
+----
+43
+
+statement ok con1
+CALL quack_stop('quack:localhost');


### PR DESCRIPTION
PREPARE/FETCH on the client side could hang indefinitely on a slow server query — Ctrl-C in the local shell set the interrupted flag but the scan thread was stuck in a blocking HTTP read.

Adds MessageType::CANCEL_REQUEST. Server tracks the currently-running client_query_id in an atomic on QuackConnection so the cancel handler can call Connection::Interrupt() without taking the connection lock that the running query is already holding.

On the client, a watchdog thread runs alongside each cancellable Request, polling ClientContext::IsInterrupted() and, on interrupt, opening a fresh client to post the cancel.

Closes #136