### PR TITLE
Support path-prefixed quack URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ FROM remote.hello;
 
 This should show the content of the remote table `hello` on the client side.
 
+Quack URIs can include an HTTP path when the endpoint is exposed behind a path-prefixing reverse proxy:
+
+```sql
+CALL quack_serve('quack:localhost/duckdb', token = 'super_secret');
+ATTACH 'quack:localhost/duckdb' AS remote;
+```
+
+When a path is provided, clients send RPC requests to that path instead of the default `/quack` endpoint.
+
 We can also copy data from client to server:
 
 ```sql

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,13 +31,23 @@ need to connect. This token can also be [set](#authentication--authorization).
 
 RPC endpoints use the `quack:` scheme, some examples:
 
-| URI                       | Host        | Port (default 1294) |
-|---------------------------|-------------|---------------------|
-| `quack:localhost`         | `localhost` | `1294`              |
-| `quack:myhost:9000`       | `myhost`    | `9000`              |
-| `quack:127.0.0.1`         | `127.0.0.1` | `1294`              |
-| `quack:[::1]:1234`        | `::1`       | `1234` (IPv6)       |
-| `quack://localhost`       | `localhost` | `1294`              |
+| URI                            | Host        | Port (default 9494) | HTTP endpoint                 |
+|--------------------------------|-------------|---------------------|-------------------------------|
+| `quack:localhost`              | `localhost` | `9494`              | `/quack`                      |
+| `quack:myhost:9000`            | `myhost`    | `9000`              | `/quack`                      |
+| `quack:myhost:9000/duckdb`     | `myhost`    | `9000`              | `/duckdb`                     |
+| `quack:127.0.0.1`              | `127.0.0.1` | `9494`              | `/quack`                      |
+| `quack:[::1]:1234`             | `::1`       | `1234` (IPv6)       | `/quack`                      |
+| `quack://localhost`            | `localhost` | `9494`              | `/quack`                      |
+
+If a URI includes a path, clients send RPC requests to that path instead of
+the default `/quack` endpoint. This is useful when routing Quack through a
+reverse proxy under a path prefix:
+
+```sql
+CALL rpc_start('quack:localhost:9000/duckdb');
+ATTACH 'quack:localhost:9000/duckdb' AS rpc;
+```
 
 You can parse and validate a URI with the `rpc_uri_parser(uri, ssl)`
 scalar function.
@@ -147,7 +157,7 @@ SET rpc_default_token = '<token-from-rpc_start>';
 
 | Function                      | Description                                                         |
 |------------------------------|---------------------------------------------------------------------|
-| `rpc_uri_parser(uri, ssl)`   | Parse an RPC URI into `{host, port, ipv6, ssl, url}`.               |
+| `rpc_uri_parser(uri, ssl)`   | Parse an RPC URI into `{host, port, ipv6, ssl, url, path, endpoint}`. |
 | `rpc_auth_token(sid, token)` | Default authentication callback; compares against `rpc_default_token`. |
 | `rpc_dummy_authorization(sid, query)` | Default authorization callback; always allows.              |
 

--- a/src/include/quack_uri.hpp
+++ b/src/include/quack_uri.hpp
@@ -14,6 +14,9 @@ public:
 	string Http() const {
 		return http;
 	}
+	string HttpEndpoint() const {
+		return http + path;
+	}
 	string Uri() const {
 		return uri;
 	}
@@ -33,12 +36,15 @@ public:
 	bool IPv6() const {
 		return ipv6;
 	}
+	string Path() const {
+		return path;
+	}
 	bool IsLocal() const {
 		return StringUtil::Lower(host) == "localhost" || host == "127.0.0.1" || host == "::1";
 	}
 	bool operator==(const QuackUri &other) const {
 		return other.ssl == ssl && other.ipv6 == ipv6 && other.host == host && other.port == port &&
-		       other.http == http && other.uri == uri;
+		       other.http == http && other.path == path && other.uri == uri;
 	}
 	bool operator!=(const QuackUri &other) const {
 		return !(*this == other);
@@ -50,6 +56,7 @@ private:
 	string host;
 	uint16_t port; // default port!
 	string http;
+	string path;
 	string uri;
 };
 

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -32,7 +32,7 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 	lock_guard<mutex> guard(request_mutex);
 
 	auto &http_util = HTTPUtil::Get(db);
-	auto request_url = uri.Http() + "/quack";
+	auto request_url = uri.HttpEndpoint();
 	if (!http_params) {
 		if (context && context->transaction.HasActiveTransaction()) {
 			http_params = http_util.InitializeParameters(*context, request_url);
@@ -114,7 +114,7 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 				error = response_message->Cast<ErrorResponse>().ErrorMessage();
 			}
 			auto msg =
-			    QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.Http(),
+			    QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.HttpEndpoint(),
 			                                      end_time - start_time, response_message->Type(), error);
 			logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 		}

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -72,15 +72,15 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 
 	// TODO: this is very liberal, and there might be reasonable cases to restrict to trusted domains (note, this is
 	// only relevant from within a Web browser, since other actors can just ignore the CORS convention
-	server->Options("/quack", [](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {
+	server->Options(uri_p.Path(), [](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {
 		res.set_header("Access-Control-Allow-Origin", "*");
 		res.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
 		res.set_header("Access-Control-Allow-Headers", "*");
 		res.status = 204;
 	});
 
-	server->Post("/quack", [&](const duckdb_httplib::Request &, duckdb_httplib::Response &res,
-	                           const duckdb_httplib::ContentReader &content_reader) {
+	server->Post(uri_p.Path(), [&](const duckdb_httplib::Request &, duckdb_httplib::Response &res,
+	                               const duckdb_httplib::ContentReader &content_reader) {
 		res.set_header("Access-Control-Allow-Origin", "*");
 		MemoryStream stream;
 		content_reader([&](const char *data, size_t data_length) {

--- a/src/quack_uri.cpp
+++ b/src/quack_uri.cpp
@@ -7,6 +7,7 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
 	// whitespace be gone
 	ipv6 = false;
 	port = 9494;
+	path = "/quack";
 	StringUtil::Trim(uri);
 	// first off, lets be tolerant and accept this variant, too
 	if (StringUtil::StartsWith(uri, "quack://")) {
@@ -20,6 +21,16 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
 	if (remainder.empty()) {
 		throw InvalidInputException("Missing hostname");
 	}
+
+	auto path_pos = remainder.find('/');
+	if (path_pos != string::npos) {
+		path = remainder.substr(path_pos);
+		remainder = remainder.substr(0, path_pos);
+		if (path.empty()) {
+			throw InvalidInputException("Invalid Path");
+		}
+	}
+
 	// we have an ipv6 URL
 	if (StringUtil::StartsWith(remainder, "[")) {
 		if (!StringUtil::Contains(remainder, ']')) {
@@ -32,6 +43,9 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
 			throw InvalidInputException("Missing IPv6 Address");
 		}
 		remainder = remainder.substr(pos + 1);
+		if (!remainder.empty() && !StringUtil::StartsWith(remainder, ":")) {
+			throw InvalidInputException("Invalid IPv6 URL");
+		}
 	}
 
 	// a port was specified
@@ -57,6 +71,9 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
 	if (!ipv6) {
 		host = remainder;
 	}
+	if (host.empty()) {
+		throw InvalidInputException("Missing hostname");
+	}
 	http = StringUtil::Format("http%s://%s:%d", ssl ? "s" : "", ipv6 ? "[" + host + "]" : host, port);
 }
 
@@ -70,7 +87,9 @@ static void QuackUriParser(const DataChunk &args, ExpressionState &, Vector &res
 	                                  {"port", Value::USMALLINT(parsed.Port())},
 	                                  {"ipv6", Value::BOOLEAN(parsed.IPv6())},
 	                                  {"ssl", Value::BOOLEAN(parsed.Ssl())},
-	                                  {"url", Value(parsed.Http())}}));
+	                                  {"url", Value(parsed.Http())},
+	                                  {"path", Value(parsed.Path())},
+	                                  {"endpoint", Value(parsed.HttpEndpoint())}}));
 	result.SetVectorType(VectorType::CONSTANT_VECTOR);
 }
 
@@ -81,7 +100,9 @@ ScalarFunction QuackParseUriFunction::GetFunction() {
 	                                           {"port", LogicalType::USMALLINT},
 	                                           {"ipv6", LogicalType::BOOLEAN},
 	                                           {"ssl", LogicalType::BOOLEAN},
-	                                           {"url", LogicalType::VARCHAR}}),
+	                                           {"url", LogicalType::VARCHAR},
+	                                           {"path", LogicalType::VARCHAR},
+	                                           {"endpoint", LogicalType::VARCHAR}}),
 	                      QuackUriParser);
 }
 

--- a/test/sql/path_prefix.test
+++ b/test/sql/path_prefix.test
@@ -1,0 +1,27 @@
+# name: test/sql/path_prefix.test
+# description: verify quack URI path prefixes are used as the HTTP endpoint
+# group: [sql]
+
+require quack
+
+require httpfs
+
+query III con1
+call quack_serve('quack:localhost:20119/duckdb', token='asdf');
+----
+quack:localhost:20119/duckdb	http://localhost:20119	asdf
+
+sleep 100 millisecond
+
+query I con2
+from quack_query('quack:localhost:20119/duckdb', 'select 42', token='asdf')
+----
+42
+
+statement error con2
+from quack_query('quack:localhost:20119', 'select 42', token='asdf')
+----
+Failed to send message
+
+statement ok con1
+call quack_stop('quack:localhost:20119/duckdb');

--- a/test/sql/uri.test
+++ b/test/sql/uri.test
@@ -6,50 +6,60 @@ require quack
 
 require httpfs
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:localhost', true));
 ----
-localhost	9494	false	true	https://localhost:9494
+localhost	9494	false	true	https://localhost:9494	/quack	https://localhost:9494/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:localhost', false));
 ----
-localhost	9494	false	false	http://localhost:9494
+localhost	9494	false	false	http://localhost:9494	/quack	http://localhost:9494/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack://localhost', true));
 ----
-localhost	9494	false	true	https://localhost:9494
+localhost	9494	false	true	https://localhost:9494	/quack	https://localhost:9494/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:localhost:1234', true));
 ----
-localhost	1234	false	true	https://localhost:1234
+localhost	1234	false	true	https://localhost:1234	/quack	https://localhost:1234/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:otherhost', true));
 ----
-otherhost	9494	false	true	https://otherhost:9494
+otherhost	9494	false	true	https://otherhost:9494	/quack	https://otherhost:9494/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:127.0.0.1', true));
 ----
-127.0.0.1	9494	false	true	https://127.0.0.1:9494
+127.0.0.1	9494	false	true	https://127.0.0.1:9494	/quack	https://127.0.0.1:9494/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:127.0.0.1:1234', true));
 ----
-127.0.0.1	1234	false	true	https://127.0.0.1:1234
+127.0.0.1	1234	false	true	https://127.0.0.1:1234	/quack	https://127.0.0.1:1234/quack
 
-query IIIII
+query IIIIIII
+select unnest(quack_uri_parser('quack:127.0.0.1:1234/duckdb', true));
+----
+127.0.0.1	1234	false	true	https://127.0.0.1:1234	/duckdb	https://127.0.0.1:1234/duckdb
+
+query IIIIIII
 select unnest(quack_uri_parser('quack:[::1]', true));
 ----
-::1	9494	true	true	https://[::1]:9494
+::1	9494	true	true	https://[::1]:9494	/quack	https://[::1]:9494/quack
 
-query IIIII
+query IIIIIII
 select unnest(quack_uri_parser('quack:[::1]:1234', true));
 ----
-::1	1234	true	true	https://[::1]:1234
+::1	1234	true	true	https://[::1]:1234	/quack	https://[::1]:1234/quack
+
+query IIIIIII
+select unnest(quack_uri_parser('quack:[::1]:1234/duckdb', true));
+----
+::1	1234	true	true	https://[::1]:1234	/duckdb	https://[::1]:1234/duckdb
 
 
 #failure cases


### PR DESCRIPTION
## Summary
- parse optional paths in `quack:` URIs and expose the full HTTP endpoint through `QuackUri`
- use the parsed endpoint for client requests and server POST/OPTIONS route registration
- document path-prefixed URIs and add SQL coverage for URI parsing and prefixed endpoints

## Validation
- `make`
- `make test`

Fixes #119