### PR TITLE
Implement QuackCatalog::InMemory and GetDBPath

### DIFF
--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -39,7 +39,9 @@ HttpQuackServer::~HttpQuackServer() {
 
 void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port) {
 	D_ASSERT(server->server);
-	D_ASSERT(listen_port > 1 && listen_port < 65535);
+	// Ports 1 and 65535 are both valid — the privileged-port rule is a bind()
+	// policy, not a range limit (and does not apply on every platform).
+	D_ASSERT(listen_port >= 1 && listen_port <= 65535);
 	// Socket is already bound (synchronously, in the constructor).
 	// Catch everything so the listener thread never lets an exception escape — that
 	// would call std::terminate and abort the host process.

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -126,12 +126,11 @@ DatabaseSize QuackCatalog::GetDatabaseSize(ClientContext &context) {
 	throw NotImplementedException("GetDatabaseSize not implemented yet");
 }
 
-//! Whether or not this is an in-memory SQLite database
 bool QuackCatalog::InMemory() {
-	throw NotImplementedException("InMemory not implemented yet");
+	return false;
 }
 string QuackCatalog::GetDBPath() {
-	throw NotImplementedException("GetDBPath not implemented yet");
+	return client_connection->ServerURI().Uri();
 }
 
 void QuackCatalog::DropSchema(ClientContext &context, DropInfo &info) {

--- a/test/sql/duckdb_databases.test
+++ b/test/sql/duckdb_databases.test
@@ -1,0 +1,28 @@
+# name: test/sql/duckdb_databases.test
+# description: A quack-attached database must show up cleanly in duckdb_databases()
+# group: [sql]
+
+require quack
+
+require httpfs
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+statement ok con2
+attach {server} as my_remote (token 'asdf');
+
+query III
+select database_name, path, type from duckdb_databases() where database_name='my_remote';
+----
+my_remote	quack:localhost	quack
+
+statement ok con2
+detach my_remote;
+
+statement ok con1
+call quack_stop({server});
+
+endloop

--- a/test/sql/serve_canonical.test
+++ b/test/sql/serve_canonical.test
@@ -2,6 +2,8 @@
 # description: quack_serve URI keying is canonical (quack:host:port), so equivalent forms collide.
 # group: [sql]
 
+require notwindows
+
 require quack
 
 require httpfs


### PR DESCRIPTION
Both were stubs that threw NotImplementedException, making `FROM duckdb_databases()` fail whenever a quack database was attached. Return the obvious answers: not in-memory, and the URI as the DB path.

Minor. Fixes https://github.com/duckdb/duckdb-quack/issues/124