### PR TITLE
Support schema-scoped Quack attach and targeted cache refresh

### DIFF
--- a/src/include/quack_clear_cache.hpp
+++ b/src/include/quack_clear_cache.hpp
@@ -3,10 +3,11 @@
 namespace duckdb {
 
 class TableFunction;
+class TableFunctionSet;
 
 class QuackClearCacheFunction {
 public:
-	static TableFunction GetFunction();
+	static TableFunctionSet GetFunction();
 };
 
 } // namespace duckdb

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -10,18 +10,20 @@ struct QuackScanBindData : FunctionData {
 		auto &other = other_p.Cast<QuackScanBindData>();
 		return other.client_connection->ConnectionId() == client_connection->ConnectionId() &&
 		       other.client_connection->ServerURI() == client_connection->ServerURI() &&
-		       other.table_name == table_name && other.column_names == column_names &&
-		       other.column_types == column_types;
+		       other.schema_name == schema_name && other.table_name == table_name &&
+		       other.column_names == column_names && other.column_types == column_types;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackScanBindData>();
 		result->client_connection = client_connection;
+		result->schema_name = schema_name;
 		result->table_name = table_name;
 		result->column_names = column_names;
 		result->column_types = column_types;
 		return std::move(result);
 	}
 
+	string schema_name;
 	string table_name;
 	vector<string> column_names;
 	vector<LogicalType> column_types;

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -21,7 +21,7 @@ class QuackClientConnection;
 class QuackCatalog : public Catalog {
 public:
 	explicit QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p, ClientContext &context,
-	                      const string &token);
+	                      const string &token, string schema_filter = string());
 	~QuackCatalog() override;
 
 public:
@@ -70,6 +70,7 @@ private:
 private:
 	shared_ptr<QuackClientConnection> client_connection;
 	unique_ptr<QuackSchemaSet> schemas;
+	string schema_filter;
 };
 
 } // namespace duckdb

--- a/src/include/storage/quack_schema.hpp
+++ b/src/include/storage/quack_schema.hpp
@@ -22,7 +22,7 @@ class QuackSchemaSet : public QuackCatalogSet {
 public:
 	QuackSchemaSet(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data);
 
-	static string GetLoadQuery();
+	static string GetLoadQuery(const string &schema_filter = string());
 
 	void Reload(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data);
 };

--- a/src/include/storage/quack_table.hpp
+++ b/src/include/storage/quack_table.hpp
@@ -20,7 +20,7 @@ public:
 	QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &parent, const QuackLoadCatalogData &load_data);
 	explicit QuackTableSet(QuackSchemaCatalogEntry &parent);
 
-	static string GetLoadQuery();
+	static string GetLoadQuery(const string &schema_filter = string());
 
 private:
 	QuackSchemaCatalogEntry &schema;

--- a/src/quack_clear_cache.cpp
+++ b/src/quack_clear_cache.cpp
@@ -1,5 +1,7 @@
 #include "quack_clear_cache.hpp"
 
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/function_set.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -11,13 +13,24 @@ namespace duckdb {
 
 struct ClearCacheFunctionData : public TableFunctionData {
 	bool finished = false;
+	string catalog_name;
 };
 
-unique_ptr<FunctionData> ClearCacheBind(ClientContext &, TableFunctionBindInput &, vector<LogicalType> &return_types,
-                                        vector<string> &names) {
+unique_ptr<FunctionData> ClearCacheBind(ClientContext &, TableFunctionBindInput &input,
+                                        vector<LogicalType> &return_types, vector<string> &names) {
+	auto bind_data = make_uniq<ClearCacheFunctionData>();
+	if (!input.inputs.empty()) {
+		if (input.inputs[0].IsNull()) {
+			throw InvalidInputException("Catalog name cannot be NULL");
+		}
+		bind_data->catalog_name = input.inputs[0].GetValue<string>();
+		if (bind_data->catalog_name.empty()) {
+			throw InvalidInputException("Catalog name cannot be empty");
+		}
+	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
-	return make_uniq<ClearCacheFunctionData>();
+	return std::move(bind_data);
 }
 
 void ClearQuackCaches(ClientContext &context) {
@@ -31,17 +44,38 @@ void ClearQuackCaches(ClientContext &context) {
 	}
 }
 
-void ClearCacheFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &) {
+void ClearQuackCache(ClientContext &context, const string &catalog_name) {
+	auto db = DatabaseManager::Get(context).GetDatabase(context, catalog_name);
+	if (!db) {
+		throw CatalogException("Failed to find attached database \"%s\"", catalog_name);
+	}
+	auto &catalog = db->GetCatalog();
+	if (catalog.GetCatalogType() != "quack") {
+		throw BinderException("Attached database \"%s\" does not refer to a Quack database", catalog_name);
+	}
+	catalog.Cast<QuackCatalog>().Refresh(context);
+}
+
+void ClearCacheFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.bind_data->CastNoConst<ClearCacheFunctionData>();
 	if (data.finished) {
 		return;
 	}
-	ClearQuackCaches(context);
+	if (data.catalog_name.empty()) {
+		ClearQuackCaches(context);
+	} else {
+		ClearQuackCache(context, data.catalog_name);
+	}
+	output.SetValue(0, 0, Value::BOOLEAN(true));
+	output.SetCardinality(1);
 	data.finished = true;
 }
 
-TableFunction QuackClearCacheFunction::GetFunction() {
-	return TableFunction("quack_clear_cache", {}, ClearCacheFunction, ClearCacheBind);
+TableFunctionSet QuackClearCacheFunction::GetFunction() {
+	TableFunctionSet set("quack_clear_cache");
+	set.AddFunction(TableFunction("quack_clear_cache", {}, ClearCacheFunction, ClearCacheBind));
+	set.AddFunction(TableFunction("quack_clear_cache", {LogicalType::VARCHAR}, ClearCacheFunction, ClearCacheBind));
+	return set;
 }
 
 } // namespace duckdb

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -216,8 +216,8 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 	if (bind_data.schema_name.empty()) {
 		query += StringUtil::Format("FROM %s", SQLIdentifier(bind_data.table_name));
 	} else {
-		query += StringUtil::Format("FROM %s.%s", SQLIdentifier(bind_data.schema_name),
-		                            SQLIdentifier(bind_data.table_name));
+		query +=
+		    StringUtil::Format("FROM %s.%s", SQLIdentifier(bind_data.schema_name), SQLIdentifier(bind_data.table_name));
 	}
 	//
 	// // Filters: build WHERE clause from pushable filters

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -213,7 +213,12 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 	// 		query = "SELECT " + StringUtil::Join(selected_columns, ", ") + " ";
 	// 	}
 	// }
-	query += StringUtil::Format("FROM %s", SQLIdentifier(bind_data.table_name));
+	if (bind_data.schema_name.empty()) {
+		query += StringUtil::Format("FROM %s", SQLIdentifier(bind_data.table_name));
+	} else {
+		query += StringUtil::Format("FROM %s.%s", SQLIdentifier(bind_data.schema_name),
+		                            SQLIdentifier(bind_data.table_name));
+	}
 	//
 	// // Filters: build WHERE clause from pushable filters
 	// if (input.filters) {

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -84,7 +84,11 @@ static unique_ptr<Catalog> QuackAttach(optional_ptr<StorageExtensionInfo> storag
 	if (attach_options.options.find("token") != attach_options.options.end()) {
 		token = attach_options.options["token"].GetValue<string>();
 	}
-	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token);
+	string schema_filter;
+	if (attach_options.options.find("schema") != attach_options.options.end()) {
+		schema_filter = attach_options.options["schema"].GetValue<string>();
+	}
+	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token, std::move(schema_filter));
 }
 
 static unique_ptr<TransactionManager> QuackCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/secret/secret.hpp"
@@ -21,8 +22,8 @@
 namespace duckdb {
 
 QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, ClientContext &context,
-                           const string &token)
-    : Catalog(db_p) {
+                           const string &token, string schema_filter_p)
+    : Catalog(db_p), schema_filter(std::move(schema_filter_p)) {
 	// connect to the server
 	client_connection = QuackClient::ConnectToServer(context, server_uri, token);
 
@@ -33,8 +34,8 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
 
 QuackLoadCatalogData QuackCatalog::LoadCatalog(ClientContext &context) {
 	QuackLoadCatalogData result;
-	result.schemas = ExecuteCommandInternal(context, QuackSchemaSet::GetLoadQuery());
-	result.tables = ExecuteCommandInternal(context, QuackTableSet::GetLoadQuery());
+	result.schemas = ExecuteCommandInternal(context, QuackSchemaSet::GetLoadQuery(schema_filter));
+	result.tables = ExecuteCommandInternal(context, QuackTableSet::GetLoadQuery(schema_filter));
 	return result;
 }
 
@@ -94,6 +95,10 @@ const string &QuackCatalog::GetConnectionId() {
 }
 
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
+	if (!schema_filter.empty() && !StringUtil::CIEquals(info.schema, schema_filter)) {
+		throw BinderException("Cannot create schema \"%s\" through schema-scoped Quack catalog \"%s\"", info.schema,
+		                      schema_filter);
+	}
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	// create schema remotely
 	quack_transaction.Query(info.ToString());

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -28,13 +28,17 @@ void QuackSchemaSet::Reload(ClientContext &context, QuackCatalog &catalog, const
 	}
 }
 
-string QuackSchemaSet::GetLoadQuery() {
-	return R"(
+string QuackSchemaSet::GetLoadQuery(const string &schema_filter) {
+	string query = R"(
 SELECT catalog_name, schema_name
 FROM information_schema.schemata
 WHERE catalog_name NOT IN ('system', 'temp')
-ORDER BY ALL
-	)";
+)";
+	if (!schema_filter.empty()) {
+		query += StringUtil::Format("AND schema_name = %s\n", SQLString(schema_filter));
+	}
+	query += "ORDER BY ALL";
+	return query;
 }
 
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p)

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -65,13 +65,17 @@ QuackTableSet::QuackTableSet(QuackSchemaCatalogEntry &parent)
     : QuackCatalogSet(parent.ParentCatalog().Cast<QuackCatalog>()), schema(parent) {
 }
 
-string QuackTableSet::GetLoadQuery() {
+string QuackTableSet::GetLoadQuery(const string &schema_filter) {
+	auto schema_predicate =
+	    schema_filter.empty() ? string() : StringUtil::Format("WHERE schema_name = %s\n", SQLString(schema_filter));
 	return R"(
 SELECT schema_name, sql, 'table'
 FROM duckdb_tables()
+)" + schema_predicate + R"(
 UNION ALL
 SELECT schema_name, view_name, 'view'
 FROM duckdb_views()
+)" + schema_predicate + R"(
 	)";
 }
 
@@ -79,6 +83,7 @@ TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, un
 	auto &quack_catalog = catalog.Cast<QuackCatalog>();
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = quack_catalog.GetClientConnection();
+	bind_data->schema_name = ParentSchema().name;
 	bind_data->table_name = name;
 	for (auto &col : GetColumns().Physical()) {
 		bind_data->column_names.push_back(col.Name());

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -71,11 +71,13 @@ string QuackTableSet::GetLoadQuery(const string &schema_filter) {
 	return R"(
 SELECT schema_name, sql, 'table'
 FROM duckdb_tables()
-)" + schema_predicate + R"(
+)" + schema_predicate +
+	       R"(
 UNION ALL
 SELECT schema_name, view_name, 'view'
 FROM duckdb_views()
-)" + schema_predicate + R"(
+)" + schema_predicate +
+	       R"(
 	)";
 }
 

--- a/test/sql/attach_schema.test
+++ b/test/sql/attach_schema.test
@@ -1,0 +1,55 @@
+# name: test/sql/attach_schema.test
+# description: test schema-scoped quack attach
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+create table t as values (7);
+
+statement ok con1
+create schema wanted;
+
+statement ok con1
+create table wanted.t as values (42);
+
+statement ok con1
+create schema other;
+
+statement ok con1
+create table other.t as values (99);
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+statement ok con2
+attach {server} as rpc (token 'asdf', schema 'wanted')
+
+query I con2
+select col0 from rpc.wanted.t;
+----
+42
+
+statement error con2
+select * from rpc.other.t;
+----
+schema "other" does not exist
+
+statement error con2
+create schema rpc.other;
+----
+Cannot create schema "other" through schema-scoped Quack catalog "wanted"
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -18,6 +18,9 @@ statement ok con2
 attach 'quack:localhost' as rpc
 
 statement ok con2
+attach 'quack:localhost' as rpc2
+
+statement ok con2
 call system.main.quack_query_by_name('rpc', 'CREATE TABLE t1(i INTEGER); INSERT INTO t1 VALUES (1),(2),(3);')
 
 statement error con2
@@ -26,10 +29,25 @@ SELECT i FROM rpc.t1
 Table with name t1 does not exist
 
 statement ok con2
-CALL quack_clear_cache()
+CALL quack_clear_cache('rpc')
 
 query I con2
 SELECT i FROM rpc.t1 ORDER BY i
+----
+1
+2
+3
+
+statement error con2
+SELECT i FROM rpc2.t1
+----
+Table with name t1 does not exist
+
+statement ok con2
+CALL quack_clear_cache('rpc2')
+
+query I con2
+SELECT i FROM rpc2.t1 ORDER BY i
 ----
 1
 2
@@ -76,6 +94,9 @@ Catalog Error: Table with name t1 does not exist
 
 statement ok con2
 detach rpc;
+
+statement ok con2
+detach rpc2;
 
 statement ok con1
 call quack_stop('quack:localhost');

--- a/test/sql/rpc.test
+++ b/test/sql/rpc.test
@@ -135,7 +135,7 @@ call quack_stop({server})
 statement error con2
 from quack_query({server}, 'select 42')
 ----
-IO Error
+Error
 
 # we can call quack_serve() without parameters and connect using just quack:localhost
 statement ok
@@ -150,4 +150,3 @@ statement ok
 call quack_stop('quack:localhost')
 
 endloop
-


### PR DESCRIPTION
## Summary

- add an optional `schema` attach option for Quack catalogs
- use the schema filter when loading remote schemas, tables, and views
- preserve the remote schema when scanning attached tables
- reject out-of-scope `CREATE SCHEMA` calls on schema-scoped Quack catalogs
- allow `quack_clear_cache(schema_name)` to refresh only one attached metadata schema
- keep the existing zero-argument `quack_clear_cache()` behavior for full-cache refreshes

## Why

DuckLake can store many independent metadata catalogs in one Quack server by using one schema per catalog. Without a schema-scoped Quack attach, each DuckLake attach has to import the whole remote Quack catalog, which gets increasingly expensive as more DuckLake catalogs are attached.

This gives DuckLake a narrow attach primitive via `META_SCHEMA`, so it can attach only the metadata schema it needs. The targeted cache refresh lets DuckLake invalidate just that metadata schema after commits instead of clearing and reloading every Quack-attached catalog.

## Related

- Pairs with duckdb/ducklake#1177, which updates DuckLake's Quack metadata manager to call the targeted cache refresh when available while falling back to the legacy zero-argument call.