### PR TITLE
Add `quack_idle_timeout_seconds` options and `quack_status()`

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -17,6 +17,8 @@ enum class MessageType : uint8_t {
 	APPEND_REQUEST = 9,
 	SUCCESS_RESPONSE = 10,
 	DISCONNECT_MESSAGE = 11,
+	STATUS_REQUEST = 12,
+	STATUS_RESPONSE = 13,
 	ERROR_RESPONSE = 100
 };
 
@@ -381,6 +383,81 @@ protected:
 
 private:
 	ErrorData error;
+};
+
+//! STATUS_REQUEST — minimal probe carrying just the server's auth token. Server compares it
+//! against its own `Token()` and returns ErrorResponse on mismatch. Does NOT count as activity
+//! for the idle-timeout computation (that's the load-bearing property of this message-pair).
+class StatusRequest : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::STATUS_REQUEST;
+
+	explicit StatusRequest(string token_p) : QuackMessage(TYPE), token(std::move(token_p)) {
+	}
+
+	const string &Token() const {
+		return token;
+	}
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<StatusRequest> Deserialize(Deserializer &deserializer);
+
+protected:
+	StatusRequest() : QuackMessage(TYPE) {
+	}
+
+private:
+	string token;
+};
+
+//! STATUS_RESPONSE — single field: a 16-char ASCII directive, space-padded ("OK" or "IDLE",
+//! right-padded to 16). The payload is intentionally minimal and **frozen** at this shape:
+//! clients (especially lightweight HTTP-only ones like AWS Lambda) can byte-compare the
+//! response against two known fixed sequences without parsing.
+//!
+//! Directive is derived purely from `quack_idle_timeout_seconds` + the server's tracked
+//! last-activity time. STATUS_REQUEST does NOT bump activity — that's the load-bearing
+//! property of this message-type pair (any other RPC would corrupt the idle measurement just
+//! by polling).
+class StatusResponse : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::STATUS_RESPONSE;
+	static constexpr idx_t DIRECTIVE_LENGTH = 16;
+
+	explicit StatusResponse(const string &directive_p) : QuackMessage(TYPE), directive(PadDirective(directive_p)) {
+	}
+
+	//! Returns the raw 16-char padded directive. Use `TrimmedDirective()` for the logical value.
+	const string &Directive() const {
+		return directive;
+	}
+
+	//! Returns the directive with trailing spaces removed ("OK" / "IDLE" etc).
+	string TrimmedDirective() const {
+		auto end = directive.find_last_not_of(' ');
+		return end == string::npos ? string() : directive.substr(0, end + 1);
+	}
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<StatusResponse> Deserialize(Deserializer &deserializer);
+
+protected:
+	StatusResponse() : QuackMessage(TYPE), directive(DIRECTIVE_LENGTH, ' ') {
+	}
+
+	//! Right-pads (or throws if too long) a logical directive value to DIRECTIVE_LENGTH chars.
+	static string PadDirective(const string &raw) {
+		if (raw.size() > DIRECTIVE_LENGTH) {
+			throw InternalException("Directive '%s' exceeds fixed length of %d", raw,
+			                        static_cast<int>(DIRECTIVE_LENGTH));
+		}
+		string padded = raw;
+		padded.append(DIRECTIVE_LENGTH - raw.size(), ' ');
+		return padded;
+	}
+
+private:
+	string directive; // always exactly DIRECTIVE_LENGTH chars (space-padded)
 };
 
 } // namespace duckdb

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
 #include <thread>
 
 #include "duckdb/common/optional_ptr.hpp"
@@ -19,6 +21,7 @@ class QueryResult;
 class DatabaseInstance;
 class PreparedStatement;
 class EncryptionState;
+enum class MessageType : uint8_t;
 
 struct QuackConnection {
 	explicit QuackConnection(string session_id_p);
@@ -79,10 +82,26 @@ public:
 		return active_connections.size();
 	}
 
+	//! Returns the wall-clock epoch seconds of the most recent non-STATUS message handled by this server.
+	//! STATUS_REQUEST handling does NOT bump this — the timestamp reflects actual work, not health-checks.
+	int64_t LastActivityAtEpochSeconds() const {
+		return last_activity_at_epoch_seconds.load();
+	}
+
+	//! Bumps last_activity_at_epoch_seconds if `type` is anything other than STATUS_REQUEST.
+	//! Called from HandleMessage on every incoming message.
+	void OnMessageReceived(MessageType type);
+
 protected:
 	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);
 	unique_ptr<QuackMessage> HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
 	                                               optional_ptr<QuackConnection> connection);
+
+	//! Reads `quack_idle_timeout_seconds` + `quack_idle` settings and computes the directive
+	//! ("OK" or "IDLE") for STATUS_RESPONSE. Read fresh on every STATUS request so SET changes
+	//! take effect immediately. The server never rejects traffic based on this — directive is
+	//! purely a signal for orchestrators that decide externally what to do with idle instances.
+	string EvaluateDirective(DatabaseInstance &db) const;
 
 protected:
 	std::vector<std::thread> listen_threads;
@@ -93,6 +112,10 @@ protected:
 
 	mutex session_id_rng_mutex;
 	shared_ptr<EncryptionState> session_id_rng;
+
+	//! Wall-clock epoch seconds of the most recent non-STATUS message. Initialized to server-start time;
+	//! bumped by OnMessageReceived. system_clock-derived so it's serializable to clients.
+	std::atomic<int64_t> last_activity_at_epoch_seconds;
 
 private:
 	QuackUri uri;

--- a/src/include/quack_startstop.hpp
+++ b/src/include/quack_startstop.hpp
@@ -19,4 +19,9 @@ public:
 	static TableFunction GetFunction();
 };
 
+class QuackStatusFunction {
+public:
+	static TableFunction GetFunction();
+};
+
 } // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -118,6 +118,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());
 	loader.RegisterFunction(QuackServerListFunction::GetFunction());
+	loader.RegisterFunction(QuackStatusFunction::GetFunction());
 	loader.RegisterFunction(QuackClearCacheFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
 
@@ -155,6 +156,15 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	config.AddExtensionOption("quack_fetch_batch_chunks", "Maximum number of DataChunks returned per FETCH response",
 	                          LogicalType::UBIGINT, Value::UBIGINT(12));
+
+	// STATUS feature — instance-wide setting shared by every quack server hosted in this DuckDB
+	// instance (a single instance can listen on multiple URIs / tokens; they all read the same
+	// value). 0 (default) disables auto-IDLE reporting; positive values are an inclusive
+	// inactivity threshold in seconds.
+	config.AddExtensionOption("quack_idle_timeout_seconds",
+	                          "Seconds of inactivity before STATUS reports IDLE (0 = disabled). "
+	                          "Instance-wide: applies to every server hosted by this DuckDB instance.",
+	                          LogicalType::BIGINT, Value::BIGINT(0), nullptr, SetScope::GLOBAL);
 
 	// Process-wide fallback anchor for whoami().uptime when whoami_started_at isn't set.
 	// Stored as BIGINT epoch-microseconds to stay TZ-invariant regardless of ICU state.

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -51,6 +51,12 @@ MessageType EnumUtil::FromString<MessageType>(const char *value) {
 	if (StringUtil::Equals(value, "DISCONNECT_MESSAGE")) {
 		return MessageType::DISCONNECT_MESSAGE;
 	}
+	if (StringUtil::Equals(value, "STATUS_REQUEST")) {
+		return MessageType::STATUS_REQUEST;
+	}
+	if (StringUtil::Equals(value, "STATUS_RESPONSE")) {
+		return MessageType::STATUS_RESPONSE;
+	}
 	if (StringUtil::Equals(value, "ERROR_RESPONSE")) {
 		return MessageType::ERROR_RESPONSE;
 	}
@@ -79,6 +85,10 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 		return "SUCCESS_RESPONSE";
 	case MessageType::DISCONNECT_MESSAGE:
 		return "DISCONNECT_MESSAGE";
+	case MessageType::STATUS_REQUEST:
+		return "STATUS_REQUEST";
+	case MessageType::STATUS_RESPONSE:
+		return "STATUS_RESPONSE";
 	case MessageType::ERROR_RESPONSE:
 		return "ERROR_RESPONSE";
 
@@ -124,6 +134,10 @@ unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, M
 		return SuccessResponse::Deserialize(deserializer);
 	case MessageType::DISCONNECT_MESSAGE:
 		return DisconnectMessage::Deserialize(deserializer);
+	case MessageType::STATUS_REQUEST:
+		return StatusRequest::Deserialize(deserializer);
+	case MessageType::STATUS_RESPONSE:
+		return StatusResponse::Deserialize(deserializer);
 	case MessageType::ERROR_RESPONSE:
 		return ErrorResponse::Deserialize(deserializer);
 	default:

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -27,9 +27,37 @@ void QuackServer::ValidateToken(const string &token) {
 	}
 }
 
+static int64_t NowEpochSeconds() {
+	return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
+	    .count();
+}
+
 QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
-    : db_ptr(context_p.db), uri(uri_p), token(token_p) {
+    : db_ptr(context_p.db), last_activity_at_epoch_seconds(NowEpochSeconds()), uri(uri_p), token(token_p) {
 	ValidateToken(token);
+}
+
+void QuackServer::OnMessageReceived(MessageType type) {
+	// STATUS probes do not count as activity — health-checking should not keep an idle server alive.
+	if (type != MessageType::STATUS_REQUEST) {
+		last_activity_at_epoch_seconds.store(NowEpochSeconds());
+	}
+}
+
+string QuackServer::EvaluateDirective(DatabaseInstance &db) const {
+	auto &config = DBConfig::GetConfig(db);
+
+	// Derive from idle timeout. A 0 / negative / unset timeout disables auto-IDLE reporting.
+	Value timeout_val;
+	if (!config.TryGetCurrentSetting("quack_idle_timeout_seconds", timeout_val) || timeout_val.IsNull()) {
+		return "OK";
+	}
+	auto timeout_seconds = timeout_val.GetValue<int64_t>();
+	if (timeout_seconds <= 0) {
+		return "OK";
+	}
+	auto elapsed = NowEpochSeconds() - last_activity_at_epoch_seconds.load();
+	return (elapsed >= timeout_seconds) ? "IDLE" : "OK";
 }
 
 QuackServer::~QuackServer() {
@@ -155,6 +183,7 @@ bool ServerSupportsMessage(MessageType type) {
 	case MessageType::FETCH_REQUEST:
 	case MessageType::APPEND_REQUEST:
 	case MessageType::DISCONNECT_MESSAGE:
+	case MessageType::STATUS_REQUEST:
 		return true;
 	default:
 		return false;
@@ -164,6 +193,7 @@ bool ServerSupportsMessage(MessageType type) {
 bool MessageRequiresConnection(MessageType type) {
 	switch (type) {
 	case MessageType::CONNECTION_REQUEST:
+	case MessageType::STATUS_REQUEST:
 		return false;
 	default:
 		return true;
@@ -197,6 +227,10 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	if (!ServerSupportsMessage(header.type)) {
 		return make_uniq<ErrorResponse>("Unsupported message type for server");
 	}
+
+	// Record activity (no-op for STATUS_REQUEST) before deserializing the body — that way slow
+	// or malformed payloads still count as activity from the wall-clock perspective.
+	OnMessageReceived(header.type);
 
 	// if the message requires it, obtain a connection
 	// these are basically all messages aside from connect request
@@ -277,6 +311,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>("Connection does not exist / already disconnected");
 		}
 		return make_uniq<SuccessResponse>();
+	}
+	case MessageType::STATUS_REQUEST: {
+		auto &status_request = received_message.Cast<StatusRequest>();
+		if (status_request.Token() != Token()) {
+			return make_uniq<ErrorResponse>("Authentication failed");
+		}
+		return make_uniq<StatusResponse>(EvaluateDirective(db));
 	}
 	case MessageType::PREPARE_REQUEST: {
 		auto &prepare_request_message = received_message.Cast<PrepareRequestMessage>();

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -1,5 +1,8 @@
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 
+#include "quack_client.hpp"
+#include "quack_message.hpp"
 #include "quack_startstop.hpp"
 #include "quack_storage.hpp"
 
@@ -179,4 +182,75 @@ static void QuackServerList(ClientContext &context, TableFunctionInput &data_p, 
 
 TableFunction QuackServerListFunction::GetFunction() {
 	return TableFunction("quack_server_list", {}, QuackServerList, QuackServerListBind);
+}
+
+struct QuackStatusFunctionData : public TableFunctionData {
+	bool finished = false;
+	QuackUri target_uri;
+	string token;
+};
+
+static unique_ptr<FunctionData> QuackStatusBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	auto bind_data = make_uniq<QuackStatusFunctionData>();
+	auto &uri_value = input.inputs[0];
+	if (uri_value.IsNull() || uri_value.GetValue<string>().empty()) {
+		throw InvalidInputException("Invalid quack URI specified");
+	}
+
+	// Mirror quack_query: SSL off by default for local hosts, optionally overridden by
+	// the `disable_ssl` named parameter.
+	auto initial_uri = QuackUri(uri_value.GetValue<string>());
+	auto enable_ssl = !initial_uri.IsLocal();
+	auto disable_it = input.named_parameters.find("disable_ssl");
+	if (disable_it != input.named_parameters.end() && !disable_it->second.IsNull()) {
+		enable_ssl = !disable_it->second.GetValue<bool>();
+	}
+	bind_data->target_uri = QuackUri(initial_uri.Uri(), enable_ssl);
+
+	auto token_it = input.named_parameters.find("token");
+	if (token_it != input.named_parameters.end() && !token_it->second.IsNull()) {
+		bind_data->token = token_it->second.GetValue<string>();
+	}
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("directive");
+
+	return std::move(bind_data);
+}
+
+static void QuackStatusFun(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->CastNoConst<QuackStatusFunctionData>();
+	if (bind_data.finished) {
+		return;
+	}
+
+	// Resolve token: explicit param > quack secret for this URI. Required — STATUS now auth-checks.
+	auto token = bind_data.token;
+	if (token.empty()) {
+		auto &secret_manager = SecretManager::Get(context);
+		auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+		auto match = secret_manager.LookupSecret(transaction, bind_data.target_uri.Uri(), "quack");
+		if (match.HasMatch()) {
+			const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
+			token = kv.TryGetValue("token", true).ToString();
+		}
+	}
+	if (token.empty()) {
+		throw InvalidInputException("Could not find a Quack authentication token for quack_status()");
+	}
+
+	auto client = QuackClient::GetClient(context, bind_data.target_uri);
+	auto response = client->Request<StatusResponse>(&context, make_uniq<StatusRequest>(token));
+
+	output.SetValue(0, 0, Value(response->TrimmedDirective()));
+	output.SetCardinality(1);
+	bind_data.finished = true;
+}
+
+TableFunction QuackStatusFunction::GetFunction() {
+	auto fun = TableFunction("quack_status", {LogicalType::VARCHAR}, QuackStatusFun, QuackStatusBind);
+	fun.named_parameters["token"] = LogicalType::VARCHAR;
+	fun.named_parameters["disable_ssl"] = LogicalType::BOOLEAN;
+	return fun;
 }

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -138,6 +138,26 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	return result;
 }
 
+void StatusRequest::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(1, "token", token);
+}
+
+unique_ptr<StatusRequest> StatusRequest::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<StatusRequest>(new StatusRequest());
+	deserializer.ReadPropertyWithDefault<string>(1, "token", result->token);
+	return result;
+}
+
+void StatusResponse::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(1, "directive", directive);
+}
+
+unique_ptr<StatusResponse> StatusResponse::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<StatusResponse>(new StatusResponse());
+	deserializer.ReadPropertyWithDefault<string>(1, "directive", result->directive);
+	return result;
+}
+
 void SuccessResponse::Serialize(Serializer &serializer) const {
 }
 

--- a/test/sql/status.test
+++ b/test/sql/status.test
@@ -1,0 +1,80 @@
+# name: test/sql/status.test
+# description: STATUS — directive-only payload. quack_idle_timeout_seconds drives the OK/IDLE
+# group: [sql]
+
+require notwindows
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+# Boot a server.
+statement ok
+FROM quack_serve('quack:127.0.0.1', token='abcd');
+
+# Wrong token is rejected.
+statement error
+FROM quack_status('quack:127.0.0.1', token='wrong');
+----
+Authentication failed
+
+# Missing token (and no secret in scope) is also rejected.
+statement error
+FROM quack_status('quack:127.0.0.1');
+----
+Could not find a Quack authentication token
+
+# Correct token: no timeout configured → OK regardless of inactivity.
+query I
+FROM quack_status('quack:127.0.0.1', token='abcd');
+----
+OK
+
+# Positive timeout with fresh activity → still OK.
+statement ok
+SET quack_idle_timeout_seconds = 3600;
+
+query I
+FROM quack_status('quack:127.0.0.1', token='abcd');
+----
+OK
+
+# Shorten timeout to 1s, sleep > 1s. STATUS does NOT bump activity, so polling here doesn't
+# reset the clock — the flip should happen.
+statement ok
+SET quack_idle_timeout_seconds = 1;
+
+sleep 2 second
+
+query I
+FROM quack_status('quack:127.0.0.1', token='abcd');
+----
+IDLE
+
+# Real query bumps last_activity_at, so next STATUS flips back to OK.
+query I
+FROM quack_query('quack:127.0.0.1', 'SELECT 1', token='abcd');
+----
+1
+
+query I
+FROM quack_status('quack:127.0.0.1', token='abcd');
+----
+OK
+
+# Secret-manager fallback works too.
+statement ok
+CREATE SECRET (type quack, token 'abcd');
+
+query I
+FROM quack_status('quack:127.0.0.1');
+----
+OK
+
+statement ok
+SET quack_idle_timeout_seconds = 0;
+
+statement ok
+CALL quack_stop('quack:127.0.0.1');


### PR DESCRIPTION
Idea is that there is a new message (still part of the protocol) that's special in the sense that STATUS messages are not updating a global activity timer, and are returning `IDLE` whenever more than `quack_idle_timeout_seconds` idle seconds are elapsed.

Goal is allowing in-protocol polling for status of a given instance (that might return IDLE, signaling it's OK to schedule destroy of the resource).

One thing to note: `quack_idle_timeout_seconds` is a global setting per duckdb-instance, not of a specific server. This is at the moment NOT a per-server property.

What this enable is having a different scheduled service that sends `POST` requests to `<endpoint>/quack`, and interprets the response as either `OK` or `IDLE`. If idle, then resource can be scheduled for destruction.