### PR TITLE
Keep track of query state

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
   quack_start_stop.cpp
   quack_storage.cpp
   quack_uri.cpp
+  quack_activity.cpp
   serialize_quack_message.cpp)
 set(EXTENSION_SOURCES
     ${EXTENSION_SOURCES} $<TARGET_OBJECTS:quack_library>

--- a/src/include/quack_activity.hpp
+++ b/src/include/quack_activity.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace duckdb {
+
+class TableFunction;
+
+class QuacktivityFunction {
+public:
+	static TableFunction GetFunction();
+};
+
+} // namespace duckdb

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -20,6 +20,8 @@ class DatabaseInstance;
 class PreparedStatement;
 class EncryptionState;
 
+enum class QuackQueryState : uint8_t { IDLE, ACTIVE, FINISHED, CANCELLED };
+
 struct QuackConnection {
 	explicit QuackConnection(string session_id_p);
 	~QuackConnection();
@@ -32,6 +34,17 @@ struct QuackConnection {
 	//! Current result UUID
 	hugeint_t result_uuid;
 	string session_id;
+	string sql_query;
+	QuackQueryState query_state = QuackQueryState::IDLE;
+	timestamp_t query_started_at {0};
+};
+
+struct QuackConnectionSnapshot {
+	string server_id;
+	string session_id;
+	string sql_query;
+	QuackQueryState query_state = QuackQueryState::IDLE;
+	timestamp_t query_started_at {0};
 };
 
 class QuackServer {
@@ -65,6 +78,8 @@ public:
 
 	//! Throw InvalidInputException if `token` doesn't meet requirements(currently, length >= 4)
 	static void ValidateToken(const string &token);
+
+	vector<QuackConnectionSnapshot> GetActiveConnectionSnap();
 
 	const string &Token() {
 		return token;

--- a/src/include/quack_storage.hpp
+++ b/src/include/quack_storage.hpp
@@ -28,6 +28,8 @@ public:
 		idx_t active_connections;
 		vector<std::pair<string, string>> info;
 	};
+
+	vector<QuackConnectionSnapshot> GetActiveConnectionSnaps();
 	vector<ServerSnapshot> ListServers();
 
 	static constexpr const char *STORAGE_EXTENSION_KEY = "quack";

--- a/src/quack_activity.cpp
+++ b/src/quack_activity.cpp
@@ -1,0 +1,75 @@
+#include "quack_activity.hpp"
+#include "duckdb.hpp"
+#include "duckdb/main/database.hpp"
+
+#include "quack_startstop.hpp"
+#include "quack_storage.hpp"
+
+namespace duckdb {
+
+static string QueryStateToString(QuackQueryState state) {
+	switch (state) {
+	case QuackQueryState::IDLE:
+		return "idle";
+	case QuackQueryState::ACTIVE:
+		return "active";
+	case QuackQueryState::FINISHED:
+		return "finished";
+	case QuackQueryState::CANCELLED:
+		return "cancelled";
+	default:
+		return "unknown";
+	}
+}
+
+struct QuackActivityData : FunctionData {
+	bool finished = false;
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<QuackActivityData>();
+		result->finished = finished;
+		return result;
+	}
+	bool Equals(const FunctionData &) const override {
+		return false;
+	}
+};
+
+static unique_ptr<FunctionData> QuackActivityBind(ClientContext &, TableFunctionBindInput &,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::TIMESTAMP};
+	names = {"server_id", "connection_id", "query", "state", "query_started_at"};
+	return make_uniq<QuackActivityData>();
+}
+
+static void QuackActivityScan(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &data = input.bind_data->CastNoConst<QuackActivityData>();
+	if (data.finished) {
+		return;
+	}
+
+	auto snapshots = QuackStorageExtensionInfo::GetState(*context.db).GetActiveConnectionSnaps();
+
+	idx_t row = 0;
+	for (auto &snap : snapshots) {
+		output.SetValue(0, row, snap.server_id);
+		output.SetValue(1, row, snap.session_id);
+		output.SetValue(2, row, snap.sql_query);
+		output.SetValue(3, row, Value(QueryStateToString(snap.query_state)));
+		if (snap.query_state == QuackQueryState::IDLE) {
+			output.SetValue(4, row, Value(LogicalType::TIMESTAMP));
+		} else {
+			output.SetValue(4, row, Value::TIMESTAMP(snap.query_started_at));
+		}
+		row++;
+	}
+	output.SetCardinality(row);
+	data.finished = true;
+}
+
+TableFunction QuacktivityFunction::GetFunction() {
+	return TableFunction("quack_activity", {}, QuackActivityScan, QuackActivityBind);
+}
+
+} // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -13,6 +13,7 @@
 #include "storage/quack_optimizer.hpp"
 
 #include "include/storage/quack_catalog.hpp"
+#include "quack_activity.hpp"
 #include "quack_clear_cache.hpp"
 #include "quack_extension.hpp"
 #include "quack_log.hpp"
@@ -120,6 +121,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(QuackServerListFunction::GetFunction());
 	loader.RegisterFunction(QuackClearCacheFunction::GetFunction());
 	loader.RegisterFunction(GetQuackIdentifyFunction());
+	loader.RegisterFunction(QuacktivityFunction::GetFunction());
 
 	// the default authentication function
 	ScalarFunction quack_check_token("quack_check_token",

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -35,6 +35,20 @@ QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const 
 QuackServer::~QuackServer() {
 }
 
+vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
+	vector<QuackConnectionSnapshot> result;
+	std::lock_guard<std::mutex> lock(active_connections_mutex);
+	for (auto &[id, conn] : active_connections) {
+		QuackConnectionSnapshot snapshot;
+		snapshot.session_id = conn->session_id;
+		snapshot.sql_query = conn->sql_query;
+		snapshot.query_state = conn->query_state;
+		snapshot.query_started_at = conn->query_started_at;
+		result.push_back(std::move(snapshot));
+	}
+	return result;
+}
+
 shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_id) {
 	std::lock_guard<std::mutex> lock(active_connections_mutex);
 	auto it = active_connections.find(connection_id);
@@ -295,13 +309,21 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 
 		std::unique_lock<std::mutex> lock(connection.lock);
 		connection.duckdb_query_result.reset();
+		connection.sql_query = prepare_request_message.Query();
+		connection.query_state = QuackQueryState::ACTIVE;
+		connection.query_started_at = Timestamp::GetCurrentTimestamp();
 
 		{
 			auto query_result = connection.duckdb_connection->SendQuery(effective_sql);
 			if (query_result->HasError()) {
+				// TODO; instead of cancelled, add an ERROR state
+				connection.query_state = QuackQueryState::CANCELLED;
+				connection.sql_query = "";
 				return make_uniq<ErrorResponse>(query_result->GetErrorObject());
 			}
 			if (query_result->names.empty()) {
+				connection.query_state = QuackQueryState::CANCELLED;
+				connection.sql_query = "";
 				return make_uniq<ErrorResponse>("Query did not return any columns");
 			}
 
@@ -329,6 +351,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(std::move(error_message));
 		}
 		auto needs_more_fetch = results.size() == max_chunks_per_batch;
+		if (!needs_more_fetch) {
+			connection.query_state = QuackQueryState::FINISHED;
+		}
 		return make_uniq<PrepareResponseMessage>(types, names, std::move(results), needs_more_fetch,
 		                                         connection.result_uuid);
 	}
@@ -360,6 +385,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(std::move(error_message));
 		}
 		auto assigned_batch_index = connection.next_batch_index++;
+		if (results.size() < max_chunks_per_batch) {
+			connection.query_state = QuackQueryState::FINISHED;
+		}
 		return make_uniq<FetchResponseMessage>(std::move(results), optional_idx(assigned_batch_index));
 	}
 

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -50,6 +50,18 @@ vector<QuackStorageExtensionInfo::ServerSnapshot> QuackStorageExtensionInfo::Lis
 	return result;
 }
 
+vector<QuackConnectionSnapshot> QuackStorageExtensionInfo::GetActiveConnectionSnaps() {
+	vector<QuackConnectionSnapshot> result;
+	std::lock_guard<std::mutex> lock(servers_mutex);
+	for (auto &[uri, server] : servers) {
+		for (auto &snapshot : server->GetActiveConnectionSnap()) {
+			snapshot.server_id = uri;
+			result.push_back(std::move(snapshot));
+		}
+	}
+	return result;
+}
+
 bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUri &listen_uri) {
 	unique_ptr<QuackServer> to_destroy;
 	{

--- a/test/sql/quack_activity.test
+++ b/test/sql/quack_activity.test
@@ -1,0 +1,82 @@
+# name: test/sql/quack_activity.test
+# description: test quacktivity function for the quack extension
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok
+create table fuu as values(42, 43);
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# no connections yet
+query I con1
+select count(*) from quack_activity();
+----
+0
+
+# attach creates a persistent QuackClientConnection
+statement ok con2
+attach {server} as rpc2 (token 'asdf');
+
+query I con1
+select state from quack_activity();
+----
+finished
+
+loop i 0 3
+
+query II con2
+from rpc2.fuu;
+----
+42	43
+
+query I con1
+select count(*) from quack_activity();
+----
+1
+
+query I con1
+select starts_with(query, 'SELECT') from quack_activity();
+----
+true
+
+endloop
+
+# two clients on the same server
+statement ok con1
+attach {server} as rpc3 (token 'asdf');
+
+query I con1
+select count(*) from quack_activity();
+----
+2
+
+statement ok con1
+detach rpc3;
+
+query I con1
+select count(*) from quack_activity();
+----
+1
+
+# detach removes the session
+statement ok con2
+detach rpc2;
+
+query I con1
+select count(*) from quack_activity();
+----
+0
+
+statement ok con1
+call quack_stop({server});
+
+endloop


### PR DESCRIPTION
This PR introduces `quack_activity()`, a table function inspired by pg_stat_activity to track current active queries. This is a primary implementation, and we can add more (detailed) attributes gradually.

`quack_activity()` shows the `connection_id` from current active connections and their last executed query, along with its `state` and `start time` of the query. For now only `active` and `finished` are used in the state. But the idea is that you'll also be able to see when a query is `idle`, `cancelled` or when it an `error` has been thrown.

This is the same PR as https://github.com/duckdb/duckdb-quack/pull/113. But git lost connection between my original fork of quack and the original repo when quack went public.