### PR TITLE
Explicit cancellations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
   quack_start_stop.cpp
   quack_storage.cpp
   quack_uri.cpp
+  quack_cancel.cpp
   quack_activity.cpp
   serialize_quack_message.cpp)
 set(EXTENSION_SOURCES

--- a/src/include/quack_cancel.hpp
+++ b/src/include/quack_cancel.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace duckdb {
+
+class TableFunction;
+
+class QuackCancelFunction {
+public:
+	static TableFunction GetFunction();
+};
+
+} // namespace duckdb

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -17,6 +17,8 @@ enum class MessageType : uint8_t {
 	APPEND_REQUEST = 9,
 	SUCCESS_RESPONSE = 10,
 	DISCONNECT_MESSAGE = 11,
+	CANCEL_REQUEST = 12,
+	CANCEL_RESPONSE = 13,
 	ERROR_RESPONSE = 100
 };
 
@@ -381,6 +383,35 @@ protected:
 
 private:
 	ErrorData error;
+};
+
+class CancelRequestMessage : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::CANCEL_REQUEST;
+
+	explicit CancelRequestMessage(string connection_id_p, hugeint_t result_uuid_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), result_uuid(result_uuid_p) {
+	}
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<CancelRequestMessage> Deserialize(Deserializer &deserializer);
+
+	hugeint_t result_uuid;
+
+protected:
+	CancelRequestMessage() : QuackMessage(TYPE) {
+	}
+};
+
+class CancelResponseMessage : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::CANCEL_RESPONSE;
+
+	explicit CancelResponseMessage() : QuackMessage(TYPE) {
+	}
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<CancelResponseMessage> Deserialize(Deserializer &deserializer);
 };
 
 } // namespace duckdb

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -65,6 +65,20 @@
     "members": []
   },
   {
+    "class": "CancelRequestMessage",
+    "members": [
+      {
+        "id": 1,
+        "name": "result_uuid",
+        "type": "hugeint_t"
+      }
+    ]
+  },
+  {
+    "class": "CancelResponseMessage",
+    "members": []
+  },
+  {
     "class": "PrepareResponseMessage",
     "members": [
       {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -80,6 +80,7 @@ public:
 	static void ValidateToken(const string &token);
 
 	vector<QuackConnectionSnapshot> GetActiveConnectionSnap();
+	bool CancelConnection(const string &connection_id);
 
 	const string &Token() {
 		return token;

--- a/src/include/quack_storage.hpp
+++ b/src/include/quack_storage.hpp
@@ -30,6 +30,7 @@ public:
 	};
 
 	vector<QuackConnectionSnapshot> GetActiveConnectionSnaps();
+	bool CancelConnection(const string &server_id, const string &connection_id);
 	vector<ServerSnapshot> ListServers();
 
 	static constexpr const char *STORAGE_EXTENSION_KEY = "quack";

--- a/src/quack_cancel.cpp
+++ b/src/quack_cancel.cpp
@@ -1,0 +1,80 @@
+#include "quack_cancel.hpp"
+#include "duckdb.hpp"
+#include "duckdb/main/database.hpp"
+#include "quack_startstop.hpp"
+#include "quack_storage.hpp"
+#include "quack_client.hpp"
+#include "quack_message.hpp"
+#include "quack_uri.hpp"
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+struct QuackCancelBindData : FunctionData {
+	string target_connection_id;
+	string server_uri;
+	bool finished = false;
+
+	explicit QuackCancelBindData(string connection_id_p) : target_connection_id(std::move(connection_id_p)) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		auto result = make_uniq<QuackCancelBindData>(target_connection_id);
+		result->finished = finished;
+		return result;
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return target_connection_id == other_p.Cast<QuackCancelBindData>().target_connection_id;
+	}
+};
+
+static unique_ptr<FunctionData> QuackCancelBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	if (input.inputs[0].IsNull() || input.inputs[1].IsNull() || input.inputs[2].IsNull()) {
+		throw BinderException("quack_cancel arguments cannot be NULL");
+	}
+	auto server_uri_str = input.inputs[0].GetValue<string>();
+	auto target_connection_id = input.inputs[1].GetValue<string>();
+	auto token = input.inputs[2].GetValue<string>();
+
+	return_types = {LogicalType::VARCHAR, LogicalType::BOOLEAN};
+	names = {"connection_id", "cancelled"};
+
+	auto initial_uri = QuackUri(server_uri_str);
+	auto enable_ssl = !initial_uri.IsLocal();
+	if (input.named_parameters.find("disable_ssl") != input.named_parameters.end()) {
+		enable_ssl = !input.named_parameters["disable_ssl"].GetValue<bool>();
+	}
+	auto server_uri = QuackUri(server_uri_str, enable_ssl);
+
+	// Connect to server — validates token via CONNECTION_REQUEST auth function
+	auto client_connection = QuackClient::ConnectToServer(context, server_uri, token);
+	auto client_wrapper = client_connection->GetClient(context);
+	auto &client = client_wrapper->GetClient();
+
+	// Target connection goes in the header; zero UUID = cancel whatever is running
+	client.Request<CancelResponseMessage>(context,
+	                                      make_uniq<CancelRequestMessage>(target_connection_id, hugeint_t {0, 0}));
+
+	return make_uniq<QuackCancelBindData>(std::move(target_connection_id));
+}
+
+static void QuackCancelScan(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	auto &data = input.bind_data->CastNoConst<QuackCancelBindData>();
+	if (data.finished) {
+		return;
+	}
+	data.finished = true;
+	output.SetValue(0, 0, data.target_connection_id);
+	output.SetValue(1, 0, Value::BOOLEAN(true));
+	output.SetCardinality(1);
+}
+
+TableFunction QuackCancelFunction::GetFunction() {
+	auto fun = TableFunction("quack_cancel", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                         QuackCancelScan, QuackCancelBind);
+	fun.named_parameters["disable_ssl"] = LogicalType::BOOLEAN;
+	return fun;
+}
+
+} // namespace duckdb

--- a/src/quack_cancel.cpp
+++ b/src/quack_cancel.cpp
@@ -13,13 +13,15 @@ namespace duckdb {
 struct QuackCancelBindData : FunctionData {
 	string target_connection_id;
 	string server_uri;
+	bool cancelled = false;
 	bool finished = false;
 
-	explicit QuackCancelBindData(string connection_id_p) : target_connection_id(std::move(connection_id_p)) {
+	explicit QuackCancelBindData(string connection_id_p, bool cancelled_p)
+	    : target_connection_id(std::move(connection_id_p)), cancelled(cancelled_p) {
 	}
 
 	unique_ptr<FunctionData> Copy() const override {
-		auto result = make_uniq<QuackCancelBindData>(target_connection_id);
+		auto result = make_uniq<QuackCancelBindData>(target_connection_id, cancelled);
 		result->finished = finished;
 		return result;
 	}
@@ -53,10 +55,11 @@ static unique_ptr<FunctionData> QuackCancelBind(ClientContext &context, TableFun
 	auto &client = client_wrapper->GetClient();
 
 	// Target connection goes in the header; zero UUID = cancel whatever is running
-	client.Request<CancelResponseMessage>(context,
-	                                      make_uniq<CancelRequestMessage>(target_connection_id, hugeint_t {0, 0}));
+	auto response = client.Request<CancelResponseMessage>(
+	    context, make_uniq<CancelRequestMessage>(target_connection_id, hugeint_t {0, 0}));
+	bool cancelled = response->Type() == MessageType::CANCEL_RESPONSE;
 
-	return make_uniq<QuackCancelBindData>(std::move(target_connection_id));
+	return make_uniq<QuackCancelBindData>(std::move(target_connection_id), cancelled);
 }
 
 static void QuackCancelScan(ClientContext &, TableFunctionInput &input, DataChunk &output) {
@@ -66,7 +69,7 @@ static void QuackCancelScan(ClientContext &, TableFunctionInput &input, DataChun
 	}
 	data.finished = true;
 	output.SetValue(0, 0, data.target_connection_id);
-	output.SetValue(1, 0, Value::BOOLEAN(true));
+	output.SetValue(1, 0, Value::BOOLEAN(data.cancelled));
 	output.SetCardinality(1);
 }
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -20,6 +20,7 @@
 #include "quack_scan.hpp"
 #include "quack_startstop.hpp"
 #include "quack_storage.hpp"
+#include "quack_cancel.hpp"
 #include "quack_uri.hpp"
 #include "include/quack_startstop.hpp"
 #include "include/quack_storage.hpp"
@@ -115,6 +116,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.SetDescription("The DuckDB 'Quack' Client/Server Protocol");
 
 	loader.RegisterFunction(QuackScanFunction::GetFunction());
+	loader.RegisterFunction(QuackCancelFunction::GetFunction());
 	loader.RegisterFunction(QuackScanByNameFunction::GetFunction());
 	loader.RegisterFunction(QuackServeFunction::GetFunction());
 	loader.RegisterFunction(QuackStopFunction::GetFunction());

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -51,6 +51,12 @@ MessageType EnumUtil::FromString<MessageType>(const char *value) {
 	if (StringUtil::Equals(value, "DISCONNECT_MESSAGE")) {
 		return MessageType::DISCONNECT_MESSAGE;
 	}
+	if (StringUtil::Equals(value, "CANCEL_REQUEST")) {
+		return MessageType::CANCEL_REQUEST;
+	}
+	if (StringUtil::Equals(value, "CANCEL_RESPONSE")) {
+		return MessageType::CANCEL_RESPONSE;
+	}
 	if (StringUtil::Equals(value, "ERROR_RESPONSE")) {
 		return MessageType::ERROR_RESPONSE;
 	}
@@ -79,6 +85,10 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 		return "SUCCESS_RESPONSE";
 	case MessageType::DISCONNECT_MESSAGE:
 		return "DISCONNECT_MESSAGE";
+	case MessageType::CANCEL_REQUEST:
+		return "CANCEL_REQUEST";
+	case MessageType::CANCEL_RESPONSE:
+		return "CANCEL_RESPONSE";
 	case MessageType::ERROR_RESPONSE:
 		return "ERROR_RESPONSE";
 
@@ -124,6 +134,10 @@ unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, M
 		return SuccessResponse::Deserialize(deserializer);
 	case MessageType::DISCONNECT_MESSAGE:
 		return DisconnectMessage::Deserialize(deserializer);
+	case MessageType::CANCEL_REQUEST:
+		return CancelRequestMessage::Deserialize(deserializer);
+	case MessageType::CANCEL_RESPONSE:
+		return CancelResponseMessage::Deserialize(deserializer);
 	case MessageType::ERROR_RESPONSE:
 		return ErrorResponse::Deserialize(deserializer);
 	default:

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -169,6 +169,7 @@ bool ServerSupportsMessage(MessageType type) {
 	case MessageType::FETCH_REQUEST:
 	case MessageType::APPEND_REQUEST:
 	case MessageType::DISCONNECT_MESSAGE:
+	case MessageType::CANCEL_REQUEST:
 		return true;
 	default:
 		return false;
@@ -264,6 +265,16 @@ static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, un
 		results.push_back(make_uniq<DataChunkWrapper>(*result_chunk));
 	}
 	return results;
+}
+
+bool QuackServer::CancelConnection(const string &connection_id) {
+	auto connection = GetConnection(connection_id);
+	if (!connection) {
+		return false;
+	}
+	connection->duckdb_connection->Interrupt();
+	connection->query_state = QuackQueryState::CANCELLED;
+	return true;
 }
 
 unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
@@ -429,6 +440,18 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(ErrorData(ex));
 		}
 		return make_uniq<SuccessResponse>();
+	}
+	case MessageType::CANCEL_REQUEST: {
+		auto &cancel_request_message = received_message.Cast<CancelRequestMessage>();
+		auto &connection = *connection_p;
+		// zero UUID = admin cancel from quack_cancel(), skip result check
+		if (cancel_request_message.result_uuid != hugeint_t {0, 0} &&
+		    connection.result_uuid != cancel_request_message.result_uuid) {
+			return make_uniq<ErrorResponse>("Result has been closed");
+		}
+		connection.duckdb_connection->Interrupt();
+		connection.query_state = QuackQueryState::CANCELLED;
+		return make_uniq<CancelResponseMessage>();
 	}
 	default: {
 		return make_uniq<ErrorResponse>(

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -436,7 +436,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			collection.Append(append_request_message.AppendChunk());
 			connection.duckdb_connection->Append(*table_info, collection);
 		} catch (std::exception &ex) {
-			// apend failed - directly pass error to user
+			// append failed - directly pass error to user
 			return make_uniq<ErrorResponse>(ErrorData(ex));
 		}
 		return make_uniq<SuccessResponse>();

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -444,11 +444,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	case MessageType::CANCEL_REQUEST: {
 		auto &cancel_request_message = received_message.Cast<CancelRequestMessage>();
 		auto &connection = *connection_p;
-		// zero UUID = admin cancel from quack_cancel(), skip result check
-		if (cancel_request_message.result_uuid != hugeint_t {0, 0} &&
-		    connection.result_uuid != cancel_request_message.result_uuid) {
-			return make_uniq<ErrorResponse>("Result has been closed");
-		}
+		// TODO; we should check the query id in the future
+		// to not cancel a newer query running on this connection
 		connection.duckdb_connection->Interrupt();
 		connection.query_state = QuackQueryState::CANCELLED;
 		return make_uniq<CancelResponseMessage>();

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -80,6 +80,18 @@ bool QuackStorageExtensionInfo::StopServer(ClientContext &context, const QuackUr
 	return true;
 }
 
+bool QuackStorageExtensionInfo::CancelConnection(const string &server_id, const string &connection_id) {
+	std::lock_guard<std::mutex> lock(servers_mutex);
+	// not for every server, but also give the server ID
+	// check if the server ID corresponds
+	for (auto &[uri, server] : servers) {
+		if (server->CancelConnection(connection_id)) {
+			return true;
+		}
+	}
+	throw InvalidInputException("Connection id '%s' not found, or query could not be cancelled", connection_id.c_str());
+}
+
 static unique_ptr<Catalog> QuackAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                        AttachedDatabase &db, const string &name, AttachInfo &info,
                                        AttachOptions &attach_options) {

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -146,4 +146,21 @@ unique_ptr<SuccessResponse> SuccessResponse::Deserialize(Deserializer &deseriali
 	return result;
 }
 
+void CancelRequestMessage::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<hugeint_t>(1, "result_uuid", result_uuid);
+}
+
+unique_ptr<CancelRequestMessage> CancelRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<CancelRequestMessage>(new CancelRequestMessage());
+	deserializer.ReadProperty<hugeint_t>(1, "result_uuid", result->result_uuid);
+	return result;
+}
+
+void CancelResponseMessage::Serialize(Serializer &serializer) const {
+}
+
+unique_ptr<CancelResponseMessage> CancelResponseMessage::Deserialize(Deserializer &deserializer) {
+	return duckdb::unique_ptr<CancelResponseMessage>(new CancelResponseMessage());
+}
+
 } // namespace duckdb

--- a/test/sql/quack_cancel.test
+++ b/test/sql/quack_cancel.test
@@ -1,0 +1,54 @@
+# name: test/sql/quack_cancel.test
+# description: test quack_cancel interrupts an active query
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok
+CALL quack_serve('quack:localhost', token='asdf');
+
+concurrentloop threadid 0 2
+
+# slow query
+onlyif threadid=0
+statement maybe
+FROM quack_query('quack:localhost', 'SELECT sleep_ms(5000)', token='asdf');
+----
+Interrupted
+
+# wait for the query to be active, sleep 1 second
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(200);
+
+# check if the query is active
+onlyif threadid=1
+query I
+SELECT count(*) FROM quack_activity() WHERE state = 'active';
+----
+1
+
+onlyif threadid=1
+statement ok
+SET VARIABLE conn_id = (
+  SELECT connection_id FROM quack_activity()
+  WHERE state = 'active' LIMIT 1
+);
+
+onlyif threadid=1
+statement ok
+FROM quack_cancel('quack:localhost', getvariable('conn_id'), 'asdf');
+
+endloop
+
+query I
+SELECT count(*) FROM quack_activity() WHERE state = 'active';
+----
+0
+
+statement ok
+CALL quack_stop('quack:localhost');

--- a/test/sql/quack_cancel.test
+++ b/test/sql/quack_cancel.test
@@ -20,18 +20,12 @@ FROM quack_query('quack:localhost', 'SELECT sleep_ms(5000)', token='asdf');
 ----
 Interrupted
 
-# wait for the query to be active, sleep 1 second
+# wait for the query to be active, sleep a bit
 onlyif threadid=1
 statement ok
 SELECT sleep_ms(200);
 
-# check if the query is active
-onlyif threadid=1
-query I
-SELECT count(*) FROM quack_activity() WHERE state = 'active';
-----
-1
-
+# get the connection id from the currently active query
 onlyif threadid=1
 statement ok
 SET VARIABLE conn_id = (


### PR DESCRIPTION
This PR adds `quack_cancel(server, connection_id, token)`, which explicitly cancels any active query running on a specific connection (`connection_id`). The cancellation is done through a different connection, and will be rejected if the server + token combination or connection_id is incorrect. Cancelling a query by a user interrupt is not covered yet. Since there is already a PR up covering this we might want to integrate https://github.com/duckdb/duckdb-quack/pull/137 too.

**Cancellation speed**
DuckDB cancels when it checks the context flag between different pipeline tasks. Queries like `from sleep_ms(10000)` only consist of a single task and therefore will be cancelled right before they are actually finished. If this is slow for some queries, we should figure out in which cases we should poll the interrupt state more frequently. 

Fixes https://github.com/duckdblabs/duckdb-internal/issues/9423



