### PR TITLE
Add support for binding to port 0 (finding a free port) - and use this in tests together with a setup template

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,29 +14,17 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: main
-      ci_tools_version: v1.5-variegata
+      ci_tools_version: main
       extension_name: quack
 
   code-quality-check:
     name: Code Quality Check
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
       duckdb_version: main
-      ci_tools_version: v1.5-variegata
+      ci_tools_version: main
       extension_name: quack
       format_checks: 'format'
-
-  duckdb-stable-deploy:
-    name: Deploy extension binaries
-    needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.5-variegata
-    secrets: inherit
-    with:
-      extension_name: quack
-      duckdb_version: main
-      ci_tools_version: v1.5-variegata
-      deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
-      deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -11,6 +11,6 @@ duckdb_extension_load(autocomplete)
 
 duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 7e86e7a5e5a1f01f458361bebdfa9b0a9a73a619
+    GIT_TAG 53c5b032f6c368cfcc1a1ac3819118e86d3286a6
     APPLY_PATCHES
 )

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -74,6 +74,10 @@ public:
 		return uri;
 	}
 
+	uint16_t BoundPort() const {
+		return bound_port;
+	}
+
 	idx_t ActiveConnectionCount() {
 		std::lock_guard<std::mutex> lock(active_connections_mutex);
 		return active_connections.size();
@@ -93,6 +97,7 @@ protected:
 
 	mutex session_id_rng_mutex;
 	shared_ptr<EncryptionState> session_id_rng;
+	uint16_t bound_port;
 
 private:
 	QuackUri uri;
@@ -109,7 +114,7 @@ public:
 	~HttpQuackServer() override;
 
 private:
-	static void ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port);
+	static void ListenThread(HttpQuackServer *server, const string &listen_host, uint16_t listen_port);
 
 	unique_ptr<QuackMessage> ReadMessage(MemoryStream &read_stream);
 

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -74,10 +74,6 @@ public:
 		return uri;
 	}
 
-	uint16_t BoundPort() const {
-		return bound_port;
-	}
-
 	idx_t ActiveConnectionCount() {
 		std::lock_guard<std::mutex> lock(active_connections_mutex);
 		return active_connections.size();
@@ -97,10 +93,10 @@ protected:
 
 	mutex session_id_rng_mutex;
 	shared_ptr<EncryptionState> session_id_rng;
-	uint16_t bound_port;
+
+	QuackUri uri;
 
 private:
-	QuackUri uri;
 	string token;
 };
 

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -34,6 +34,8 @@ struct QuackConnection {
 	string session_id;
 };
 
+enum class QuackServerState { UNINITIALIZED, WAITING_TO_START, RUNNING, CLOSED };
+
 class QuackServer {
 public:
 	static constexpr const idx_t QUACK_VERSION = 1;
@@ -115,7 +117,8 @@ private:
 	unique_ptr<QuackMessage> ReadMessage(MemoryStream &read_stream);
 
 	unique_ptr<duckdb_httplib::Server> server;
-	bool is_running = false;
+	mutex state_lock;
+	atomic<QuackServerState> server_state {QuackServerState::UNINITIALIZED};
 };
 
 } // namespace duckdb

--- a/src/include/quack_uri.hpp
+++ b/src/include/quack_uri.hpp
@@ -12,9 +12,7 @@ public:
 	explicit QuackUri(string uri_p, bool ssl_p = true);
 	QuackUri(const QuackUri &uri, uint16_t new_port);
 
-	string Http() const {
-		return http;
-	}
+	string Http() const;
 	string Uri() const {
 		return uri;
 	}
@@ -38,8 +36,7 @@ public:
 		return StringUtil::Lower(host) == "localhost" || host == "127.0.0.1" || host == "::1";
 	}
 	bool operator==(const QuackUri &other) const {
-		return other.ssl == ssl && other.ipv6 == ipv6 && other.host == host && other.port == port &&
-		       other.http == http && other.uri == uri;
+		return other.ssl == ssl && other.ipv6 == ipv6 && other.host == host && other.port == port && other.uri == uri;
 	}
 	bool operator!=(const QuackUri &other) const {
 		return !(*this == other);
@@ -50,7 +47,6 @@ private:
 	bool ipv6;
 	string host;
 	uint16_t port; // default port!
-	string http;
 	string uri;
 };
 

--- a/src/include/quack_uri.hpp
+++ b/src/include/quack_uri.hpp
@@ -10,6 +10,7 @@ public:
 	} // orrr
 
 	explicit QuackUri(string uri_p, bool ssl_p = true);
+	QuackUri(const QuackUri &uri, uint16_t new_port);
 
 	string Http() const {
 		return http;

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -37,9 +37,8 @@ HttpQuackServer::~HttpQuackServer() {
 	}
 }
 
-void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen_host, int listen_port) {
+void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen_host, uint16_t listen_port) {
 	D_ASSERT(server->server);
-	D_ASSERT(listen_port > 1 && listen_port < 65535);
 	// Socket is already bound (synchronously, in the constructor).
 	// Catch everything so the listener thread never lets an exception escape — that
 	// would call std::terminate and abort the host process.
@@ -97,15 +96,23 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 	}
 	is_running = true;
 
-	// Bind synchronously here so that bind() failures (e.g. EADDRINUSE)
-	// propagate to the caller of quack_serve()
-	if (!server->bind_to_port(uri_p.Host(), uri_p.Port())) {
+	bool success;
+	if (uri_p.Port() == 0) {
+		int actual_port = server->bind_to_any_port(uri_p.Host());
+		success = actual_port >= 0;
+		if (success) {
+			bound_port = NumericCast<uint16_t>(actual_port);
+		}
+	} else {
+		success =  server->bind_to_port(uri_p.Host(), uri_p.Port());
+	}
+	if (!success) {
 		throw IOException("Failed to bind DuckDB Quack RPC server to %s (address in use, permission denied, "
 		                  "or invalid host/port)",
 		                  uri_p.Http());
 	}
 
-	listen_threads.push_back(std::thread(ListenThread, this, uri_p.Host(), uri_p.Port()));
+	listen_threads.push_back(std::thread(ListenThread, this, uri_p.Host(), BoundPort()));
 }
 
 } // namespace duckdb

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -11,10 +11,15 @@ namespace duckdb {
 void HttpQuackServer::StopAccepting() {
 	// Closes the listening socket only. Idempotent. Safe to call from a
 	// request-handler thread.
-	if (is_running) {
+	lock_guard<mutex> guard(state_lock);
+	if (server_state == QuackServerState::RUNNING) {
+		// server is running - stop it and decommission
+		server->wait_until_ready();
 		server->stop();
-		is_running = false;
+		server->decommission();
 	}
+	// close the server
+	server_state = QuackServerState::CLOSED;
 }
 
 void HttpQuackServer::Close() {
@@ -42,10 +47,17 @@ void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen
 	// Socket is already bound (synchronously, in the constructor).
 	// Catch everything so the listener thread never lets an exception escape — that
 	// would call std::terminate and abort the host process.
+	{
+		lock_guard<mutex> guard(server->state_lock);
+		if (server->server_state != QuackServerState::WAITING_TO_START) {
+			return;
+		}
+		server->server_state = QuackServerState::RUNNING;
+	}
 	try {
 		server->server->listen_after_bind();
 	} catch (...) {
-		server->is_running = false;
+		server->server_state = QuackServerState::CLOSED;
 	}
 }
 
@@ -94,7 +106,6 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 	if (!server->is_valid()) {
 		throw IOException("Failed to instantiate DuckDB server at %s / %s", uri_p.Uri(), uri_p.Http());
 	}
-	is_running = true;
 
 	bool success;
 	if (uri_p.Port() == 0) {
@@ -113,6 +124,7 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 		                  uri_p.Http());
 	}
 
+	server_state = QuackServerState::WAITING_TO_START;
 	listen_threads.emplace_back(ListenThread, this, uri.Host(), uri.Port());
 }
 

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -101,10 +101,11 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 		int actual_port = server->bind_to_any_port(uri_p.Host());
 		success = actual_port >= 0;
 		if (success) {
-			bound_port = NumericCast<uint16_t>(actual_port);
+			auto bound_port = NumericCast<uint16_t>(actual_port);
+			uri = QuackUri(uri_p, bound_port);
 		}
 	} else {
-		success =  server->bind_to_port(uri_p.Host(), uri_p.Port());
+		success = server->bind_to_port(uri_p.Host(), uri_p.Port());
 	}
 	if (!success) {
 		throw IOException("Failed to bind DuckDB Quack RPC server to %s (address in use, permission denied, "
@@ -112,7 +113,7 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 		                  uri_p.Http());
 	}
 
-	listen_threads.push_back(std::thread(ListenThread, this, uri_p.Host(), BoundPort()));
+	listen_threads.emplace_back(ListenThread, this, uri.Host(), uri.Port());
 }
 
 } // namespace duckdb

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -91,7 +91,7 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	write_stream.Rewind();
 	SerializationOptions options;
-	options.serialization_compatibility = SerializationCompatibility::FromIndex(7);
+	options.storage_compatibility = StorageCompatibility::FromIndex(StorageVersion::V1_4_4);
 	BinarySerializer serializer(write_stream, options);
 
 	// write the header

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -28,7 +28,7 @@ void QuackServer::ValidateToken(const string &token) {
 }
 
 QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
-    : db_ptr(context_p.db), bound_port(uri_p.Port()), uri(uri_p), token(token_p) {
+    : db_ptr(context_p.db), uri(uri_p), token(token_p) {
 	ValidateToken(token);
 }
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -28,7 +28,7 @@ void QuackServer::ValidateToken(const string &token) {
 }
 
 QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
-    : db_ptr(context_p.db), uri(uri_p), token(token_p) {
+    : db_ptr(context_p.db), bound_port(uri_p.Port()), uri(uri_p), token(token_p) {
 	ValidateToken(token);
 }
 

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -41,11 +41,9 @@ static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunc
 	return_types.emplace_back(LogicalType::VARCHAR);
 	return_types.emplace_back(LogicalType::VARCHAR);
 	return_types.emplace_back(LogicalType::VARCHAR);
-	return_types.emplace_back(LogicalType::USMALLINT);
 	names.emplace_back("listen_uri");
 	names.emplace_back("listen_url");
 	names.emplace_back("auth_token");
-	names.emplace_back("port");
 
 	// Every server has a token: either user-supplied or auto-generated. The
 	// authn callback (default token-check or a user-defined function) decides
@@ -68,11 +66,12 @@ static void QuackServe(ClientContext &context, TableFunctionInput &data_p, DataC
 		return;
 	}
 
-	auto &server = QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
-	output.SetValue(0, 0, bind_data.listen_uri.Uri());
-	output.SetValue(1, 0, bind_data.listen_uri.Http());
+	auto &server =
+	    QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
+	auto &actual_uri = server.ListenUri();
+	output.SetValue(0, 0, actual_uri.Uri());
+	output.SetValue(1, 0, actual_uri.Http());
 	output.SetValue(2, 0, bind_data.token);
-	output.SetValue(3, 0, Value::USMALLINT(server.BoundPort()));
 
 	output.SetCardinality(1);
 	bind_data.finished = true;

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -41,9 +41,11 @@ static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunc
 	return_types.emplace_back(LogicalType::VARCHAR);
 	return_types.emplace_back(LogicalType::VARCHAR);
 	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::USMALLINT);
 	names.emplace_back("listen_uri");
 	names.emplace_back("listen_url");
 	names.emplace_back("auth_token");
+	names.emplace_back("port");
 
 	// Every server has a token: either user-supplied or auto-generated. The
 	// authn callback (default token-check or a user-defined function) decides
@@ -66,10 +68,11 @@ static void QuackServe(ClientContext &context, TableFunctionInput &data_p, DataC
 		return;
 	}
 
-	QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
+	auto &server = QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
 	output.SetValue(0, 0, bind_data.listen_uri.Uri());
 	output.SetValue(1, 0, bind_data.listen_uri.Http());
 	output.SetValue(2, 0, bind_data.token);
+	output.SetValue(3, 0, Value::USMALLINT(server.BoundPort()));
 
 	output.SetCardinality(1);
 	bind_data.finished = true;

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -20,14 +20,15 @@ QuackStorageExtensionInfo &QuackStorageExtensionInfo::GetState(const DatabaseIns
 
 QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, const QuackUri &listen_uri,
                                                      const string &token) {
-	auto key = listen_uri.CanonicalUri();
+	auto server = make_uniq<HttpQuackServer>(context, listen_uri, token);
+
+	auto &actual_uri = server->ListenUri();
+	auto key = actual_uri.CanonicalUri();
 	std::lock_guard<std::mutex> lock(servers_mutex);
 	auto it = servers.find(key);
 	if (it != servers.end()) {
 		throw InvalidInputException("Server already exists for %s", key);
 	}
-	unique_ptr<QuackServer> server;
-	server = make_uniq<HttpQuackServer>(context, listen_uri, token);
 	servers.emplace(key, std::move(server));
 	return *servers[key];
 }
@@ -42,7 +43,7 @@ vector<QuackStorageExtensionInfo::ServerSnapshot> QuackStorageExtensionInfo::Lis
 		snap.listen_uri = uri.Uri();
 		snap.listen_url = uri.Http();
 		snap.host = uri.Host();
-		snap.port = kv.second->BoundPort();
+		snap.port = uri.Port();
 		snap.active_connections = kv.second->ActiveConnectionCount();
 		snap.info.emplace_back("ipv6", uri.IPv6() ? "true" : "false");
 		result.push_back(std::move(snap));

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -42,7 +42,7 @@ vector<QuackStorageExtensionInfo::ServerSnapshot> QuackStorageExtensionInfo::Lis
 		snap.listen_uri = uri.Uri();
 		snap.listen_url = uri.Http();
 		snap.host = uri.Host();
-		snap.port = uri.Port();
+		snap.port = kv.second->BoundPort();
 		snap.active_connections = kv.second->ActiveConnectionCount();
 		snap.info.emplace_back("ipv6", uri.IPv6() ? "true" : "false");
 		result.push_back(std::move(snap));

--- a/src/quack_uri.cpp
+++ b/src/quack_uri.cpp
@@ -2,7 +2,12 @@
 
 namespace duckdb {
 
-QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
+QuackUri::QuackUri(const QuackUri &input_p, uint16_t new_port)
+    : ssl(input_p.Ssl()), ipv6(input_p.IPv6()), host(input_p.Host()), port(new_port), http(input_p.Http()) {
+	uri = CanonicalUri();
+}
+
+QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(std::move(uri_p)) {
 	// we should really instantiate a parser here instead, but alas
 	// whitespace be gone
 	ipv6 = false;

--- a/src/quack_uri.cpp
+++ b/src/quack_uri.cpp
@@ -3,7 +3,7 @@
 namespace duckdb {
 
 QuackUri::QuackUri(const QuackUri &input_p, uint16_t new_port)
-    : ssl(input_p.Ssl()), ipv6(input_p.IPv6()), host(input_p.Host()), port(new_port), http(input_p.Http()) {
+    : ssl(input_p.Ssl()), ipv6(input_p.IPv6()), host(input_p.Host()), port(new_port) {
 	uri = CanonicalUri();
 }
 
@@ -62,7 +62,10 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(std::move(uri_p))
 	if (!ipv6) {
 		host = remainder;
 	}
-	http = StringUtil::Format("http%s://%s:%d", ssl ? "s" : "", ipv6 ? "[" + host + "]" : host, port);
+}
+
+string QuackUri::Http() const {
+	return StringUtil::Format("http%s://%s:%d", ssl ? "s" : "", ipv6 ? "[" + host + "]" : host, port);
 }
 
 static void QuackUriParser(const DataChunk &args, ExpressionState &, Vector &result) {

--- a/src/quack_uri.cpp
+++ b/src/quack_uri.cpp
@@ -39,16 +39,16 @@ QuackUri::QuackUri(string uri_p, bool ssl_p) : ssl(ssl_p), uri(uri_p) {
 		auto pos = remainder.find(':');
 		auto port_str = remainder.substr(pos + 1);
 		if (port_str.empty()) {
-			throw InvalidInputException("Invalid Port");
+			throw InvalidInputException("Invalid Port \"\"");
 		}
 		int raw_port;
 		try {
 			raw_port = stoi(port_str);
+			if (raw_port < 0 || raw_port > 65535) {
+				throw InvalidInputException("Invalid Port");
+			}
 		} catch (std::exception &) {
-			throw InvalidInputException("Invalid Port");
-		}
-		if (raw_port < 1 || raw_port > 65535) {
-			throw InvalidInputException("Invalid Port");
+			throw InvalidInputException("Invalid Port \"%s\" - must be between 0 and 65535", port_str);
 		}
 		port = raw_port;
 		remainder = remainder.substr(0, pos);

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -2,47 +2,33 @@
 # description: test rpc extension
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-test-env QUACK_SERVER quack:localhost
-
-set ignore_error_messages __none__
-
-statement ok
-SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
-
-statement ok
+statement ok quack_db:quack_server_con
 create schema moo;
 
-statement ok
+statement ok quack_db:quack_server_con
 create table fuu as values(42, 43);
 
-statement ok
+statement ok quack_db:quack_server_con
 create table moo.fuu2 as values(44, 45);
 
-statement ok
-set variable listen_uri = (select list(concat('''{QUACK_SERVER}', ':', port, '''')) from quack_serve('{QUACK_SERVER}:0', token='asdf'));
-
-foreach server <variable:listen_uri>
-
-query II con2
+query II
 from quack_query({server}, 'select 42, 43', token='asdf')
 ----
 42	43
 
 # we can attach with a straight token
-statement ok con2
+statement ok
 attach {server} as rpc2 (token 'asdf')
 
-statement ok con2
+statement ok
 detach rpc2;
 
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
-statement ok con2
+statement ok
 attach {server} as rpc
 
 
@@ -113,11 +99,6 @@ begin transaction
 statement ok
 create table rpc.fuu3(i integer);
 
-statement error
-insert into rpc.fuu2 values (42);
-----
-not exist
-
 statement ok
 insert into rpc.fuu3 from range(10000);
 
@@ -135,19 +116,16 @@ from rpc.fuu3;
 not exist
 
 
-statement ok con2
+statement ok
 detach rpc;
 
-statement error con2
+statement error
 detach rpc;
 ----
 database not found
 
-statement ok con1
-call quack_stop('{QUACK_SERVER}:0');
+include test/template/quack_teardown.test_template
 
-statement error con2
+statement error
 attach {server} as rpc
 ----
-
-endloop

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -6,7 +6,12 @@ require quack
 
 require httpfs
 
+test-env QUACK_SERVER quack:localhost
+
 set ignore_error_messages __none__
+
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
 
 statement ok
 create schema moo;
@@ -17,11 +22,10 @@ create table fuu as values(42, 43);
 statement ok
 create table moo.fuu2 as values(44, 45);
 
-foreach server 'quack:localhost'
+statement ok
+set variable listen_uri = (select list(concat('''{QUACK_SERVER}', ':', port, '''')) from quack_serve('{QUACK_SERVER}:0', token='asdf'));
 
-
-statement ok con1
-call quack_serve({server}, token='asdf');
+foreach server <variable:listen_uri>
 
 query II con2
 from quack_query({server}, 'select 42, 43', token='asdf')
@@ -140,7 +144,7 @@ detach rpc;
 database not found
 
 statement ok con1
-call quack_stop({server});
+call quack_stop('{QUACK_SERVER}:0');
 
 statement error con2
 attach {server} as rpc

--- a/test/sql/attach_ctas.test
+++ b/test/sql/attach_ctas.test
@@ -2,18 +2,9 @@
 # description: test CREATE TABLE AS over rpc attach
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-foreach server 'quack:localhost'
-
-statement ok con1
-call quack_serve({server}, token='asdf');
-
-statement ok con2
+statement ok
 attach {server} as rpc (token 'asdf')
 
 statement ok
@@ -30,7 +21,4 @@ drop table rpc.t;
 statement ok con2
 detach rpc;
 
-statement ok con1
-call quack_stop({server});
-
-endloop
+include test/template/quack_teardown.test_template

--- a/test/sql/attach_fetch_large.test_slow
+++ b/test/sql/attach_fetch_large.test_slow
@@ -2,16 +2,7 @@
 # description: test large fetch using attach
 # group: [sql]
 
-require quack
-
-require httpfs
-
-set ignore_error_messages __none__
-
-foreach server 'quack:localhost'
-
-statement ok con1
-call quack_serve({server}, token='asdf');
+include test/template/quack_setup.test_template
 
 statement ok
 attach {server} as rpc (token 'asdf')
@@ -29,7 +20,7 @@ select count(*), sum(i) from quack_query_by_name('rpc', 'from big_tbl')
 ----
 10000000	49999995000000
 
-statement ok con2
+statement ok
 detach rpc;
 
 query II
@@ -37,7 +28,4 @@ select count(*), sum(i) from quack_query({server}, 'from big_tbl', token='asdf')
 ----
 10000000	49999995000000
 
-statement ok con1
-call quack_stop({server});
-
-endloop
+include test/template/quack_teardown.test_template

--- a/test/sql/attach_views.test
+++ b/test/sql/attach_views.test
@@ -2,22 +2,13 @@
 # description: test attaching views
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-statement ok
+statement ok quack_db:quack_server_con
 create schema moo;
 
-statement ok
+statement ok quack_db:quack_server_con
 create view fuu as select 42 i, 'hello world' j
-
-foreach server 'quack:localhost'
-
-statement ok con1
-call quack_serve({server}, token='asdf');
 
 query II con2
 from quack_query({server}, 'select * from fuu', token='asdf')
@@ -48,7 +39,4 @@ FROM rpc.fuu
 ----
 does not exist
 
-statement ok con1
-call quack_stop({server});
-
-endloop
+include test/template/quack_teardown.test_template

--- a/test/sql/authn_swap.test
+++ b/test/sql/authn_swap.test
@@ -2,76 +2,67 @@
 # description: swap quack_authentication_function and quack_authorization_function at runtime
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO authn_no(sid, auth_string, token)  AS false;
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO authn_yes(sid, auth_string, token) AS true;
 
-query III con1
-CALL quack_serve('quack:localhost', token='asdf');
-----
-quack:localhost	http://localhost:9494	asdf
-
-sleep 100 millisecond
-
 # Phase 1: deny-all — both correct and wrong token rejected
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authentication_function = 'authn_no';
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 Authentication failed
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+statement error
+FROM quack_query({server}, 'select 42', token='fdsa');
 ----
 Authentication failed
 
 # Phase 2: token check — correct token works, wrong token fails
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authentication_function = 'quack_check_token';
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 42
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+statement error
+FROM quack_query({server}, 'select 42', token='fdsa');
 ----
 Authentication failed
 
 # Phase 3: allow-all — both correct and wrong token accepted
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authentication_function = 'authn_yes';
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 42
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+query I
+FROM quack_query({server}, 'select 42', token='fdsa');
 ----
 42
 
 # Phase 4: non-existent function — auth path fails closed for any token
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authentication_function = 'authn_does_not_exist';
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 Authentication failed
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+statement error
+FROM quack_query({server}, 'select 42', token='fdsa');
 ----
 Authentication failed
 
@@ -79,21 +70,21 @@ Authentication failed
 # Note: plain RESET (without GLOBAL) only clears the session view — the auth
 # callback runs on a fresh connection that would still read the stale GLOBAL
 # value. RESET GLOBAL is the correct incantation.
-statement ok con1
+statement ok quack_db:quack_server_con
 RESET GLOBAL quack_authentication_function;
 
-query I con1
+query I quack_db:quack_server_con
 SELECT current_setting('quack_authentication_function');
 ----
 quack_check_token
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 42
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+statement error
+FROM quack_query({server}, 'select 42', token='fdsa');
 ----
 Authentication failed
 
@@ -101,99 +92,99 @@ Authentication failed
 # 'duck', ignoring sid and the server-configured token.
 # Macro arg order: (sid, client_token, server_token) — arg[1] is the value the
 # client passed as token=..., arg[2] is the server-configured token.
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO authn_duck(sid, client_token, server_token) AS client_token = 'duck';
 
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authentication_function = 'authn_duck';
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='duck');
+query I
+FROM quack_query({server}, 'select 42', token='duck');
 ----
 42
 
 # the server-configured token ('asdf') is no longer special — only 'duck' passes
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 Authentication failed
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='quack');
+statement error
+FROM quack_query({server}, 'select 42', token='quack');
 ----
 Authentication failed
 
-statement ok con1
+statement ok quack_db:quack_server_con
 RESET GLOBAL quack_authentication_function;
 
 ####################
 # quack_authorization_function — authn stays at default (quack_check_token)
 ####################
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO authz_no(sid, query)  AS false;
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO authz_yes(sid, query) AS true;
 
 # Phase A: deny-all — even an authenticated request is rejected
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authorization_function = 'authz_no';
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 Authorization failed
 
 # Phase B: allow-all (default-equivalent)
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authorization_function = 'quack_nop_authorization';
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 42
 
 # Phase C: explicit authz_yes
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authorization_function = 'authz_yes';
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 42
 
 # Authn still gates: wrong token fails before authz runs
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='fdsa');
+statement error
+FROM quack_query({server}, 'select 42', token='fdsa');
 ----
 Authentication failed
 
 # Phase D: non-existent function — authz path fails closed
-statement ok con1
+statement ok quack_db:quack_server_con
 SET quack_authorization_function = 'authz_does_not_exist';
 
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 Authorization failed
 
 # Phase E: RESET GLOBAL restores the default (quack_nop_authorization)
-statement ok con1
+statement ok quack_db:quack_server_con
 RESET GLOBAL quack_authorization_function;
 
-query I con1
+query I quack_db:quack_server_con
 SELECT current_setting('quack_authorization_function');
 ----
 quack_nop_authorization
 
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token='asdf');
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
 ----
 42
 
-statement ok con1
-CALL quack_stop('quack:localhost');
+statement ok quack_db:quack_server_con
+CALL quack_stop({server});
 
 ####################
 # Combined: custom authn + custom authz, server starts with a long token.
@@ -202,59 +193,56 @@ CALL quack_stop('quack:localhost');
 # tripped ValidateToken with "must be at least 4 characters."
 ####################
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO check_token(sid, auth_string, token) AS auth_string = token;
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE MACRO read_only(sid, query) AS regexp_matches(upper(ltrim(query)), '^(SELECT|PRAGMA|CALL|EXPLAIN|DESCRIBE|SHOW)\b');
 
-statement ok con1
+statement ok quack_db:quack_server_con
 SET GLOBAL quack_authentication_function = 'check_token';
 
-statement ok con1
+statement ok quack_db:quack_server_con
 SET GLOBAL quack_authorization_function = 'read_only';
 
-query III con1
-CALL quack_serve('quack:localhost', token => 'analytics-team-token');
+query I quack_db:quack_server_con
+SELECT auth_token FROM quack_serve({server}, token => 'analytics-team-token');
 ----
-quack:localhost	http://localhost:9494	analytics-team-token
-
-sleep 100 millisecond
+analytics-team-token
 
 # Authn happy path with the configured token
-query I con2
-FROM quack_query('quack:localhost', 'select 42', token => 'analytics-team-token');
+query I
+FROM quack_query({server}, 'select 42', token => 'analytics-team-token');
 ----
 42
 
 # Authn rejects wrong token
-statement error con2
-FROM quack_query('quack:localhost', 'select 42', token => 'wrong-token');
+statement error
+FROM quack_query({server}, 'select 42', token => 'wrong-token');
 ----
 Authentication failed
 
 # Authz allows SELECT
-query I con2
-FROM quack_query('quack:localhost', 'select 1+1', token => 'analytics-team-token');
+query I
+FROM quack_query({server}, 'select 1+1', token => 'analytics-team-token');
 ----
 2
 
 # Authz blocks writes
-statement error con2
-FROM quack_query('quack:localhost', 'CREATE TABLE t(x INT)', token => 'analytics-team-token');
+statement error
+FROM quack_query({server}, 'CREATE TABLE t(x INT)', token => 'analytics-team-token');
 ----
 Authorization failed
 
 statement error con2
-FROM quack_query('quack:localhost', 'INSERT INTO t VALUES (1)', token => 'analytics-team-token');
+FROM quack_query({server}, 'INSERT INTO t VALUES (1)', token => 'analytics-team-token');
 ----
 Authorization failed
 
-statement ok con1
+statement ok quack_db:quack_server_con
 RESET GLOBAL quack_authentication_function;
 
-statement ok con1
+statement ok quack_db:quack_server_con
 RESET GLOBAL quack_authorization_function;
 
-statement ok con1
-CALL quack_stop('quack:localhost');
+include test/template/quack_teardown.test_template

--- a/test/sql/authn_swap.test
+++ b/test/sql/authn_swap.test
@@ -6,8 +6,6 @@ require quack
 
 require httpfs
 
-set ignore_error_messages __none__
-
 statement ok con1
 CREATE MACRO authn_no(sid, auth_string, token)  AS false;
 

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -2,80 +2,72 @@
 # description: quack_clear_cache refreshes the cached catalog snapshot after server-side DDL via quack_query_by_name
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-statement ok con1
-call quack_serve('quack:localhost', token='asdf');
-
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
-statement ok con2
-attach 'quack:localhost' as rpc
+statement ok
+attach {server} as rpc
 
-statement ok con2
+statement ok
 call system.main.quack_query_by_name('rpc', 'CREATE TABLE t1(i INTEGER); INSERT INTO t1 VALUES (1),(2),(3);')
 
-statement error con2
+statement error
 SELECT i FROM rpc.t1
 ----
 Table with name t1 does not exist
 
-statement ok con2
+statement ok
 CALL quack_clear_cache()
 
-query I con2
+query I
 SELECT i FROM rpc.t1 ORDER BY i
 ----
 1
 2
 3
 
-statement ok con2
+statement ok
 call system.main.quack_query_by_name('rpc', 'CREATE TABLE t2(s VARCHAR); INSERT INTO t2 VALUES (''a''),(''b'');')
 
-statement error con2
+statement error
 SELECT s FROM rpc.t2
 ----
 Table with name t2 does not exist
 
-statement ok con2
+statement ok
 CALL quack_clear_cache()
 
-query I con2
+query I
 SELECT s FROM rpc.t2 ORDER BY s
 ----
 a
 b
 
-statement ok con2
+statement ok
 call system.main.quack_query_by_name('rpc', 'DROP TABLE t1;')
 
-query I con2
+query I
 SELECT s FROM rpc.t2 ORDER BY s
 ----
 a
 b
 
-statement error con2
+statement error
 SELECT i FROM rpc.t1
 ----
 Invalid Input Error: Table with name t1 does not exist
 
-statement ok con2
+statement ok
 CALL quack_clear_cache()
 
-statement error con2
+statement error
 SELECT i FROM rpc.t1
 ----
 Catalog Error: Table with name t1 does not exist
 
-statement ok con2
+statement ok
 detach rpc;
 
-statement ok con1
-call quack_stop('quack:localhost');
+include test/template/quack_teardown.test_template

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -2,84 +2,78 @@
 # description: test RPC and HTTP logging
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-
-statement ok con1
-call quack_serve('quack:localhost', token='asdf');
-
-sleep 100 millisecond
-
-
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
 
 # --- RPC logging ---
 
-statement ok con2
+# enable client-side logging
+statement ok
+CALL enable_logging('Quack');
+
+# enable server-side logging
+statement ok quack_db:quack_server_con
 CALL enable_logging('Quack');
 
 # quack_query should produce RPC log entries
-query I con2
-from quack_query('quack:localhost', 'select 42 as answer')
+query I
+from quack_query({server}, 'select 42 as answer')
 ----
 42
 
 # check that we have RPC logs with correct structure
-query I con2
+query I
 select count(*) > 0 from duckdb_logs where type = 'Quack'
 ----
 true
 
 # check that PREPARE_REQUEST has the query
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where message_type = 'PREPARE_REQUEST' and query = 'select 42 as answer'
 ----
 true
 
 # we no longer need a fetch
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where message_type = 'FETCH_REQUEST'
 ----
 false
 
 # check that rpc_connection_id is set on non-connection messages
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where message_type = 'PREPARE_REQUEST' and quack_connection_id != ''
 ----
 true
 
 # check duration_ms is non-negative
-query I con2
+query I
 select count(*) = 0 from duckdb_logs_parsed('Quack') where duration_ms < 0
 ----
 true
 
 # check server field is populated on client-side logs
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where server is not null and server != ''
 ----
 true
 
 # check response_type is populated
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where response_type = 'PREPARE_RESPONSE'
 ----
 true
 
 # check error field for successful queries is NULL
-query I con2
+query I
 select count(*) = 0 from duckdb_logs_parsed('Quack') where error is not null and server is not null
 ----
 true
 
 # check client_query_id is populated on client-side logs
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where client_query_id is not null and server is not null
 ----
 true
@@ -87,7 +81,7 @@ true
 mode skip
 
 # check client_query_id is populated on server-side logs
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where client_query_id is not null and (server is null or server = '')
 ----
 true
@@ -95,62 +89,61 @@ true
 mode unskip
 
 # check server-side logs exist (scope=DATABASE, no server field)
-query I con2
+query I quack_db:quack_server_con
 select count(*) > 0 from duckdb_logs_parsed('Quack') where server is null or server = ''
 ----
 true
 
 # clear logs and test error logging
-statement ok con2
+statement ok
 CALL truncate_duckdb_logs();
 
-statement error con2
-from quack_query('quack:localhost', 'selexxxct 42')
+statement error
+from quack_query({server}, 'selexxxct 42')
 ----
 Error
 
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('Quack') where response_type = 'ERROR_RESPONSE' and error is not null
 ----
 true
 
 # --- HTTP logging ---
 
-statement ok con2
+statement ok
 CALL truncate_duckdb_logs();
 
-statement ok con2
+statement ok
 CALL disable_logging();
 
-statement ok con2
+statement ok
 CALL enable_logging('HTTP');
 
-query I con2
-from quack_query('quack:localhost', 'select 1')
+query I
+from quack_query({server}, 'select 1')
 ----
 1
 
 # check HTTP logs exist with POST method
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.type = 'POST'
 ----
 true
 
 # check HTTP response status
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('HTTP') where response.status = 'OK_200'
 ----
 true
 
 # check URL contains /quack
-query I con2
+query I
 select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.url like '%/quack'
 ----
 true
 
 # clean up
-statement ok con2
+statement ok
 CALL disable_logging();
 
-statement ok con1
-call quack_stop('quack:localhost');
+include test/template/quack_teardown.test_template

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -2,31 +2,18 @@
 # description: test that multiple LookupEntry calls don't overwrite each other's results
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-statement ok con1
+statement ok quack_db:quack_server_con
 create table t1 as select range i from range(100);
 
-statement ok con1
+statement ok quack_db:quack_server_con
 create table t2 as select range j from range(200);
 
-foreach server 'quack:localhost'
-
-foreach ssl true
-
-statement ok con1
-call quack_serve({server}, token='asdf');
-
-
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
-
-statement ok con2
+statement ok
 attach {server} as rpc
 
 # Single table scan should work
@@ -48,12 +35,7 @@ select count(t1.i), count(t2.j) from rpc.main.t1, rpc.main.t2;
 ----
 not currently supported
 
-statement ok con2
+statement ok
 detach rpc;
 
-statement ok con1
-call quack_stop({server});
-
-endloop
-
-endloop
+include test/template/quack_teardown.test_template

--- a/test/sql/pgbench.test
+++ b/test/sql/pgbench.test
@@ -2,43 +2,32 @@
 # description: test rpc extension
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE TABLE pgbench_accounts(aid INTEGER, bid INTEGER, abalance INTEGER, filler VARCHAR);
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE TABLE pgbench_branches(bid INTEGER, bbalance INTEGER, filler VARCHAR);
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE TABLE pgbench_history(tid INTEGER, bid INTEGER, aid INTEGER, delta INTEGER, mtime TIMESTAMP, filler VARCHAR);
 
-statement ok con1
+statement ok quack_db:quack_server_con
 CREATE TABLE pgbench_tellers(tid INTEGER, bid INTEGER, tbalance INTEGER, filler VARCHAR);
 
-statement ok con1
-call quack_serve('quack:localhost', token='asdf');
-
-
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
-statement ok con2
-attach 'quack:localhost' as rpc
+statement ok
+attach {server} as rpc
 
-
-statement ok con2
+statement ok
 CALL enable_logging('Quack');
-
 
 loop i 0 10
 
-statement ok con2
+statement ok
 from rpc.query('
 BEGIN;
 UPDATE pgbench_accounts SET abalance = abalance + 2655 WHERE aid = 5445192;
@@ -52,11 +41,9 @@ COMMIT;
 endloop
 
 # we send 100 times 7 queries, so 700 messages
-query I con2
+query I
 select count(*) from duckdb_logs where type = 'Quack' and scope = 'CONNECTION'
 ----
 10
 
-
-statement ok con1
-call quack_stop('quack:localhost');
+include test/template/quack_teardown.test_template

--- a/test/sql/pragma_crash.test
+++ b/test/sql/pragma_crash.test
@@ -6,8 +6,6 @@ require quack
 
 require httpfs
 
-set ignore_error_messages __none__
-
 foreach server 'quack:localhost:20118'
 
 foreach ssl true

--- a/test/sql/pragma_crash.test
+++ b/test/sql/pragma_crash.test
@@ -2,33 +2,19 @@
 # description: USE on RPC catalog then PRAGMA should not crash (optional_idx with no active query)
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
+statement ok
+create or replace secret q2 (TYPE quack, SCOPE {server}, TOKEN 'asdf');
 
-foreach server 'quack:localhost:20118'
-
-foreach ssl true
-
-statement ok con1
-call quack_serve({server}, token='1234');
-
-statement ok con2
-create or replace secret q2 (TYPE quack, SCOPE {server}, TOKEN '1234');
-
-statement ok con2
+statement ok
 attach {server} as rpc
 
-statement ok con2
+statement ok
 use rpc;
 
 # This should not crash with optional_idx error
-statement ok con2
+statement ok
 pragma version;
 
-statement ok con1
-call quack_stop({server});
-
-endloop
-
-endloop
+include test/template/quack_teardown.test_template

--- a/test/sql/pushdown.test
+++ b/test/sql/pushdown.test
@@ -2,26 +2,15 @@
 # description: test filter and projection pushdown for RPC catalog scans
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-statement ok con1
+statement ok quack_db:quack_server_con
 create table test_data as select range i, range * 2 as doubled, 'name_' || range::varchar as name from range(10000);
 
-foreach server 'quack:localhost'
-
-statement ok con1
-call quack_serve({server}, token='asdf');
-
-
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
-
-statement ok con2
+statement ok
 attach {server} as rpc
 
 # Verify projection pushdown: selecting one column should only project that column
@@ -97,10 +86,7 @@ select max(i) from rpc.main.test_data;
 ----
 9999
 
-statement ok con2
+statement ok
 detach rpc;
 
-statement ok con1
-call quack_stop({server});
-
-endloop
+include test/template/quack_teardown.test_template

--- a/test/sql/rpc.test
+++ b/test/sql/rpc.test
@@ -2,149 +2,134 @@
 # description: test rpc extension
 # group: [sql]
 
-require quack
-
-require httpfs
-
-foreach server 'quack:localhost'
-
-query III con1
-call quack_serve({server}, token='asdf');
-----
-quack:localhost	http://localhost:9494	asdf
-
-sleep 100 millisecond
+include test/template/quack_setup.test_template
 
 # we can use the direct token param
-query I con2
+query I
 from quack_query({server}, 'select 42', token='asdf')
 ----
 42
 
 # we fail with the wrong token
-statement error con2
+statement error
 from quack_query({server}, 'select 42', token='fdsa')
 ----
 Authentication failed
 
 # or a secret
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
-query I con2
+query I
 from quack_query({server}, 'select 42')
 ----
 42
 
 # we return the last result set - for now
-query I con2
+query I
 from quack_query({server}, 'select 42; select 43')
 ----
 42
 
-query I con2
+query I
 from quack_query({server}, 'set variable x=44; select getvariable(''x'')')
 ----
 44
 
 # we can run whole goddamn transactions in here
-query I con2
+query I
 from quack_query({server}, 'create table fuu2 (i integer); begin transaction; insert into fuu2 values(45); rollback; from fuu2')
 ----
 
 
-statement error con2
+statement error
 from quack_query({server}, '')
 ----
 Error
 
 
-statement error con2
+statement error
 from quack_query({server}, NULL)
 ----
 Error
 
 
-statement error con2
+statement error
 from quack_query({server}, 'selexxxct 42')
 ----
 Error
 
-query I con2
+query I
 select max(range) from quack_query({server}, 'from range(100000)')
 ----
 99999
 
-statement ok con2
+statement ok
 from quack_query({server}, 'from test_all_types()')
 
 
-statement ok con2
+statement ok
 from quack_query({server}, 'create table fuu(i integer)')
 
-statement ok con2
+statement ok
 from quack_query({server}, 'insert into fuu values (42)')
 
-query I ok con2
+query I ok
 from quack_query({server}, 'from fuu')
 ----
 42
 
-statement error con2
+statement error
 from quack_query({server}, 'from yyyy')
 ----
 does not exist
 
-statement ok con2
+statement ok
 from quack_query({server}, 'drop table fuu')
 
 # some error cases
-statement error con2
+statement error
 from quack_query({server}, NULL)
 ----
 cannot be NULL
 
-statement error con2
+statement error
 from quack_query(NULL, '')
 ----
 cannot be NULL
 
 
-statement error con1
+statement error quack_db:quack_server_con
 call quack_serve('')
 ----
 Invalid listen string
 
-statement error con1
+statement error quack_db:quack_server_con
 call quack_serve(NULL)
 ----
 Invalid listen string
 
-statement ok con2
+statement ok
 from quack_query({server}, 'select 42')
 
-statement ok con 1
+statement ok quack_db:quack_server_con
 call quack_stop({server})
 
-statement ok con 1
+statement ok quack_db:quack_server_con
 call quack_stop({server})
 
-statement error con2
+statement error
 from quack_query({server}, 'select 42')
 ----
 IO Error
 
 # we can call quack_serve() without parameters and connect using just quack:localhost
-statement ok
-SET VARIABLE token=(FROM quack_serve() SELECT auth_token);
+statement ok quack_db:quack_server_con
+SET VARIABLE token=(FROM quack_serve({server}) SELECT auth_token);
 
-query I
-FROM quack_query('quack:localhost', 'select 42', token=getvariable('token'))
+query I quack_db:quack_server_con
+FROM quack_query({server}, 'select 42', token=getvariable('token'))
 ----
 42
 
-statement ok
-call quack_stop('quack:localhost')
-
-endloop
-
+include test/template/quack_teardown.test_template

--- a/test/sql/rpc.test
+++ b/test/sql/rpc.test
@@ -6,10 +6,7 @@ require quack
 
 require httpfs
 
-set ignore_error_messages __none__
-
 foreach server 'quack:localhost'
-
 
 query III con1
 call quack_serve({server}, token='asdf');

--- a/test/sql/rpc_call_projection.test
+++ b/test/sql/rpc_call_projection.test
@@ -2,80 +2,72 @@
 # description: projection pushdown through quack_query returns the RIGHT column (not just first-N)
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-statement ok con1
-call quack_serve('quack:localhost', token='asdf');
-
-statement ok con2
+statement ok
 create secret (type quack, token 'asdf')
 
 # Pick the non-first column — exercises the column_ids remap in RpcScan.
-query I con2
-SELECT b FROM quack_query('quack:localhost', 'SELECT 1 as a, ''2'' as b');
+query I
+SELECT b FROM quack_query({server}, 'SELECT 1 as a, ''2'' as b');
 ----
 2
 
 # Multi-column projection with reordering — output wants b, a (reverse of server order).
-query II con2
-SELECT b, a FROM quack_query('quack:localhost', 'SELECT 1 as a, ''2'' as b');
+query II
+SELECT b, a FROM quack_query({server}, 'SELECT 1 as a, ''2'' as b');
 ----
 2	1
 
 # Types differ per column — catches type-mismatch (INTEGER vs VARCHAR).
-query I con2
-SELECT b FROM quack_query('quack:localhost', 'SELECT 42 as a, ''hello'' as b');
+query I
+SELECT b FROM quack_query({server}, 'SELECT 42 as a, ''hello'' as b');
 ----
 hello
 
 # Projection of a single middle column.
-query I con2
-SELECT middle FROM quack_query('quack:localhost',
+query I
+SELECT middle FROM quack_query({server},
     'SELECT 1 as first, 2.5 as middle, ''last'' as last');
 ----
 2.5
 
 # No projection — SELECT * — identity mapping should still work.
-query III con2
-SELECT * FROM quack_query('quack:localhost',
+query III
+SELECT * FROM quack_query({server},
     'SELECT 1 as a, ''two'' as b, true as c');
 ----
 1	two	true
 
 # Projection + alias at the outer SELECT.
-query I con2
-SELECT b AS renamed FROM quack_query('quack:localhost',
+query I
+SELECT b AS renamed FROM quack_query({server},
     'SELECT 1 as a, ''hello'' as b');
 ----
 hello
 
 # Projection through aggregation — only needs `b`, drops `a`.
-query I con2
-SELECT count(b) FROM quack_query('quack:localhost',
+query I
+SELECT count(b) FROM quack_query({server},
     'SELECT 1 as a, ''x'' as b UNION ALL SELECT 2, ''y''');
 ----
 2
 
 # Same via quack_query_by_name (ATTACH path).
-statement ok con2
-attach 'quack:localhost' as r (type quack);
+statement ok
+attach {server} as r (type quack);
 
-query I con2
+query I
 SELECT b FROM quack_query_by_name('r', 'SELECT 1 as a, ''2'' as b');
 ----
 2
 
-query II con2
+query II
 SELECT b, a FROM quack_query_by_name('r', 'SELECT 1 as a, ''2'' as b');
 ----
 2	1
 
-statement ok con2
+statement ok
 detach r;
 
-statement ok con1
-call quack_stop('quack:localhost');
+include test/template/quack_teardown.test_template

--- a/test/sql/secret.test
+++ b/test/sql/secret.test
@@ -2,44 +2,38 @@
 # description: verify quack auth token resolution via DuckDB secrets (with rpc_default_token fallback)
 # group: [sql]
 
-require quack
-
-require httpfs
-
-statement ok con1
-call quack_serve('quack:localhost:20101', token='s3kr3t');
+include test/template/quack_setup.test_template
 
 # --- 1. Matching secret: ATTACH succeeds without touching rpc_default_token on the client ---
 
-statement ok con2
-create secret quack_ok (type quack, token 's3kr3t', scope 'quack:localhost:20101')
+statement ok
+create secret quack_ok (type quack, token 'asdf', scope {server})
 
-statement ok con2
-attach 'quack:localhost:20101' as r_ok (type quack)
+statement ok
+attach {server} as r_ok (type quack)
 
-query II con2
+query II
 from r_ok.query('select 1, 2')
 ----
 1	2
 
-statement ok con2
+statement ok
 detach r_ok
 
-statement ok con2
+statement ok
 drop secret quack_ok
 
 # --- 2. Wrong secret: ATTACH fails with Authentication failed ---
 
-statement ok con2
-create secret quack_bad (type quack, token 'nope', scope 'quack:localhost:20101')
+statement ok
+create secret quack_bad (type quack, token 'nope', scope {server})
 
-statement error con2
-attach 'quack:localhost:20101' as r_bad (type quack)
+statement error
+attach {server} as r_bad (type quack)
 ----
 Authentication failed
 
-statement ok con2
+statement ok
 drop secret quack_bad
 
-statement ok con1
-call quack_stop('quack:localhost:20101')
+include test/template/quack_teardown.test_template

--- a/test/sql/secret.test
+++ b/test/sql/secret.test
@@ -6,11 +6,8 @@ require quack
 
 require httpfs
 
-
 statement ok con1
 call quack_serve('quack:localhost:20101', token='s3kr3t');
-
-sleep 100 millisecond
 
 # --- 1. Matching secret: ATTACH succeeds without touching rpc_default_token on the client ---
 

--- a/test/sql/secret_rpc_call.test
+++ b/test/sql/secret_rpc_call.test
@@ -2,40 +2,32 @@
 # description: verify quack_query(uri, sql) picks up auth token from quack secrets
 # group: [sql]
 
-require quack
-
-require httpfs
-
-statement ok con1
-call quack_serve('quack:localhost:20102', token='s3kr3t');
-
-sleep 100 millisecond
+include test/template/quack_setup.test_template
 
 # --- 1. Matching secret: quack_query succeeds with the secret's token ---
 
-statement ok con2
-create secret rpc_ok (type quack, token 's3kr3t', scope 'quack:localhost:20102')
+statement ok
+create secret rpc_ok (type quack, token 'asdf', scope {server})
 
-query II con2
-from quack_query('quack:localhost:20102', 'select 1, 2')
+query II
+from quack_query({server}, 'select 1, 2')
 ----
 1	2
 
-statement ok con2
+statement ok
 drop secret rpc_ok
 
 # --- 2. Wrong secret: quack_query fails with Authentication failed ---
 
-statement ok con2
-create secret rpc_bad (type quack, token 'nope', scope 'quack:localhost:20102')
+statement ok
+create secret rpc_bad (type quack, token 'nope', scope {server})
 
-statement error con2
-from quack_query('quack:localhost:20102', 'select 1')
+statement error
+from quack_query({server}, 'select 1')
 ----
 Authentication failed
 
-statement ok con2
+statement ok
 drop secret rpc_bad
 
-statement ok con1
-call quack_stop('quack:localhost:20102')
+include test/template/quack_teardown.test_template

--- a/test/sql/self_stop.test
+++ b/test/sql/self_stop.test
@@ -2,31 +2,22 @@
 # description: A client may instruct a quack server to stop itself via `CALL quack_stop(...)` over RPC. Must not deadlock or crash.
 # group: [sql]
 
-require quack
-
-require httpfs
-
-# Don't skip on the connection-error string — it's exactly what we expect.
-set ignore_error_messages __none__
-
-# Start the server.
-statement ok
-FROM quack_serve('quack:127.0.0.1', token='abcd');
+include test/template/quack_setup.test_template
 
 # Have the client tell the server to stop itself. The server processes the
 # request on a worker thread, runs CALL quack_stop, returns the result row,
 # and asynchronously tears itself down — no deadlock joining the worker pool
 # from inside a worker.
 statement ok
-FROM quack_query('quack:127.0.0.1', 'CALL quack_stop(''quack:127.0.0.1'')', token='abcd');
+FROM quack_query({server}, 'CALL quack_stop('{server}')', token='asdf');
 
 # Server is now gone — a subsequent client request to the same address must
 # fail (any error is fine, as long as it doesn't hang or succeed).
 statement error
-FROM quack_query('quack:127.0.0.1', 'CALL quack_stop(''quack:127.0.0.1'')', token='abcd');
+FROM quack_query({server}, 'CALL quack_stop('{server}')', token='asdf');
 ----
 Failed to send message
 
 # Local-side stop is a no-op (no entry in the registry).
 statement ok
-CALL quack_stop('quack:127.0.0.1');
+CALL quack_stop({server});

--- a/test/sql/serve_canonical.test
+++ b/test/sql/serve_canonical.test
@@ -6,7 +6,7 @@ require quack
 
 require httpfs
 
-# Start a server on the explicit form. listen_uri column preserves what was sent.
+# Start a server with the explicit form. listen_uri column preserves what was sent.
 query III
 FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
 ----

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -2,64 +2,49 @@
 # description: quack_server_list returns rows for active servers
 # group: [sql]
 
-require notwindows
-
 require quack
 
 require httpfs
 
 # empty initially
-query I
+query I quack_db:quack_server_con
 SELECT count(*) FROM quack_server_list();
 ----
 0
 
-# one server
-statement ok
-FROM quack_serve('quack:127.0.0.1:9494', token='abcd');
+include test/template/quack_setup.test_template
 
-query I
+query I quack_db:quack_server_con
 SELECT count(*) FROM quack_server_list();
 ----
 1
 
-query IIIII
-SELECT listen_uri, listen_url, host, port, active_connections FROM quack_server_list();
+query II quack_db:quack_server_con
+SELECT host, active_connections FROM quack_server_list();
 ----
-quack:127.0.0.1:9494	http://127.0.0.1:9494	127.0.0.1	9494	0
+localhost	0
 
 # info map carries ipv6 flag
-query I
+query I quack_db:quack_server_con
 SELECT info['ipv6'] FROM quack_server_list();
 ----
 false
 
 # add a second server, verify count and ordering-agnostic content
-statement ok
+statement ok quack_db:quack_server_con
 FROM quack_serve('quack:127.0.0.1:9495', token='abcd');
 
-query I
+query I quack_db:quack_server_con
 SELECT count(*) FROM quack_server_list();
 ----
 2
 
-query I
-SELECT count(*) FROM quack_server_list() WHERE listen_uri = 'quack:127.0.0.1:9494';
-----
-1
-
-query I
-SELECT count(*) FROM quack_server_list() WHERE listen_uri = 'quack:127.0.0.1:9495';
-----
-1
-
-statement ok
-CALL quack_stop('quack:127.0.0.1:9494');
-
-statement ok
+statement ok quack_db:quack_server_con
 CALL quack_stop('quack:127.0.0.1:9495');
 
-query I
+include test/template/quack_teardown.test_template
+
+query I quack_db:quack_server_con
 SELECT count(*) FROM quack_server_list();
 ----
 0

--- a/test/sql/token_validation.test
+++ b/test/sql/token_validation.test
@@ -2,44 +2,44 @@
 # description: Reject quack_serve() tokens shorter than 4 chars; accept 4+; accept no token (auto-generated).
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
+statement ok quack_db:quack_server_con
+CALL quack_stop({server})
 
 # Reject empty token
-statement error
-FROM quack_serve('quack:127.0.0.1', token='');
+statement error quack_db:quack_server_con
+FROM quack_serve({server}, token='');
 ----
 Quack server token must be at least 4 characters long
 
 # Reject 1-char token
-statement error
-FROM quack_serve('quack:127.0.0.1', token='1');
+statement error quack_db:quack_server_con
+FROM quack_serve({server}, token='1');
 ----
 Quack server token must be at least 4 characters long
 
 # Reject 2-char token
-statement error
-FROM quack_serve('quack:127.0.0.1', token='12');
+statement error quack_db:quack_server_con
+FROM quack_serve({server}, token='12');
 ----
 Quack server token must be at least 4 characters long
 
 # Reject 3-char token
-statement error
-FROM quack_serve('quack:127.0.0.1', token='123');
+statement error quack_db:quack_server_con
+FROM quack_serve({server}, token='123');
 ----
 Quack server token must be at least 4 characters long
 
 # Accept 4-char token (boundary).
-statement ok
-FROM quack_serve('quack:127.0.0.1', token='1234');
+statement ok quack_db:quack_server_con
+FROM quack_serve({server}, token='1234');
 
-statement ok
-CALL quack_stop('quack:127.0.0.1');
+statement ok quack_db:quack_server_con
+CALL quack_stop({server});
 
 # No token argument -> auto-generated 32-char hex token, should succeed.
-statement ok
-FROM quack_serve('quack:127.0.0.1');
+statement ok quack_db:quack_server_con
+FROM quack_serve({server});
 
-statement ok
-CALL quack_stop('quack:127.0.0.1');
+include test/template/quack_teardown.test_template

--- a/test/template/quack_setup.test_template
+++ b/test/template/quack_setup.test_template
@@ -1,0 +1,13 @@
+require quack
+
+require httpfs
+
+test-env QUACK_SERVER quack:localhost
+
+statement ok quack_db:quack_server_con
+set variable actual_listen_uri = (select listen_uri from quack_serve('{QUACK_SERVER}:0', token='asdf'));
+
+query I quack_db:quack_server_con
+set variable listen_uri = concat('''', getvariable('actual_listen_uri'), '''');
+
+set variable server <variable:quack_server_con:listen_uri>

--- a/test/template/quack_setup.test_template
+++ b/test/template/quack_setup.test_template
@@ -4,6 +4,8 @@ require httpfs
 
 test-env QUACK_SERVER quack:localhost
 
+set ignore_error_messages
+
 statement ok quack_db:quack_server_con
 set variable actual_listen_uri = (select listen_uri from quack_serve('{QUACK_SERVER}:0', token='asdf'));
 

--- a/test/template/quack_teardown.test_template
+++ b/test/template/quack_teardown.test_template
@@ -1,0 +1,3 @@
+statement ok quack_db:quack_server_con
+call quack_stop({server});
+


### PR DESCRIPTION
Implements https://github.com/duckdb/duckdb-quack/issues/91

Adds support for `quack_serve` to bind to port 0, which finds a free port on the system instead of requiring a dedicated port to be specified. The actual port that is bound on is returned as part of the `listen_uri`, e.g.:

```sql
memory D call quack_serve('quack:localhost:0');
┌───────────────────────┬────────────────────────┬──────────────────────────────────┐
│      listen_uri       │       listen_url       │            auth_token            │
│        varchar        │        varchar         │             varchar              │
├───────────────────────┼────────────────────────┼──────────────────────────────────┤
│ quack:localhost:60593 │ http://localhost:60593 │ 20F74EA291D7DEDA2E4964E387E5F62C │
└───────────────────────┴────────────────────────┴──────────────────────────────────┘
```

We use this in the tests as well. We implement a template that uses the new include syntax introduced in https://github.com/duckdb/duckdb/pull/22927 that launches a server and retrieves the URI. The server is launched in a separate database (`quack_db:quack_server_con `) using the functionality introduced in https://github.com/duckdb/duckdb/pull/22914.

We rewrite all tests except for `test/sql/serve_canonical.test` to use this new template. This makes the tests much more robust as they no longer interfere with one another, preventing one failing tests from causing a cascade of failures, and also allows these tests to be run (in parallel) in the main CI.

We should maybe also just rewrite `test/sql/serve_canonical.test` to use this - as this is likely required to make these tests work, but this requires stripping down at least some of the functionality tested in that test so I refrained from doing that for now (as the canonicalization is only tested for the default port number). We could maybe allow this to be tested by allowing the default port number to be configurable.

We also fix a race condition in the shutdown of the httpfs server which could cause a deadlock if `StopAccepting` was called before `listen_after_bind`. This popped up more frequently as a result of this change because of a required order change in how we do registration of servers (as when specifying `port 0` we first need to bind to the port before we know which port we are registering to, which then affects the canonical URL).
