### PR TITLE
Add remote pushdown implementation in quack

### DIFF
--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -27,6 +27,7 @@ struct QuackScanBindData : FunctionData {
 	vector<LogicalType> column_types;
 	vector<unique_ptr<DataChunkWrapper>> results;
 	shared_ptr<QuackClientConnection> client_connection;
+	optional_ptr<TableCatalogEntry> table_entry;
 	bool needs_more_fetch = true;
 	hugeint_t result_uuid;
 };

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -54,6 +54,12 @@ public:
 	bool InMemory() override;
 	string GetDBPath() override;
 
+	bool IsRemoteCatalog() const override {
+		return true;
+	}
+	unique_ptr<TableRef> RemoteExecute(ClientContext &context, unique_ptr<QueryNode> node) override;
+	unique_ptr<TableRef> RemoteExecute(ClientContext &context, const string &sql) override;
+
 	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(ClientContext &context, const string &query);
 	const QuackUri &GetServerUri();
 	const string &GetConnectionId();

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -55,7 +55,7 @@ public:
 	string GetDBPath() override;
 
 	bool Supports(RemoteCapability capability) const override {
-		switch(capability) {
+		switch (capability) {
 		case RemoteCapability::IS_REMOTE:
 		case RemoteCapability::EXECUTE_QUERY_NODE:
 		case RemoteCapability::CONNECT:

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -54,8 +54,15 @@ public:
 	bool InMemory() override;
 	string GetDBPath() override;
 
-	bool IsRemoteCatalog() const override {
-		return true;
+	bool Supports(RemoteCapability capability) const override {
+		switch(capability) {
+		case RemoteCapability::IS_REMOTE:
+		case RemoteCapability::EXECUTE_QUERY_NODE:
+		case RemoteCapability::CONNECT:
+			return true;
+		default:
+			return false;
+		}
 	}
 	unique_ptr<TableRef> RemoteExecute(ClientContext &context, unique_ptr<QueryNode> node) override;
 	unique_ptr<TableRef> RemoteExecute(ClientContext &context, const string &sql) override;

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -370,6 +370,14 @@ unique_ptr<FunctionData> QuackScanDeserialize(Deserializer &deserializer, TableF
 	throw NotImplementedException("Quack scans cannot be deserialized (yet?)");
 }
 
+BindInfo QuackScanGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
+	auto &bind_data = bind_data_p->CastNoConst<QuackScanBindData>();
+	if (bind_data.table_entry) {
+		return BindInfo(*bind_data.table_entry);
+	}
+	return BindInfo(ScanType::EXTERNAL);
+}
+
 TableFunction QuackScanFunction::GetFunction() {
 	auto fun = TableFunction("quack_query", {LogicalType::VARCHAR, LogicalType::VARCHAR}, QuackScan, QuackScanBind,
 	                         QuackScanInitGlobal, QuackScanInitLocal);
@@ -381,6 +389,7 @@ TableFunction QuackScanFunction::GetFunction() {
 	fun.to_string = QuackScanToString;
 	fun.serialize = QuackScanSerialize;
 	fun.deserialize = QuackScanDeserialize;
+	fun.get_bind_info = QuackScanGetBindInfo;
 	// fun.filter_pushdown = true;
 	// fun.filter_prune = true;
 	return fun;
@@ -394,6 +403,7 @@ TableFunction QuackScanByNameFunction::GetFunction() {
 	fun.to_string = QuackScanToString;
 	fun.serialize = QuackScanSerialize;
 	fun.deserialize = QuackScanDeserialize;
+	fun.get_bind_info = QuackScanGetBindInfo;
 	// fun.filter_pushdown = true;
 	// fun.filter_prune = true;
 	return fun;

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -7,6 +7,9 @@
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 #include "duckdb/storage/database_size.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 
 #include "storage/quack_catalog.hpp"
 #include "storage/quack_table.hpp"
@@ -124,6 +127,19 @@ unique_ptr<LogicalOperator> QuackCatalog::BindCreateIndex(Binder &binder, Create
 
 DatabaseSize QuackCatalog::GetDatabaseSize(ClientContext &context) {
 	throw NotImplementedException("GetDatabaseSize not implemented yet");
+}
+
+unique_ptr<TableRef> QuackCatalog::RemoteExecute(ClientContext &context, unique_ptr<QueryNode> node) {
+	return RemoteExecute(context, node->ToString());
+}
+
+unique_ptr<TableRef> QuackCatalog::RemoteExecute(ClientContext &context, const string &sql) {
+	vector<unique_ptr<ParsedExpression>> args;
+	args.push_back(make_uniq<ConstantExpression>(Value(GetName())));
+	args.push_back(make_uniq<ConstantExpression>(Value(sql)));
+	auto func_ref = make_uniq<TableFunctionRef>();
+	func_ref->function = make_uniq<FunctionExpression>("quack_query_by_name", std::move(args));
+	return func_ref;
 }
 
 //! Whether or not this is an in-memory SQLite database

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -83,8 +83,8 @@ SinkFinalizeType QuackInsert::Finalize(Pipeline &pipeline, Event &event, ClientC
 SourceResultType QuackInsert::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                               OperatorSourceInput &input) const {
 	auto &insert_gstate = sink_state->Cast<QuackInsertGlobalState>();
+	chunk.data[0].Append(Value::BIGINT(NumericCast<int64_t>(insert_gstate.insert_count)));
 	chunk.SetCardinality(1);
-	chunk.SetValue(0, 0, Value::BIGINT(NumericCast<int64_t>(insert_gstate.insert_count)));
 	return SourceResultType::FINISHED;
 }
 
@@ -103,6 +103,9 @@ InsertionOrderPreservingMap<string> QuackInsert::ParamsToString() const {
 
 PhysicalOperator &QuackCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
                                            optional_ptr<PhysicalOperator> plan) {
+	if (op.return_chunk) {
+		throw NotImplementedException("RETURNING not yet supported for QUACK_INSERT");
+	}
 	D_ASSERT(plan);
 	if (!op.column_index_map.empty()) {
 		plan = planner.ResolveDefaultsProjection(op, *plan);

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -84,6 +84,7 @@ TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, un
 		bind_data->column_names.push_back(col.Name());
 		bind_data->column_types.push_back(col.Type());
 	}
+	bind_data->table_entry = this;
 	bind_data_p = std::move(bind_data);
 	return QuackScanFunction::GetFunction();
 }

--- a/test/remote_pushdown/remote_pushdown_advanced.test
+++ b/test/remote_pushdown/remote_pushdown_advanced.test
@@ -1,0 +1,467 @@
+# name: test/remote_pushdown/remote_pushdown_advanced.test
+# description: Advanced edge cases: window functions, QUALIFY, HAVING, DISTINCT ON, set ops, INSERT ON CONFLICT
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+# t1 = {0..9}, t2 = {5..14}
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+# t3: table with a primary key for ON CONFLICT tests
+statement ok quack_db:quack_server_con
+create table t3(i int primary key, v int);
+
+statement ok quack_db:quack_server_con
+insert into t3 values (1, 10), (2, 20), (3, 30);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table local_t(i int);
+
+statement ok
+insert into local_t from range(10);
+
+# --- Window functions ---
+
+# Running sum pushed to remote (no SEQ_SCAN in local plan)
+query II
+explain select i, sum(i) over (order by i) from rpc.t1 where i < 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# running sum: 0, 1, 3, 6, 10
+query II
+select i, sum(i) over (order by i) as running_sum
+from rpc.t1 where i < 5
+order by i
+----
+0	0
+1	1
+2	3
+3	6
+4	10
+
+query II
+select i, row_number() over (order by i) as rn
+from rpc.t1 where i >= 7
+order by i
+----
+7	1
+8	2
+9	3
+
+# Catalog-qualified column refs inside window spec stripped before push
+query II
+explain select rpc.t1.i, rank() over (order by rpc.t1.i) from rpc.t1 where rpc.t1.i < 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query II
+select rpc.t1.i, rank() over (order by rpc.t1.i) as rnk
+from rpc.t1 where rpc.t1.i < 5
+order by rpc.t1.i
+----
+0	1
+1	2
+2	3
+3	4
+4	5
+
+# PARTITION BY in window function
+query III
+select i % 2 as parity, i, row_number() over (partition by i % 2 order by i) as rn
+from rpc.t1
+where i < 6
+order by i
+----
+0	0	1
+1	1	1
+0	2	2
+1	3	2
+0	4	3
+1	5	3
+
+# --- QUALIFY clause ---
+
+# QUALIFY to keep only the row with max i per parity group
+query II
+explain select i, row_number() over (partition by i % 2 order by i desc) as rn
+from rpc.t1
+qualify rn = 1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# even parity max=8, odd parity max=9
+query I
+select i from rpc.t1
+qualify row_number() over (partition by i % 2 order by i desc) = 1
+order by i
+----
+8
+9
+
+# QUALIFY with catalog-qualified column ref stripped before push
+query I
+select rpc.t1.i from rpc.t1
+qualify row_number() over (order by rpc.t1.i) <= 3
+order by rpc.t1.i
+----
+0
+1
+2
+
+# --- HAVING with catalog-qualified column refs ---
+
+query II
+explain select i % 3 as bucket, count(*) from rpc.t1 group by bucket having count(*) > 3
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# bucket 0→4 rows, buckets 1,2→3 rows each; only bucket 0 passes count>3
+query II
+select i % 3 as bucket, count(*) as cnt
+from rpc.t1
+group by bucket
+having count(*) > 3
+order by bucket
+----
+0	4
+
+# HAVING with catalog-qualified ref
+query II
+select rpc.t1.i % 2 as parity, count(*)
+from rpc.t1
+group by parity
+having count(*) >= 5
+order by parity
+----
+0	5
+1	5
+
+# --- DISTINCT ON: catalog-qualified refs in DISTINCT modifier stripped before push ---
+
+query II
+explain select distinct on (rpc.t1.i) rpc.t1.i from rpc.t1 order by rpc.t1.i
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1={0..9}: 10 distinct values
+query I
+select count(*) from (
+  select distinct on (rpc.t1.i) rpc.t1.i from rpc.t1
+) sub
+----
+10
+
+query I
+select distinct on (rpc.t1.i % 3) rpc.t1.i
+from rpc.t1
+order by rpc.t1.i % 3, rpc.t1.i
+----
+0
+1
+2
+
+# --- LIMIT with scalar subquery: catalog-qualified refs in LIMIT modifier stripped before push ---
+
+# LIMIT = count of t1 rows where i < 3 = 3
+query I
+select i from rpc.t1
+order by i
+limit (select count(*) from rpc.t1 where rpc.t1.i < 3)
+----
+0
+1
+2
+
+# LIMIT with catalog-qualified ref in subquery filter
+query I
+select count(*) from (
+  select i from rpc.t1
+  order by i desc
+  limit (select max(rpc.t1.i) from rpc.t1 where rpc.t1.i < 5)
+) sub
+----
+4
+
+# OFFSET with catalog-qualified ref in subquery
+query I
+select i from rpc.t1
+order by i
+limit 3 offset (select min(rpc.t1.i) from rpc.t1 where rpc.t1.i > 2)
+----
+3
+4
+5
+
+# --- EXCEPT ALL / INTERSECT ALL ---
+
+# INTERSECT ALL: all remote → pushed
+query II
+explain select i from rpc.t1 intersect all select i from rpc.t2
+----
+physical_plan	<!REGEX>:.*INTERSECT.*
+
+# t1∩t2 = {5,6,7,8,9} → 5 rows
+query I
+select count(*) from (select i from rpc.t1 intersect all select i from rpc.t2)
+----
+5
+
+# EXCEPT ALL: all remote → pushed
+query II
+explain select i from rpc.t1 except all select i from rpc.t2
+----
+physical_plan	<!REGEX>:.*EXCEPT.*
+
+# t1-t2 = {0,1,2,3,4} → 5 rows
+query I
+select count(*) from (select i from rpc.t1 except all select i from rpc.t2)
+----
+5
+
+query I
+select sum(i) from (select i from rpc.t1 except all select i from rpc.t2)
+----
+10
+
+# --- INSERT ON CONFLICT (UPSERT) ---
+
+# conflict on i=1 → update v to 999
+statement ok
+insert into rpc.t3 values (1, 999) on conflict (i) do update set v = excluded.v
+
+query II
+select i, v from rpc.t3 where i = 1
+----
+1	999
+
+statement ok
+update rpc.t3 set v = 10 where i = 1
+
+# ON CONFLICT DO NOTHING: duplicate i=2 silently ignored
+statement ok
+insert into rpc.t3 values (2, 999) on conflict (i) do nothing
+
+query II
+select i, v from rpc.t3 where i = 2
+----
+2	20
+
+statement ok
+insert into rpc.t3 values (4, 40) on conflict (i) do nothing
+
+query I
+select count(*) from rpc.t3
+----
+4
+
+statement ok
+delete from rpc.t3 where i = 4
+
+# --- Correlated subquery in SELECT list ---
+
+query II
+explain select i, (select count(*) from rpc.t2 where rpc.t2.i > rpc.t1.i) as cnt from rpc.t1 where i >= 8
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# i=8: 6 rows in t2 where j>8; i=9: 5 rows
+query II
+select i, (select count(*) from rpc.t2 where rpc.t2.i > rpc.t1.i) as cnt
+from rpc.t1
+where i >= 8
+order by i
+----
+8	6
+9	5
+
+# --- Mixed: remote subquery in LIMIT of a local+remote query ---
+
+# local_t={0..9}; LIMIT = count of t1 rows where i < 4 = 4
+query I
+select count(*) from (
+  select i from local_t order by i
+  limit (select count(*) from rpc.t1 where i < 4)
+) sub
+----
+4
+
+# --- VALUES list in FROM clause ---
+
+query II
+explain select * from rpc.t1 where i in (values (3), (7), (9))
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select i from rpc.t1 where i in (values (3), (7), (9)) order by i
+----
+3
+7
+9
+
+# --- Multiple aggregates and complex GROUP BY ---
+
+query III
+select i % 3 as bucket, min(i), max(i)
+from rpc.t1
+group by bucket
+order by bucket
+----
+0	0	9
+1	1	7
+2	2	8
+
+# --- Subquery in FROM with alias used in outer WHERE ---
+
+query I
+select count(*) from (select i * 2 as doubled from rpc.t1) sub where doubled > 10
+----
+4
+
+# --- Self-join with filter ---
+
+query II
+explain select count(*) from rpc.t1 a join rpc.t1 b on a.i + 1 = b.i where a.i < 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# a.i∈{0..4}, b.i=a.i+1: 5 pairs
+query I
+select count(*) from rpc.t1 a join rpc.t1 b on a.i + 1 = b.i where a.i < 5
+----
+5
+
+query II
+select a.i as ai, b.i as bi from rpc.t1 a join rpc.t1 b on a.i + 1 = b.i where a.i < 3 order by ai
+----
+0	1
+1	2
+2	3
+
+# --- Three-table JOIN ---
+
+query II
+explain
+select count(*) from rpc.t1 a
+join rpc.t1 b on a.i = b.i
+join rpc.t2 c on b.i = c.i
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# a=b always; b∈t2∩t1={5..9} → 5 rows
+query I
+select count(*) from rpc.t1 a
+join rpc.t1 b on a.i = b.i
+join rpc.t2 c on b.i = c.i
+----
+5
+
+# --- CROSS JOIN ---
+
+query I
+select count(*) from rpc.t1 cross join (select 1 as x) v
+----
+10
+
+# --- NATURAL JOIN ---
+
+# t1(i)={0..9}, t2(i)={5..14}: NATURAL JOIN → {5,6,7,8,9} → 5 rows
+query II
+explain select count(*) from rpc.t1 natural join rpc.t2
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1 natural join rpc.t2
+----
+5
+
+# mixed: remote t1 and local local_t (both have column i) → stays local
+query II
+explain select count(*) from rpc.t1 natural join local_t
+----
+physical_plan	<REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1 natural join local_t
+----
+10
+
+# --- Lambda expressions ---
+
+# list_transform([1,2,3], x→x+2)=[3,4,5]; i∈{3,4,5} → 3 rows
+query I
+select count(*) from rpc.t1 where list_contains(list_transform([1, 2, 3], lambda x: x + 2), i)
+----
+3
+
+# local macro inside lambda forces individual table push
+statement ok
+create macro my_double(x) as x * 2;
+
+# list_contains([4,6,8], i): i∈{4,6,8} → 3 rows
+query I
+select count(*) from rpc.t1 where list_contains(list_transform([2, 3, 4], lambda x: my_double(x)), i)
+----
+3
+
+statement ok
+drop macro my_double;
+
+# --- NULL handling ---
+
+statement ok quack_db:quack_server_con
+create table nulls(i int);
+
+statement ok quack_db:quack_server_con
+insert into nulls values (1), (NULL), (3), (NULL), (5);
+
+# COUNT(*) counts nulls, COUNT(i) skips them
+query II
+select count(*), count(i) from rpc.nulls
+----
+5	3
+
+query I
+select sum(coalesce(i, 0)) from rpc.nulls
+----
+9
+
+statement ok quack_db:quack_server_con
+drop table nulls
+
+# --- Aggregate without GROUP BY ---
+
+query IIII
+select min(i), max(i), sum(i), count(*) from rpc.t1
+----
+0	9	45	10
+
+# --- FILTER clause on aggregate ---
+
+query II
+select
+  count(*) filter (where i < 5) as below_5,
+  count(*) filter (where i >= 5) as above_eq_5
+from rpc.t1
+----
+5	5
+
+statement ok
+drop table local_t
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_basic.test
+++ b/test/remote_pushdown/remote_pushdown_basic.test
@@ -1,0 +1,237 @@
+# name: test/remote_pushdown/remote_pushdown_basic.test
+# description: Basic SELECT pushdown scenarios for remote catalogs
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(j int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# --- Simple SELECT pushdown ---
+
+# Full table scan: no SEQ_SCAN in local plan (replaced by quack_query)
+query II
+explain select * from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1
+----
+10
+
+# Filter is pushed
+query II
+explain select * from rpc.t1 where i > 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1 where i > 5
+----
+4
+
+# LIMIT is pushed — no LIMIT operator in the local plan
+query II
+explain select * from rpc.t1 limit 5
+----
+physical_plan	<!REGEX>:.*LIMIT.*
+
+query I
+select count(*) from (select * from rpc.t1 limit 5)
+----
+5
+
+# LIMIT with OFFSET is pushed
+query II
+explain select i from rpc.t1 order by i limit 3 offset 5
+----
+physical_plan	<!REGEX>:.*LIMIT.*
+
+query I
+select i from rpc.t1 order by i limit 3 offset 5
+----
+5
+6
+7
+
+# DISTINCT is pushed
+query II
+explain select distinct i from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from (select distinct i from rpc.t1)
+----
+10
+
+# --- Aggregate functions ---
+
+query II
+explain select count(*) from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select sum(i) from rpc.t1
+----
+45
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	9
+
+query I
+select count(distinct i) from rpc.t1
+----
+10
+
+# --- GROUP BY and HAVING ---
+
+query II
+explain select i % 2 as parity, count(*) from rpc.t1 group by parity
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1 = {0..9}: 5 even, 5 odd
+query II
+select i % 2 as parity, count(*) from rpc.t1 group by parity order by parity
+----
+0	5
+1	5
+
+# GROUP BY with HAVING: buckets 0%3=4 rows, 1%3=3 rows, 2%3=3 rows; only count=3 groups pass
+query I
+select count(*) from (
+  select i % 3 as bucket, count(*) as cnt
+  from rpc.t1 group by bucket having count(*) = 3
+)
+----
+2
+
+# --- ORDER BY ---
+
+query II
+explain select i from rpc.t1 order by i desc
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select i from rpc.t1 order by i desc limit 3
+----
+9
+8
+7
+
+# --- Arithmetic and expressions ---
+
+query II
+explain select i * 2 as doubled from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# sum of doubled values: 2*(0+1+...+9) = 90
+query I
+select sum(i * 2) from rpc.t1
+----
+90
+
+# CASE WHEN is pushed
+query II
+explain select case when i < 5 then 0 else 1 end as bucket from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# 5 rows < 5, 5 rows >= 5
+query II
+select
+  sum(case when i < 5 then 1 else 0 end),
+  sum(case when i >= 5 then 1 else 0 end)
+from rpc.t1
+----
+5	5
+
+# BETWEEN is pushed: {3,4,5,6,7} = 5 rows
+query I
+select count(*) from rpc.t1 where i between 3 and 7
+----
+5
+
+# Cast expression is pushed
+query I
+select count(*) from rpc.t1 where i::varchar = '5'
+----
+1
+
+# --- Joins (all remote) ---
+
+# Self-join: no JOIN in local plan
+query II
+explain select a.i from rpc.t1 a join rpc.t1 b on a.i = b.i
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+query I
+select count(*) from rpc.t1 a join rpc.t1 b on a.i = b.i
+----
+10
+
+# JOIN USING clause
+query I
+select count(*) from rpc.t1 a join rpc.t1 b using (i)
+----
+10
+
+# Two different remote tables: t1={0..9}, t2={5..14}, overlap={5..9} -> 5 rows
+query II
+explain select * from rpc.t1 join rpc.t2 on i = j
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+query I
+select count(*) from rpc.t1 join rpc.t2 on i = j
+----
+5
+
+# LEFT JOIN: all 10 rows from t1 preserved (5 match, 5 don't)
+query I
+select count(*) from rpc.t1 left join rpc.t2 on i = j
+----
+10
+
+# --- Window functions ---
+
+query II
+explain select i, row_number() over (order by i) as rn from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# row_number over filtered rows: i=0,1,2 get rn=1,2,3
+query II
+select i, row_number() over (order by i) as rn from rpc.t1 where i < 3 order by i
+----
+0	1
+1	2
+2	3
+
+# max row_number equals total count
+query I
+select max(rn) from (select row_number() over (order by i) as rn from rpc.t1) sub
+----
+10
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_catalog.test
+++ b/test/remote_pushdown/remote_pushdown_catalog.test
@@ -1,0 +1,173 @@
+# name: test/remote_pushdown/remote_pushdown_catalog.test
+# description: Catalog/schema qualification and optimizer control for remote pushdown
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# --- Schema-qualified table references ---
+
+# rpc.main.t1 is pushed (rpc=catalog, main=schema, t1=table)
+query II
+explain select * from rpc.main.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.main.t1
+----
+10
+
+# Schema-qualified in filter
+query I
+select count(*) from rpc.main.t1 where i > 5
+----
+4
+
+# Schema-qualified in aggregate
+query I
+select sum(i) from rpc.main.t1
+----
+45
+
+# --- Catalog-qualified column references ---
+
+# rpc.t1.i in WHERE clause: catalog prefix stripped before sending to remote
+query II
+explain select * from rpc.t1 where rpc.t1.i > 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1 where rpc.t1.i > 5
+----
+4
+
+# Schema + table qualified column: rpc.main.t1.i stripped to t1.i
+query I
+select count(*) from rpc.main.t1 where rpc.main.t1.i > 5
+----
+4
+
+# Catalog-qualified column in ORDER BY: stripped before push
+query II
+explain select rpc.t1.i from rpc.t1 order by rpc.t1.i
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select rpc.t1.i from rpc.t1 order by rpc.t1.i limit 3
+----
+0
+1
+2
+
+# Catalog-qualified column in ORDER BY DESC
+query I
+select rpc.t1.i from rpc.t1 where rpc.t1.i <= 2 order by rpc.t1.i desc
+----
+2
+1
+0
+
+# --- GROUP BY with catalog-qualified column refs ---
+
+# GROUP BY with catalog-qualified ref: stripped to unqualified in pushed SQL
+query II
+explain select rpc.t1.i, count(*) from rpc.t1 group by rpc.t1.i order by rpc.t1.i
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# Verify correct aggregation result with qualified refs
+query II
+select rpc.t1.i, count(*) from rpc.t1 where rpc.t1.i >= 8 group by rpc.t1.i order by rpc.t1.i
+----
+8	1
+9	1
+
+# GROUP BY with schema-qualified ref
+query I
+select count(*) from (
+  select rpc.main.t1.i % 2 as parity from rpc.main.t1 group by parity
+)
+----
+2
+
+# --- DML with schema-qualified table ---
+
+# INSERT targeting schema-qualified remote table
+statement ok
+insert into rpc.main.t1 values (100), (101), (102)
+
+query I
+select count(*) from rpc.t1 where i >= 100
+----
+3
+
+# DELETE from schema-qualified remote table
+statement ok
+delete from rpc.main.t1 where i >= 100
+
+query I
+select count(*) from rpc.t1 where i >= 100
+----
+0
+
+# UPDATE on schema-qualified remote table
+statement ok
+update rpc.main.t1 set i = i + 1 where i = 0
+
+query I
+select count(*) from rpc.t1 where i = 0
+----
+0
+
+query I
+select count(*) from rpc.t1 where i = 1
+----
+2
+
+# Restore: remove both rows with i=1 then insert originals back
+statement ok
+delete from rpc.main.t1 where i = 1
+
+statement ok
+insert into rpc.main.t1 values (0), (1)
+
+# --- Optimizer control ---
+
+# Verify remote pushdown can be disabled via disabled_optimizers
+statement ok
+SET disabled_optimizers = 'remote_pushdown'
+
+# With pushdown disabled, query still routes through quack transport (QUACK_QUERY)
+query II
+explain select * from rpc.t1
+----
+physical_plan	<REGEX>:.*QUACK_QUERY.*
+
+# Functional: query still works correctly even without pushdown
+query I
+select count(*) from rpc.t1
+----
+10
+
+statement ok
+RESET disabled_optimizers
+
+# After re-enabling, pushdown is active again
+query II
+explain select * from rpc.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+statement ok quack_db:quack_server_con
+call quack_stop('quack:localhost')

--- a/test/remote_pushdown/remote_pushdown_catalog_stripping.test
+++ b/test/remote_pushdown/remote_pushdown_catalog_stripping.test
@@ -1,0 +1,275 @@
+# name: test/remote_pushdown/remote_pushdown_catalog_stripping.test
+# description: Regression tests for catalog name stripping and alias resolution bugs in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t1_struct(id int, info struct(val int));
+
+statement ok quack_db:quack_server_con
+insert into t1_struct values (1, {'val': 10}), (2, {'val': 20}), (3, {'val': 30});
+
+statement ok quack_db:quack_server_con
+create table t_struct_col(id int, rpc struct(x int, y int));
+
+statement ok quack_db:quack_server_con
+insert into t_struct_col values (1, {'x': 10, 'y': 1}), (2, {'x': 20, 'y': 2}), (3, {'x': 5, 'y': 3});
+
+statement ok quack_db:quack_server_con
+create table t_nested(id int, s struct(a struct(b struct(c int))));
+
+statement ok quack_db:quack_server_con
+insert into t_nested values (1, {'a': {'b': {'c': 42}}}), (2, {'a': {'b': {'c': 7}}});
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Bug 12: StripCatalogName(ParsedExpression) stripped unqualified column refs whose single name matched
+# the catalog name, leaving column_names=[] and causing a binder crash.
+# Fix: require at least 2 elements before stripping.
+
+statement ok
+create table local_rpc(rpc int);
+
+statement ok
+insert into local_rpc values (3), (5), (7);
+
+# Mixed join: local_rpc + rpc.t1; "rpc" column ref must survive stripping intact.
+# local_rpc={3,5,7}; rpc.t1={0..9}: inner join matches {3,5,7} -> 3 rows.
+query I
+select rpc from local_rpc join rpc.t1 on local_rpc.rpc = rpc.t1.i order by rpc
+----
+3
+5
+7
+
+statement ok
+drop table local_rpc
+
+# Bug 30: StripCatalogName for ColumnRefExpression must require at least 3 parts before stripping.
+# A 2-part ref like "rpc.x" is table.column or struct.field, never catalog-qualified.
+
+# (a) 3-part catalog.table.column in SELECT list and WHERE
+query I
+select rpc.t1.i from rpc.t1 where rpc.t1.i >= 8 order by rpc.t1.i
+----
+8
+9
+
+# (b) 2-part table.column not stripped (t1.i stays as-is)
+query I
+select t1.i from rpc.t1 t1 where t1.i >= 8 order by t1.i
+----
+8
+9
+
+# "rpc.x" is a 2-part struct field access; old code (size >= 2) incorrectly stripped to "x".
+# With fix (size >= 3), rpc.x is preserved as a struct field access.
+query II
+select id, rpc.x from rpc.t_struct_col order by id
+----
+1	10
+2	20
+3	5
+
+# struct field in WHERE: rpc.x > 8 must not be stripped to x > 8
+query I
+select id from rpc.t_struct_col where rpc.x > 8 order by id
+----
+1
+2
+
+statement ok quack_db:quack_server_con
+drop table t_struct_col;
+
+# Bug 30 (extended): deeply nested structs — 5-part ref rpc.t_nested.s.a.b.c correctly strips to t_nested.s.a.b.c.
+query II
+select id, rpc.t_nested.s.a.b.c from rpc.t_nested order by id
+----
+1	42
+2	7
+
+# 5-part ref in WHERE
+query I
+select id from rpc.t_nested where rpc.t_nested.s.a.b.c > 10 order by id
+----
+1
+
+# Bug 33: Rewrite(SelectNode) pending stripping loop handled ORDER_MODIFIER but missed DISTINCT_MODIFIER;
+# DISTINCT ON (rpc.t1.i) on a mixed join left the ref unstripped, causing a binder error.
+# Fix: add DISTINCT_MODIFIER handling to the pending stripping loop.
+
+statement ok
+create table local_bug33(k int);
+
+statement ok
+insert into local_bug33 values (2), (5), (8);
+
+# Mixed join: rpc.t1 (pushed individually) + local_bug33.
+# t1={0..9}; inner join on t1.i=k gives {2,5,8}; DISTINCT ON t1.i -> 3 rows.
+query I
+select distinct on (rpc.t1.i) rpc.t1.i
+from rpc.t1 join local_bug33 on rpc.t1.i = local_bug33.k
+order by rpc.t1.i
+----
+2
+5
+8
+
+statement ok
+drop table local_bug33;
+
+# Bug 34: PushJoinChild with explicit alias differing from table name; after stripping rpc.t1.i -> t1.i,
+# the binder only sees the alias "rt1", so t1.i cannot be resolved.
+
+statement ok
+create table local_bug34(k int);
+
+statement ok
+insert into local_bug34 values (2), (5), (8);
+
+# Mixed join: rpc.t1 AS rt1 pushed individually; ON condition uses catalog-qualified rpc.t1.i.
+# After stripping rpc.t1.i -> t1.i, the binder still fails because alias "rt1" != "t1".
+statement error
+select rt1.i
+from rpc.t1 AS rt1 join local_bug34 on rpc.t1.i = local_bug34.k
+order by rt1.i
+----
+not found
+
+statement ok
+drop table local_bug34;
+
+# Bug 35: pending_outer_strip_catalogs missing RenameTableInExpr; after stripping rpc.t1.col -> t1.col
+# in SELECT/WHERE, the result t1.col cannot be resolved when only the alias rt1 is in scope.
+
+statement ok
+create table local_bug35(k int);
+
+statement ok
+insert into local_bug35 values (2), (5), (8);
+
+# SELECT uses catalog-qualified rpc.t1.i; after stripping -> t1.i; binder fails (only rt1 in scope).
+statement error
+select rpc.t1.i
+from rpc.t1 AS rt1 join local_bug35 on rt1.i = local_bug35.k
+order by rpc.t1.i
+----
+not found
+
+# WHERE also uses catalog-qualified form
+statement error
+select rpc.t1.i
+from rpc.t1 AS rt1 join local_bug35 on rt1.i = local_bug35.k
+where rpc.t1.i > 3
+order by rpc.t1.i
+----
+not found
+
+statement ok
+drop table local_bug35;
+
+# Bug 38: RenameTableInExpr only handled 2-part column refs; schema-qualified refs like main.t1.col
+# (3-part after catalog stripping) were left unmodified, causing binder errors.
+# Fix: extend RenameTableInExpr to reduce 3-part schema.table.col -> alias.col.
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# Bug 38a: schema-qualified ON condition — no alias; rpc.main.t1={0..9}, local_t={0..9}: 10 rows match
+query I
+select count(*) from rpc.main.t1 join local_t on (rpc.main.t1.i = local_t.local_col)
+----
+10
+
+# Bug 38b: schema-qualified ON condition — with explicit alias (rt1)
+statement error
+select count(*) from rpc.main.t1 as rt1 join local_t on (rpc.main.t1.i = local_t.local_col)
+----
+not found
+
+# Bug 38c: schema-qualified column ref in WHERE; 4 rows with local_col > 5
+query I
+select count(*) from rpc.main.t1 join local_t on (i = local_col) where rpc.main.t1.i > 5
+----
+4
+
+# Bug 38d: schema-qualified column ref in SELECT list
+query I
+select count(rpc.main.t1.i) from rpc.main.t1 join local_t on (i = local_col)
+----
+10
+
+statement ok
+drop table local_t;
+
+# Bug 39: RenameTableInExpr did not handle struct field access in 3+-part refs after catalog stripping;
+# t1.info.val (3-part) was not renamed to alias.info.val.
+# Fix: Case 3 in RenameTableInExpr renames col[0] when size>=3 and col[0]==old_table.
+
+statement ok
+create table local_struct(id int);
+
+statement ok
+insert into local_struct values (1), (2), (3);
+
+# Bug 39a: struct field in SELECT of mixed join — no alias
+query I
+select rpc.t1_struct.info.val from rpc.t1_struct join local_struct on (rpc.t1_struct.id = local_struct.id) order by 1
+----
+10
+20
+30
+
+# Bug 39b: struct field in SELECT of mixed join — with explicit alias
+statement error
+select rpc.t1_struct.info.val from rpc.t1_struct as ts join local_struct on (rpc.t1_struct.id = local_struct.id) order by 1
+----
+not found
+
+# Bug 39c: struct field in WHERE of mixed join
+query I
+select rpc.t1_struct.id from rpc.t1_struct join local_struct on (rpc.t1_struct.id = local_struct.id) where rpc.t1_struct.info.val > 15 order by 1
+----
+2
+3
+
+# Bug 40: RenameTableInExpr did not handle schema-qualified struct field access in 4+-part refs;
+# main.t1_struct.info.val (4-part after catalog stripping) was left unchanged, causing binder errors.
+# Fix: Case 4 strips the schema prefix and renames: main.t1_struct.info.val -> alias.info.val.
+
+# Bug 40a: schema-qualified struct field in SELECT — no alias
+query I
+select rpc.main.t1_struct.info.val from rpc.main.t1_struct join local_struct on (rpc.main.t1_struct.id = local_struct.id) order by 1
+----
+10
+20
+30
+
+# Bug 40b: schema-qualified struct field in SELECT — with alias
+statement error
+select rpc.main.t1_struct.info.val from rpc.main.t1_struct as ts join local_struct on (rpc.main.t1_struct.id = local_struct.id) order by 1
+----
+not found
+
+# Bug 40c: schema-qualified struct field in WHERE
+query I
+select rpc.main.t1_struct.id from rpc.main.t1_struct join local_struct on (rpc.main.t1_struct.id = local_struct.id) where rpc.main.t1_struct.info.val > 15 order by 1
+----
+2
+3
+
+statement ok
+drop table local_struct;
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_cte.test
+++ b/test/remote_pushdown/remote_pushdown_cte.test
@@ -1,0 +1,387 @@
+# name: test/remote_pushdown/remote_pushdown_cte.test
+# description: CTE (non-recursive and recursive) pushdown for remote catalogs
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table local_t(i int);
+
+statement ok
+insert into local_t from range(10);
+
+# --- Non-recursive CTE: all remote → pushed ---
+
+query II
+explain with cte as (select * from rpc.t1) select * from cte
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+with cte as (select * from rpc.t1 where i > 5) select count(*) from cte
+----
+4
+
+query I
+with cte as (select i from rpc.t1 where i < 5) select sum(i) from cte
+----
+10
+
+query II
+explain with cte as (select * from rpc.t1 limit 5) select count(*) from cte
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+with cte as (select * from rpc.t1 order by i limit 5) select count(*) from cte
+----
+5
+
+# CTE used twice via self-join
+query II
+explain with cte as (select i from rpc.t1 where i < 5)
+select count(*) from cte a join cte b on a.i = b.i
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# {0..4} self-join: 5 matching pairs
+query I
+with cte as (select i from rpc.t1 where i < 5)
+select count(*) from cte a join cte b on a.i = b.i
+----
+5
+
+# CTE referenced in WHERE subquery
+query II
+explain with cte as (select i from rpc.t1 where i > 7)
+select count(*) from rpc.t1 where i in (select i from cte)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# cte={8,9}; t1 WHERE i in {8,9} = 2 rows
+query I
+with cte as (select i from rpc.t1 where i > 7)
+select count(*) from rpc.t1 where i in (select i from cte)
+----
+2
+
+# --- Chained CTEs ---
+
+query II
+explain with c1 as (select * from rpc.t1), c2 as (select i * 2 as val from c1)
+select count(*) from c2
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+with c1 as (select * from rpc.t1), c2 as (select i * 2 as val from c1)
+select count(*) from c2
+----
+10
+
+# c1={0..4}, c2 doubles each value, sum=20
+query I
+with c1 as (select i from rpc.t1 where i < 5), c2 as (select i * 2 as v from c1)
+select sum(v) from c2
+----
+20
+
+query I
+with agg as (select i % 2 as parity, count(*) as cnt from rpc.t1 group by parity)
+select sum(cnt) from agg
+----
+10
+
+# --- Mixed CTE (CTE body references local table → pushdown blocked) ---
+
+query II
+explain with cte as (select * from local_t)
+select * from cte c join rpc.t1 r on c.i = r.i
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+# local_t={0..9}, rpc.t1={0..9}: all 10 values match
+query I
+with cte as (select * from local_t)
+select count(*) from cte c join rpc.t1 r on c.i = r.i
+----
+10
+
+query I
+with cte as (select i from local_t where i >= 5)
+select count(*) from rpc.t1 where i in (select i from cte)
+----
+5
+
+# Unreferenced local CTE blocks full pushdown (its local body is still merged into the result)
+# cte1={0..4} from rpc.t1; outer selects count(*) from cte1 = 5
+query I
+with cte1 as (select * from rpc.t1 where i < 5),
+     cte2 as (select * from local_t)
+select count(*) from cte1
+----
+5
+
+# --- CTE attached to UNION (SetOperationNode) ---
+
+# Unreferenced local CTE on a UNION blocks whole-query pushdown; only the remote arm is pushed
+query I
+with local_cte as (select * from local_t)
+select i from rpc.t1 where i = 3
+union all
+select 99
+order by i
+----
+3
+99
+
+# All-remote CTE on a UNION: whole query pushed (no SEQ_SCAN)
+query II
+explain with cte as (select i from rpc.t1 where i < 5)
+select * from cte union all select * from rpc.t1 where i >= 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# cte={0,1,2,3,4}, second arm={5,6,7,8,9} → 10 rows total
+query I
+with cte as (select i from rpc.t1 where i < 5)
+select count(*) from (select * from cte union all select * from rpc.t1 where i >= 5)
+----
+10
+
+# Mixed CTE on a UNION: CTE body has local table → stays local
+query II
+explain with cte as (select i from local_t where i < 5)
+select * from cte union all select * from rpc.t1 where i >= 5
+----
+physical_plan	<REGEX>:.*UNION.*
+
+# cte={0,1,2,3,4} from local_t, second arm={5,6,7,8,9} → 10 rows
+query I
+with cte as (select i from local_t where i < 5)
+select count(*) from (select * from cte union all select * from rpc.t1 where i >= 5)
+----
+10
+
+# --- Recursive CTEs ---
+
+# Pure arithmetic recursive CTE: no remote refs → stays local
+query II
+explain with recursive r(n) as (
+  select 1 union all select n+1 from r where n < 5
+) select count(*) from r
+----
+physical_plan	<REGEX>:.*REC_CTE.*
+
+# {1,2,3,4,5} → count = 5
+query I
+with recursive r(n) as (
+  select 1 union all select n+1 from r where n < 5
+) select count(*) from r
+----
+5
+
+# Recursive CTE with remote base case: whole CTE pushed
+query II
+explain with recursive chain(n, depth) as (
+  select i, 0 from rpc.t1 where i = 0
+  union all
+  select n+1, depth+1 from chain where depth < 4
+) select count(*) from chain
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# base (0,0) + 4 steps → 5 rows
+query I
+with recursive chain(n, depth) as (
+  select i, 0 from rpc.t1 where i = 0
+  union all
+  select n+1, depth+1 from chain where depth < 4
+) select count(*) from chain
+----
+5
+
+# Recursive CTE with remote reference in recursive arm: pushed
+# Use JOIN form to avoid compound AND in WHERE (quack has limited stack for PEG parsing)
+query II
+explain with recursive acc(val) as (
+  select 0
+  union all
+  select val + 1 from acc join rpc.t1 on rpc.t1.i = acc.val where acc.val < 3
+) select count(*) from acc
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# base {0}; steps 0→1, 1→2, 2→3; stops at val=3; count = 4
+query I
+with recursive acc(val) as (
+  select 0
+  union all
+  select val + 1 from acc join rpc.t1 on rpc.t1.i = acc.val where acc.val < 3
+) select count(*) from acc
+----
+4
+
+# Recursive CTE with remote in both arms: pushed
+query II
+explain with recursive r(n) as (
+  select min(i) from rpc.t1
+  union all
+  select n + 1 from r join rpc.t1 on rpc.t1.i = n + 1 where n < 3
+) select count(*) from r
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# base: min=0; steps 0→1, 1→2, 2→3; stops; count = 4
+query I
+with recursive r(n) as (
+  select min(i) from rpc.t1
+  union all
+  select n + 1 from r join rpc.t1 on rpc.t1.i = n + 1 where n < 3
+) select count(*) from r
+----
+4
+
+# Mixed recursive CTE (local base case): not pushed → stays local
+query II
+explain with recursive r(n) as (
+  select i from local_t where i = 0
+  union all
+  select n + 1 from r where r.n < 3
+) select count(*) from r
+----
+physical_plan	<REGEX>:.*REC_CTE.*
+
+# base {0}, steps {1,2,3} → 4 rows total
+query I
+with recursive r(n) as (
+  select i from local_t where i = 0
+  union all
+  select n + 1 from r where r.n < 3
+) select count(*) from r
+----
+4
+
+# --- SubqueryRef referencing an outer CTE inside a JoinRef with a local table ---
+# Pushing a SubqueryRef wrapping a CTE name would fail; falls back to local execution.
+
+# cte={0..4} from rpc.t1, local_t join on i → 5 rows
+query I
+with cte as (select * from rpc.t1 where i < 5)
+select count(*) from local_t join (select * from cte) sub on local_t.i = sub.i
+----
+5
+
+# Reversed: SubqueryRef on left side
+query I
+with cte as (select * from rpc.t1 where i >= 7)
+select count(*) from (select * from cte) sub join local_t on sub.i = local_t.i
+----
+3
+
+# --- CTE reference inside a JoinRef with a local table ---
+# Individual pushdown of CTE-named BaseTableRefs is skipped; falls back to local execution.
+
+# cte={0,1,2,3,4}, local_t={0..9}, join on cte.i=local_t.i → 5 rows
+query I
+with cte as (select * from rpc.t1 where i < 5)
+select count(*) from cte join local_t on cte.i = local_t.i
+----
+5
+
+query I
+with cte as (select * from rpc.t1 where i >= 7)
+select count(*) from local_t join cte on local_t.i = cte.i
+----
+3
+
+# --- Recursive CTE with mixed JoinRef in base case: node arms saved/restored ---
+# Without the fix, stale quack wrappers from JoinRef pushdown remain after UNKNOWN classification.
+# local_t = {0..9}, rpc.t1 = {0..9}; base: rpc.t1 JOIN local_t where i < 3 → {0,1,2}; recursive adds 10 each
+query I
+with recursive r(n) as (
+  select t1.i from rpc.t1 t1 join local_t on t1.i = local_t.i where t1.i < 3
+  union all
+  select n + 10 from r where r.n < 5
+) select count(*) from r
+----
+6
+
+query I
+with recursive r(n) as (
+  select t1.i from rpc.t1 t1 join local_t on t1.i = local_t.i where t1.i < 3
+  union all
+  select n + 10 from r where r.n < 5
+) select n from r order by n
+----
+0
+1
+2
+10
+11
+12
+
+# --- SelectNode with CTE + mixed JoinRef: outer-expression stripping outside CTE guard ---
+# Bug fix: catalog-qualified refs in SELECT/WHERE must be stripped even when CTEs are present.
+
+# rpc.t1={0..9}, local_t={0..9}, local_cte={0..4}; join rpc.t1 and local_cte
+query I
+with local_cte as (select i from local_t where i < 5)
+select t1.i from rpc.t1 t1 join local_cte on t1.i = local_cte.i
+where t1.i < 3
+order by t1.i
+----
+0
+1
+2
+
+query II
+with local_cte as (select i from local_t where i < 5)
+select t1.i % 2 as parity, count(*) as cnt
+from rpc.t1 t1 join local_cte on t1.i = local_cte.i
+where t1.i < 5
+group by t1.i % 2
+order by parity
+----
+0	3
+1	2
+
+query I
+with unused_cte as (select 42 as v)
+select t1.i from rpc.t1 t1 join local_t on t1.i = local_t.i
+where t1.i < 2
+order by t1.i
+----
+0
+1
+
+# WITH cte AS (...) INSERT INTO remote SELECT * FROM cte
+statement ok
+create table rpc.t3(i int);
+
+statement ok
+with cte as (select * from (values (0), (1), (2)) t(i)) insert into rpc.t3 select * from cte
+
+query I
+select i from rpc.t3 order by i
+----
+0
+1
+2
+
+statement ok
+drop table rpc.t3;
+
+statement ok
+drop table local_t
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_dml.test
+++ b/test/remote_pushdown/remote_pushdown_dml.test
@@ -1,0 +1,313 @@
+# name: test/remote_pushdown/remote_pushdown_dml.test
+# description: INSERT/UPDATE/DELETE pushdown for remote catalogs
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(j int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (3), (4), (5), (6);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Initial state: t1 = {0..9}
+query I
+select count(*) from rpc.t1
+----
+10
+
+# --- INSERT ---
+
+statement ok
+insert into rpc.t1 select i + 10 from rpc.t1
+
+# t1 now has {0..19}
+query I
+select count(*) from rpc.t1
+----
+20
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	19
+
+statement ok
+insert into rpc.t1 select i + 100 from rpc.t1 where i < 5
+
+# adds {100,101,102,103,104} → total 25 rows
+query I
+select count(*) from rpc.t1
+----
+25
+
+query I
+select count(*) from rpc.t1 where i >= 100
+----
+5
+
+statement ok
+insert into rpc.t1 select i + 200 from (select i from rpc.t1 where i >= 100) sub
+
+# adds {300,301,302,303,304} → total 30 rows
+query I
+select count(*) from rpc.t1
+----
+30
+
+# --- DELETE ---
+
+statement ok
+delete from rpc.t1 where i >= 200
+
+query I
+select count(*) from rpc.t1
+----
+25
+
+statement ok
+delete from rpc.t1 where i >= 100
+
+# t1 = {0..19}
+query I
+select count(*) from rpc.t1
+----
+20
+
+# DELETE with subquery: max(i) where i < 15 = 14; removes {15..19}
+statement ok
+delete from rpc.t1 where i > (select max(i) from rpc.t1 where i < 15)
+
+query I
+select count(*) from rpc.t1
+----
+15
+
+# DELETE with IN subquery: removes {10..14}
+statement ok
+delete from rpc.t1 where i in (select i from rpc.t1 where i >= 10)
+
+# t1 = {0..9}
+query I
+select count(*) from rpc.t1
+----
+10
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	9
+
+# --- UPDATE ---
+
+statement ok
+update rpc.t1 set i = i + 100
+
+# t1 = {100..109}
+query II
+select min(i), max(i) from rpc.t1
+----
+100	109
+
+statement ok
+update rpc.t1 t1 set i = t1.i where t1.i in (select i from rpc.t1 where i >= 105)
+
+query I
+select count(*) from rpc.t1 where i >= 105
+----
+5
+
+statement ok
+update rpc.t1 set i = i - 100
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	9
+
+# i=3 → 7; t1 now has two rows where i=7
+statement ok
+update rpc.t1 set i = i * 2 + 1 where i = 3
+
+query I
+select count(*) from rpc.t1 where i = 7
+----
+2
+
+# --- Mixed DML: local target with remote USING / FROM ---
+
+statement ok quack_db:quack_server_con
+delete from t1 where true
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok
+create table local_t(i int);
+
+statement ok
+insert into local_t from range(10);
+
+# DELETE USING: catalog-qualified ref rpc.t1.i stripped to t1.i after individual pushdown
+statement ok
+delete from local_t using rpc.t1 where local_t.i = rpc.t1.i and rpc.t1.i > 5
+
+# rows 6-9 deleted; local_t = {0..5}
+query I
+select count(*) from local_t
+----
+6
+
+statement ok
+insert into local_t from range(6, 10);
+
+# UPDATE FROM: catalog-qualified ref rpc.t1.i stripped in SET expression
+statement ok
+update local_t set i = rpc.t1.i * 2 from rpc.t1 where local_t.i = rpc.t1.i
+
+# local_t = {0,2,4,6,8,10,12,14,16,18}; rows > 10: {12,14,16,18} = 4
+query I
+select count(*) from local_t where i > 10
+----
+4
+
+statement ok
+drop table local_t
+
+# Explicit-alias forms: catalog-qualified refs must resolve via the alias after stripping
+statement ok
+create table local_alias(k int);
+
+statement ok
+insert into local_alias from range(10);
+
+# DELETE USING with explicit alias: rpc.t1.i in WHERE must resolve to rt1.i
+statement error
+delete from local_alias using rpc.t1 AS rt1 where local_alias.k = rpc.t1.i and rpc.t1.i > 5
+----
+not found
+
+statement ok
+delete from local_alias using rpc.t1 AS rt1 where local_alias.k = rt1.i and rt1.i > 5
+
+# rows 6-9 deleted; local_alias = {0..5}
+query I
+select count(*) from local_alias
+----
+6
+
+statement ok
+insert into local_alias select k + 4 from local_alias where k > 1;
+
+# UPDATE FROM with explicit alias: rpc.t1.i must resolve to rt1.i
+statement error
+update local_alias set k = rpc.t1.i * 2 from rpc.t1 AS rt1 where local_alias.k = rpc.t1.i
+----
+not found
+
+statement ok
+update local_alias set k = rt1.i * 2 from rpc.t1 AS rt1 where local_alias.k = rt1.i
+
+# each row k→k*2; rows > 10: {12,14,16,18} = 4
+query I
+select count(*) from local_alias where k > 10
+----
+4
+
+statement ok
+drop table local_alias
+
+# --- DELETE USING with mixed JoinRef (remote + local) in USING clause ---
+# rpc.t1 is pushed individually; JoinRef result is UNKNOWN; DELETE runs locally.
+
+statement ok
+create table local_del(val int);
+
+statement ok
+insert into local_del from range(10);
+
+statement ok
+create table local_j(val int);
+
+statement ok
+insert into local_j values (3), (4), (5), (6);
+
+# rpc.t1={0..9}, local_j={3,4,5,6}; removes {3,4,5,6} from local_del
+statement ok
+delete from local_del
+    using rpc.t1 join local_j on (rpc.t1.i = local_j.val)
+    where local_del.val = rpc.t1.i
+
+query I
+select count(*) from local_del
+----
+6
+
+query II
+select min(val), max(val) from local_del
+----
+0	9
+
+statement ok
+drop table local_del
+
+statement ok
+drop table local_j
+
+# --- All-remote DELETE USING (same remote catalog) ---
+
+# rpc.t1={0..9}, rpc.t2.j={3,4,5,6}; removes {3,4,5,6} from t1
+statement ok
+delete from rpc.t1 using rpc.t2 where rpc.t1.i = rpc.t2.j
+
+query I
+select count(*) from rpc.t1
+----
+6
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	9
+
+statement ok quack_db:quack_server_con
+delete from t1 where true
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+# --- All-remote UPDATE FROM (same remote catalog) ---
+
+# rpc.t2.j={3,4,5,6}; rows 3,4,5,6 become 13,14,15,16
+statement ok
+update rpc.t1 set i = rpc.t1.i + 10 from rpc.t2 where rpc.t1.i = rpc.t2.j
+
+query I
+select count(*) from rpc.t1 where i >= 10
+----
+4
+
+query II
+select min(i), max(i) from rpc.t1 where i >= 10
+----
+13	16
+
+statement ok quack_db:quack_server_con
+drop table t2;
+
+statement ok quack_db:quack_server_con
+delete from t1 where true
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_dml_local.test
+++ b/test/remote_pushdown/remote_pushdown_dml_local.test
@@ -1,0 +1,323 @@
+# name: test/remote_pushdown/remote_pushdown_dml_local.test
+# description: Regression tests for local vs remote DML detection bugs in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# Bug 7: Rewrite(DML) did not guard on target-table locality; local DML with remote subquery was pushed to remote.
+
+# DELETE with remote scalar subquery in WHERE; max(rpc.t1.i)=9; local_col > 9 -> 0 rows deleted
+query I
+select count(*) from local_t
+----
+10
+
+statement ok
+delete from local_t where local_col > (select max(i) from rpc.t1)
+
+query I
+select count(*) from local_t
+----
+10
+
+# local_col IN {0,1,2} -> 3 rows removed; 7 remain
+statement ok
+delete from local_t where local_col in (select i from rpc.t1 where i < 3)
+
+query I
+select count(*) from local_t
+----
+7
+
+statement ok
+insert into local_t from range(3)
+
+# UPDATE local table with remote scalar subquery in SET: local_col += max(rpc.t1.i)=9 where local_col < 3
+statement ok
+update local_t set local_col = local_col + (select max(i) from rpc.t1) where local_col < 3
+
+query I
+select count(*) from local_t where local_col >= 9
+----
+4
+
+# Restore
+statement ok
+update local_t set local_col = local_col - (select max(i) from rpc.t1) where local_col >= 9 and local_col <= 11
+
+# INSERT into local table from remote SELECT: adds rows {100,101,102}
+statement ok
+insert into local_t select i + 100 from rpc.t1 where i < 3
+
+query I
+select count(*) from local_t where local_col >= 100
+----
+3
+
+statement ok
+delete from local_t where local_col >= 100
+
+# Bug 8: Rewrite(BaseTableRef) returned NO_CATALOG_REFERENCED for local tables with explicit catalog prefix,
+# causing them to be misclassified as all-remote and pushed to the remote server.
+
+statement ok
+drop table local_t
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# local_t = {0..9}; local_col IN {0..4} -> 5 rows
+query I
+select count(*) from memory.main.local_t where local_col in (select i from rpc.t1 where i < 5)
+----
+5
+
+# Result sanity check with explicit-catalog subquery
+query I
+select count(*) from local_t where local_col >= (select min(i) from rpc.t1)
+----
+10
+
+statement ok
+drop table local_t
+
+# Bug 10: Rewrite/StripCatalogName for DML did not process the node's own cte_map,
+# causing CTE bodies to be invisible and CTE catalog refs to go unstripped.
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# DELETE with all-remote CTE: t1={0..9}; cte = {8,9}; delete local_col in {8,9} -> 2 removed; 8 remain.
+statement ok
+with remote_cte as (select i from rpc.t1 where i > 7)
+delete from local_t where local_col in (select i from remote_cte)
+
+query I
+select count(*) from local_t
+----
+8
+
+statement ok
+insert into local_t values (8), (9)
+
+# DELETE with local CTE: must NOT be pushed to remote; deletes local_col in {0,1,2} -> 7 remain.
+statement ok
+create table local_t2(v int);
+
+statement ok
+insert into local_t2 values (0), (1), (2);
+
+statement ok
+with local_cte as (select v from local_t2)
+delete from local_t where local_col in (select v from local_cte)
+
+query I
+select count(*) from local_t
+----
+7
+
+statement ok
+insert into local_t values (0), (1), (2)
+
+# INSERT with all-remote CTE: cte = {0..4}; insert {100..104} -> 5 new rows added.
+statement ok
+with remote_cte as (select i from rpc.t1 where i < 5)
+insert into local_t select local_col + 100 from (select i as local_col from remote_cte) sub
+
+query I
+select count(*) from local_t where local_col >= 100
+----
+5
+
+statement ok
+delete from local_t where local_col >= 100
+
+# UPDATE with all-remote CTE: max(rpc.t1.i)=9; local_col {0,1,2} become {9,10,11}; count >= 9 becomes 4
+statement ok
+with remote_max as (select max(i) as m from rpc.t1)
+update local_t set local_col = local_col + (select m from remote_max) where local_col < 3
+
+query I
+select count(*) from local_t where local_col >= 9
+----
+4
+
+statement ok
+drop table local_t
+
+statement ok
+drop table local_t2
+
+# Bug 16: Rewrite(InsertQueryNode) polluted local_table_column_names with INSERT target's columns,
+# falsely blocking pushdown of remote subqueries in the source SELECT.
+# Fix: save/restore local_table_names/column_names around Rewrite(target_ref).
+
+statement ok
+create table local_bugfix16(i int);
+
+# Source SELECT (rpc.t1 WHERE i < max(rpc.t2.i)) must be pushed as a single quack call.
+query I rowsort
+insert into local_bugfix16
+select i from rpc.t1
+where i < (select max(i) from rpc.t2)
+returning i
+----
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+statement ok
+drop table local_bugfix16
+
+# Bug 22: HasLocalTableReference(QueryNode) returned false for INSERT/DELETE/UPDATE nodes, causing DML
+# CTEs inside subqueries to be pushed to remote where local tables don't exist.
+# Fix: add explicit cases for DML nodes that inspect body expressions for local table refs.
+# Note: DuckDB's binder rejects DML CTEs inside non-top-level subqueries; with the fix the optimizer
+# correctly preserves the subquery locally, and the binder then raises the clear error below.
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# Correlated IN subquery with DELETE CTE referencing outer local table.
+# Without fix: remote error. With fix: binder error (DML not at top level).
+statement error
+select count(*) from local_t where local_col in (
+    with del as (delete from rpc.t1 where t1.i > 100 and t1.i = local_t.local_col returning i)
+    select * from del
+)
+----
+<REGEX>:.*WITH clause containing a data-modifying statement must be at the top level.*
+
+# Same pattern with INSERT.
+statement error
+select count(*) from local_t where local_col in (
+    with ins as (insert into rpc.t2 select i from rpc.t2 where t2.i > 100 and t2.i = local_t.local_col returning i)
+    select * from ins
+)
+----
+<REGEX>:.*WITH clause containing a data-modifying statement must be at the top level.*
+
+statement ok
+drop table local_t;
+
+# Bug 23: StripCatalogName(InsertQueryNode) used exact string comparison instead of CIEquals for
+# catalog/schema fields; uppercase-quoted catalog "RPC" was not stripped, failing on the remote.
+
+# INSERT with uppercase-quoted catalog name must still push and succeed.
+statement ok
+INSERT INTO "RPC".t1 VALUES (55)
+
+query I
+SELECT i FROM rpc.t1 WHERE i = 55
+----
+55
+
+statement ok
+DELETE FROM rpc.t1 WHERE i = 55
+
+# Bug 24: Rewrite(InsertQueryNode/DeleteQueryNode/UpdateQueryNode) did not include returning_list
+# inside the save/restore block, causing stale quack wrappers from JoinRef pushes to trigger
+# "Multiple streaming scans". Fix: include returning_list inside the save/restore block.
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+mode skip unsupported_returning
+
+# All-remote INSERT with RETURNING: whole INSERT is pushed; returns i=99.
+query I
+with ins as (insert into rpc.t1 values (99) returning i as val)
+select val from ins
+----
+99
+
+statement ok
+DELETE FROM rpc.t1 WHERE i = 99
+
+# INSERT with pure-local RETURNING subquery: TryPushDMLWithLocalReturning falls back to RETURNING *.
+# Remote executes "INSERT INTO t1 VALUES (99) RETURNING *"; outer evaluates max(local_col)=9.
+query I
+INSERT INTO rpc.t1 VALUES (99) RETURNING (select max(local_col) from local_t) AS local_max
+----
+9
+
+statement ok
+DELETE FROM rpc.t1 WHERE i = 99
+
+mode unskip
+
+statement ok
+drop table local_t;
+
+# Bug 41: Rewrite(BaseTableRef) Case 2 only checked TABLE_ENTRY in local catalogs, not VIEW_ENTRY.
+# A local view without a catalog qualifier was classified as SINGLE_REMOTE and pushed to quack.
+# Fix: also check VIEW_ENTRY in the local catalog search loop.
+
+statement ok
+create view local_v as select * from range(5) t(i)
+
+# Verify local view is usable locally
+query I
+select count(*) from local_v
+----
+5
+
+# Mixed query: local view + remote table; without fix local_v incorrectly pushed -> error.
+query I
+select count(*) from rpc.t1 join local_v on (rpc.t1.i = local_v.i)
+----
+5
+
+query I
+select local_v.i from rpc.t1 join local_v on (rpc.t1.i = local_v.i) order by 1
+----
+0
+1
+2
+3
+4
+
+statement ok
+drop view local_v
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_dml_using_from.test
+++ b/test/remote_pushdown/remote_pushdown_dml_using_from.test
@@ -1,0 +1,241 @@
+# name: test/remote_pushdown/remote_pushdown_dml_using_from.test
+# description: Regression tests for DELETE USING / UPDATE FROM join pushdown in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# Bug 27: DELETE with multiple remote USING clauses each being pushed to concurrent quack streaming slots.
+# Fix: pre-analyze all USING clauses; restore all when more than one is SINGLE_REMOTE.
+
+# Two remote USING clauses still hit quack's single-stream limit; fix ensures no worse failure.
+mode skip multiple_streaming_scans
+
+query I
+delete from local_t using rpc.t1, rpc.t2
+where local_t.local_col = t1.i and local_t.local_col = t2.i
+----
+5
+
+mode unskip
+
+# Single remote USING clause: rpc.t1 pushed to one quack slot; removes {7,8,9} from local_t.
+statement ok
+delete from local_t using rpc.t1
+where local_t.local_col = rpc.t1.i and rpc.t1.i > 6
+
+query I
+select count(*) from local_t
+----
+7
+
+query I
+select local_col from local_t order by local_col
+----
+0
+1
+2
+3
+4
+5
+6
+
+statement ok
+drop table local_t;
+
+# Enhancement: PushJoinChild for SubqueryRef — fully-remote SubqueryRef on one side of a mixed JOIN
+# is individually pushed so the filter executes on the remote server.
+
+statement ok
+create table local_sq(k int);
+
+statement ok
+insert into local_sq from range(10);
+
+# Remote subquery with filter in mixed JOIN is pushed individually
+query I
+select sub.i from local_sq join (select i from rpc.t1 where i > 5) sub on local_sq.k = sub.i
+order by sub.i
+----
+6
+7
+8
+9
+
+# Remote subquery with aggregation in mixed JOIN is pushed individually
+query I
+select count(*) from local_sq join (select i from rpc.t1 where i between 3 and 7) sub on local_sq.k = sub.i
+----
+5
+
+# DELETE USING with remote subquery USING clause is pushed individually
+statement ok
+delete from local_sq using (select i from rpc.t1 where i >= 7) sub where local_sq.k = sub.i
+
+# rows 7-9 deleted; local_sq = {0..6}, count = 7
+query I
+select count(*) from local_sq
+----
+7
+
+# UPDATE FROM with remote subquery FROM clause is pushed individually
+statement ok
+update local_sq set k = sub.v from (select i, i * 10 as v from rpc.t1 where i < 3) sub where local_sq.k = sub.i
+
+# rows 0,1,2 become 0,10,20; count where k > 9 = 2 (values 10 and 20)
+query I
+select count(*) from local_sq where k > 9
+----
+2
+
+statement ok
+drop table local_sq;
+
+# Bug 36: pending_outer_strip_catalogs was not applied to DELETE WHERE / UPDATE SET when the USING/FROM
+# clause was a mixed JoinRef. Fix: apply accumulated pending entries to WHERE/SET/RETURNING.
+
+statement ok
+create table local_del_jref(k int);
+
+statement ok
+insert into local_del_jref from range(10);
+
+statement ok
+create table local_del_jref_aux(m int);
+
+statement ok
+insert into local_del_jref_aux values (3), (5), (7);
+
+# DELETE with USING (local JOIN rpc.t1): WHERE uses rpc.t1.i which must be stripped.
+# t1={0..9}, aux={3,5,7}: condition rpc.t1.i > 4 matches {5,7}; rows 5 and 7 deleted.
+statement ok
+delete from local_del_jref
+using local_del_jref_aux join rpc.t1 on local_del_jref_aux.m = rpc.t1.i
+where local_del_jref.k = rpc.t1.i and rpc.t1.i > 4
+
+# {0..9} minus {5,7} = 8 rows
+query I
+select count(*) from local_del_jref
+----
+8
+
+statement ok
+drop table local_del_jref;
+
+statement ok
+drop table local_del_jref_aux;
+
+statement ok
+create table local_upd_jref(k int);
+
+statement ok
+insert into local_upd_jref from range(5);
+
+statement ok
+create table local_upd_jref_aux(m int);
+
+statement ok
+insert into local_upd_jref_aux values (1), (3);
+
+# UPDATE with FROM (local JOIN rpc.t1): SET uses rpc.t1.i which must be stripped.
+# With fix: k=1 -> 10, k=3 -> 30.
+statement ok
+update local_upd_jref set k = rpc.t1.i * 10
+from local_upd_jref_aux join rpc.t1 on local_upd_jref_aux.m = rpc.t1.i
+where local_upd_jref.k = rpc.t1.i
+
+# rows with original k=1 and k=3 updated to 10 and 30; count >= 10 = 2
+query I
+select count(*) from local_upd_jref where k >= 10
+----
+2
+
+statement ok
+drop table local_upd_jref;
+
+statement ok
+drop table local_upd_jref_aux;
+
+# Bug 36 addendum: symmetric coverage — remote table on the LEFT of a JoinRef inside DELETE USING / UPDATE FROM.
+
+statement ok
+create table local_del_jref2(k int);
+
+statement ok
+insert into local_del_jref2 from range(10);
+
+statement ok
+create table local_del_jref2_aux(m int);
+
+statement ok
+insert into local_del_jref2_aux values (3), (5), (7);
+
+# DELETE with USING (rpc.t1 JOIN local) — remote LEFT, local RIGHT; rpc.t1.i > 4 matches {5,7}.
+statement ok
+delete from local_del_jref2
+using rpc.t1 join local_del_jref2_aux on rpc.t1.i = local_del_jref2_aux.m
+where local_del_jref2.k = rpc.t1.i and rpc.t1.i > 4
+
+# rows 5 and 7 deleted; {0..9} minus {5,7} = 8 rows
+query I
+select count(*) from local_del_jref2
+----
+8
+
+statement ok
+drop table local_del_jref2;
+
+statement ok
+drop table local_del_jref2_aux;
+
+statement ok
+create table local_upd_jref2(k int);
+
+statement ok
+insert into local_upd_jref2 from range(5);
+
+statement ok
+create table local_upd_jref2_aux(m int);
+
+statement ok
+insert into local_upd_jref2_aux values (1), (3);
+
+# UPDATE with FROM (rpc.t1 JOIN local) — remote LEFT, local RIGHT; k=1 -> 10, k=3 -> 30.
+statement ok
+update local_upd_jref2 set k = rpc.t1.i * 10
+from rpc.t1 join local_upd_jref2_aux on rpc.t1.i = local_upd_jref2_aux.m
+where local_upd_jref2.k = rpc.t1.i
+
+# rows with original k=1 and k=3 updated to 10 and 30; count >= 10 = 2
+query I
+select count(*) from local_upd_jref2 where k >= 10
+----
+2
+
+statement ok
+drop table local_upd_jref2;
+
+statement ok
+drop table local_upd_jref2_aux;
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_join.test
+++ b/test/remote_pushdown/remote_pushdown_join.test
@@ -1,0 +1,264 @@
+# name: test/remote_pushdown/remote_pushdown_join.test
+# description: Regression tests for JOIN pushdown bugs in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Bug 2: StripCatalogName(JoinRef) did not strip JOIN ON condition expressions.
+
+# JOIN ON with catalog-qualified left column: rpc.t1.i stripped to t1.i
+query II
+explain select count(*) from rpc.t1 join rpc.t1 t2 on rpc.t1.i = t2.i
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+query I
+select count(*) from rpc.t1 join rpc.t1 t2 on rpc.t1.i = t2.i
+----
+10
+
+# JOIN ON with both sides catalog-qualified: rpc.t1.i and rpc.t2.i both stripped
+# t1={0..9}, t2={5..14}: join on equal values gives {5,6,7,8,9} -> 5 rows
+query II
+explain select count(*) from rpc.t1 join rpc.t2 on rpc.t1.i = rpc.t2.i
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+query I
+select count(*) from rpc.t1 join rpc.t2 on rpc.t1.i = rpc.t2.i
+----
+5
+
+# JOIN ON with catalog-qualified filter: t1 rows where i < 5 have no overlap with t2={5..14} -> 0 rows
+query I
+select count(*) from rpc.t1 join rpc.t2 on rpc.t1.i = rpc.t2.i and rpc.t1.i < 5
+----
+0
+
+# Bug 3: Rewrite(JoinRef) did not analyze the JOIN ON condition; local macro in ON must block pushdown.
+
+statement ok
+create macro double_it(x) as x * 2;
+
+# Local macro in JOIN ON blocks full pushdown; hits "multiple streaming scans" limitation
+mode skip multiple_streaming_scans
+
+query I
+select count(*) from rpc.t1 a join rpc.t2 b on double_it(a.i) = b.i
+----
+5
+
+mode unskip
+
+# double_it(i) > 10 -> i > 5 -> {6,7,8,9} = 4 rows
+query I
+select count(*) from rpc.t1 where double_it(i) > 10
+----
+4
+
+# double_it(i) in [10,14] -> i in {5,6,7} = 3 rows
+query I
+select count(*) from rpc.t1 where double_it(i) >= 10 and double_it(i) <= 14
+----
+3
+
+statement ok
+drop macro double_it;
+
+# Bug 4: pushing a JOIN with duplicate output column names caused an internal binding crash.
+# Fix: quack_query_by_name's bind function now calls QueryResult::DeduplicateColumns so that
+# two identically-named result columns (e.g. a.i and b.i both named "i") are renamed to i, i_1.
+# The pushed query executes correctly; the test verifies values (not column names).
+
+mode skip duplicate_name_pushdown_bug
+
+query II rowsort
+select a.i, b.i from rpc.t1 a join rpc.t1 b on a.i + 1 = b.i order by a.i
+----
+0	1
+1	2
+2	3
+3	4
+4	5
+5	6
+6	7
+7	8
+8	9
+
+mode unskip
+
+# Verify that the alias-based workaround still works correctly
+query II
+select a.i as ai, b.i as bi from rpc.t1 a join rpc.t1 b on a.i + 1 = b.i where a.i < 3 order by ai
+----
+0	1
+1	2
+2	3
+
+# Bug 6: FinishPushdown(TableRef&) with a JoinRef loses table aliases, causing "table not found".
+# Fix: skip JoinRef pushdown in FinishPushdown(TableRef&); falls back to native scanning.
+
+statement ok
+create macro double_it(x) as x * 2;
+
+# Local macro in SELECT over 2-table remote join must produce "Multiple streaming scans", not an internal error
+mode skip multiple_streaming_scans
+
+query I rowsort
+select double_it(a.i) from rpc.t1 a join rpc.t2 b on a.i = b.i
+----
+10
+12
+14
+16
+18
+
+mode unskip
+
+statement ok
+drop macro double_it;
+
+# Bug 11: Correlated WHERE subquery was pushed independently when the outer from_table was pushed to remote.
+# Fix: alias must be preserved on the outer table-function wrapper so column refs like ft.i resolve.
+
+statement ok
+create macro id_macro(x) as x;
+
+# id_macro(ft.i) forces UNKNOWN result; rpc.t1 AS ft is pushed individually.
+# t1={0..9}; ft.i>=5 -> {5,6,7,8,9} -> count=5.
+query I
+select count(*) from rpc.t1 AS ft where id_macro(ft.i) >= 5
+----
+5
+
+statement ok
+drop macro id_macro;
+
+# Bug 13: Two bugs: (a) StripCatalogName incorrectly recursed into unpushed subquery bodies in partial
+# pushdown; (b) HasLocalTableReference missed aliases of individually pushed JoinRef children.
+# Fix: pass strip_subquery_bodies=false in partial-pushdown; populate from_pushed_table_aliases.
+
+statement ok
+create table local_k(k int);
+
+statement ok
+insert into local_k values (2), (5), (8);
+
+# Mixed join with correlated EXISTS: must hit "Multiple streaming scans", not a binder error.
+mode skip multiple_streaming_scans
+
+query I
+select count(*) from rpc.t1 t1 join local_k on t1.i = local_k.k
+where exists (select 1 from rpc.t2 where t2.i = t1.i)
+----
+2
+
+mode unskip
+
+statement ok
+drop table local_k
+
+# Bug 14: PushdownSubqueries was incorrectly called when JoinRef children already occupied the quack
+# streaming slot, creating a second concurrent connection.
+
+statement ok
+create table local_m(m int);
+
+statement ok
+insert into local_m values (1), (3), (5);
+
+# Mixed join (rpc.t1 + local_m): both old and new code produce "Multiple streaming scans".
+mode skip multiple_streaming_scans
+
+query I rowsort
+select t1.i from rpc.t1 join local_m on t1.i = local_m.m
+where t1.i < (select max(i) from rpc.t2)
+----
+1
+3
+5
+
+mode unskip
+
+statement ok
+drop table local_m
+
+# Bug 21: Rewrite(JoinRef) analyzed the right side without the left remote table's aliases in
+# local_table_names; a LATERAL correlated subquery was incorrectly classified SINGLE_REMOTE and pushed.
+# Fix: add left aliases to local_table_names before analyzing the right side.
+
+statement ok
+CREATE OR REPLACE MACRO local_double(x) AS (x * 2);
+
+# Both with and without the fix, quack rejects this due to single-stream limit.
+# The error must be about streaming concurrency, not an undefined table reference.
+mode skip multiple_streaming_scans
+
+query II rowsort
+SELECT t1.i, sub.i AS sub_i
+FROM rpc.t1 JOIN (SELECT i FROM rpc.t2 WHERE i = t1.i) sub ON local_double(sub.i) > 0
+ORDER BY t1.i
+----
+5	5
+6	6
+7	7
+8	8
+9	9
+
+mode unskip
+
+statement ok
+DROP MACRO local_double;
+
+# Bug 29: Nested mixed JoinRef — outer ON condition references a remote table pushed in-place inside an
+# inner JoinRef; the stripping loop only processed direct SINGLE_REMOTE children, not nested ones.
+# Fix: also strip catalogs accumulated by nested JoinRef processing from the outer ON condition.
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+statement ok
+create table local_x(x int);
+
+statement ok
+insert into local_x values (0), (2), (4), (6);
+
+# Nested mixed join: rpc.t1 pushed inside (rpc.t1 JOIN local_x); outer ON references rpc.t1.i -> stripped to t1.i.
+# rpc.t1={0..9}, local_x={0,2,4,6}: intersection with local_t = {0,2,4,6}
+query I
+select local_t.local_col
+from local_t
+join (rpc.t1 join local_x on rpc.t1.i = local_x.x)
+on local_t.local_col = rpc.t1.i
+order by local_col
+----
+0
+2
+4
+6
+
+statement ok
+drop table local_x;
+
+statement ok
+drop table local_t;
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_mixed.test
+++ b/test/remote_pushdown/remote_pushdown_mixed.test
@@ -1,0 +1,230 @@
+# name: test/remote_pushdown/remote_pushdown_mixed.test
+# description: Mixed local/remote scenarios, lateral joins, SET_RETURNING_FUNCTION neutrality
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# --- Mixed UNION ALL ---
+
+# Mixed: UNION operator stays in local plan
+query II
+explain (select * from rpc.t1 limit 5) union all select * from local_t
+----
+physical_plan	<REGEX>:.*UNION.*
+
+# Pushed remote side (LIMIT 5) is not visible as LIMIT in the local plan
+query II
+explain (select * from rpc.t1 limit 5) union all select * from local_t
+----
+physical_plan	<!REGEX>:.*LIMIT.*
+
+# 5 from remote + 10 from local = 15 rows
+query I
+select count(*) from ((select * from rpc.t1 limit 5) union all select * from local_t)
+----
+15
+
+# --- Mixed JOIN ---
+
+# Mixed JOIN: stays in local plan
+query II
+explain select * from rpc.t1 join local_t on (i = local_col)
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+# local_t={0..9}, rpc.t1={0..9}: all 10 values match
+query I
+select count(*) from rpc.t1 join local_t on (i = local_col)
+----
+10
+
+# Catalog-qualified column ref in mixed JOIN condition: rpc.t1.i stripped to t1.i after individual pushdown
+query I
+select count(*) from rpc.t1 join local_t on (rpc.t1.i = local_t.local_col)
+----
+10
+
+# Catalog-qualified ref in WHERE clause with mixed join
+query I
+select count(*) from rpc.t1 join local_t on (i = local_col) where rpc.t1.i > 5
+----
+4
+
+# Catalog-qualified ref in SELECT list with mixed join
+query I
+select count(rpc.t1.i) from rpc.t1 join local_t on (i = local_col)
+----
+10
+
+# --- SET_RETURNING_FUNCTION neutrality ---
+
+# range() is neutral: doesn't block pushdown of adjacent remote refs
+query II
+explain select count(*) from rpc.t1, range(0, 10) r(n) where i = n
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1={0..9}, range(0,10)={0..9}: all 10 match
+query I
+select count(*) from rpc.t1, range(0, 10) r(n) where i = n
+----
+10
+
+# generate_series() is also neutral
+query II
+explain select count(*) from rpc.t1, generate_series(0, 9) gs(n) where i = n
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1, generate_series(0, 9) gs(n) where i = n
+----
+10
+
+# range() with local table: local table blocks full pushdown
+query II
+explain select count(*) from local_t, range(0, 10) r(n) where local_col = n
+----
+physical_plan	<REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from local_t, range(0, 10) r(n) where local_col = n
+----
+10
+
+# range() in UNION with local: UNION stays local
+query II
+explain (select * from rpc.t1 limit 3) union all select * from range(0, 3) r(i)
+----
+physical_plan	<REGEX>:.*UNION.*
+
+# --- Local macros ---
+
+statement ok
+create macro my_add(x, y) as x + y;
+
+# Local macro used on remote table: macro stays local, remote scan pushed individually
+# i > 5 → {6,7,8,9} → 4 rows
+query I
+select count(*) from rpc.t1 where my_add(i, 0) > 5
+----
+4
+
+# Table-qualified column ref (t1.i) in WHERE with local macro
+query I
+select count(*) from rpc.t1 where my_add(t1.i, 0) > 5
+----
+4
+
+query I
+select my_add(10, 5)
+----
+15
+
+statement ok
+drop macro my_add;
+
+# After dropping macro, built-in expressions are pushed again
+query II
+explain select i + 1 from rpc.t1 where i > 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc.t1 where i + 1 > 6
+----
+4
+
+# --- Lateral joins ---
+
+# Local outer + remote inner: NOT pushed (outer must stay local)
+# local_t={0..9}, rpc.t1={0..9}: each row matches → 10 rows
+query I
+select count(*) from local_t, lateral (select * from rpc.t1 where i = local_col) sub
+----
+10
+
+# Explicit catalog prefix on local table: column names still tracked correctly
+query I
+select count(*) from memory.main.local_t, lateral (select * from rpc.t1 where i = local_col) sub
+----
+10
+
+# local_col+100 not in t1={0..9} → 0 rows
+query I
+select count(*) from local_t, lateral (select * from rpc.t1 where i = local_col + 100) sub
+----
+0
+
+# Correlated ORDER BY in lateral: outer local_col in ORDER BY blocks push
+# 10 outer rows × 1 inner row (LIMIT 1) = 10 rows
+query I
+select count(*) from local_t, lateral (select i from rpc.t1 order by local_col limit 1) sub
+----
+10
+
+# Correlated JOIN ON in lateral: local_col in ON clause blocks push; falls back to local execution
+mode skip multiple_streaming_scans
+
+query I
+select count(*) from local_t,
+    lateral (select a.i from rpc.t1 a join rpc.t1 b on a.i = local_col and b.i = local_col) sub
+----
+?
+
+# Correlated SubqueryRef inside JoinRef in lateral: local_col inside nested subquery blocks push
+query I
+select count(*) from local_t,
+    lateral (
+        select a.i from rpc.t1 a
+        join (select * from rpc.t1 where i = local_col) sq on a.i = sq.i
+    ) sub
+----
+?
+
+mode unskip
+
+# All-remote outer + remote inner: pushed
+query II
+explain select t1a.i from rpc.t1 t1a, lateral (select * from rpc.t1 t1b where t1b.i = t1a.i) sub
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# 10 rows in t1, each has exactly 1 match via lateral → 10 rows
+query I
+select count(*) from rpc.t1 t1a, lateral (select * from rpc.t1 t1b where t1b.i = t1a.i) sub
+----
+10
+
+# --- Subquery wrapping remote (nested levels) ---
+
+# Double-wrapped subquery: all remote → pushed
+query II
+explain select count(*) from (select * from (select i from rpc.t1 where i > 5) sub1) sub2
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from (select * from (select i from rpc.t1 where i > 5) sub1) sub2
+----
+4
+
+statement ok
+drop table local_t
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_multi_catalog.test
+++ b/test/remote_pushdown/remote_pushdown_multi_catalog.test
@@ -1,0 +1,228 @@
+# name: test/remote_pushdown/remote_pushdown_multi_catalog.test
+# description: Tests with two distinct remote catalogs (rpc1, rpc2)
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(j int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+# rpc2: t3={0..4}, t4={10..14}
+statement ok quack_db2:quack_server_con2
+set variable actual_listen_uri = (select listen_uri from quack_serve('{QUACK_SERVER}:0', token='asdf2'));
+
+statement ok quack_db2:quack_server_con2
+set variable listen_uri = concat('''', getvariable('actual_listen_uri'), '''');
+
+set variable server2 <variable:quack_server_con2:listen_uri>
+
+statement ok quack_db2:quack_server_con2
+create table t3(k int);
+
+statement ok quack_db2:quack_server_con2
+insert into t3 from range(5);
+
+statement ok quack_db2:quack_server_con2
+create table t4(m int);
+
+statement ok quack_db2:quack_server_con2
+insert into t4 values (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc1 (token 'asdf')
+
+statement ok
+attach {server2} as rpc2 (token 'asdf2')
+
+# --- Single-catalog queries: each pushed to its own remote ---
+
+# rpc1.t1 pushed (no SEQ_SCAN)
+query II
+explain select * from rpc1.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc1.t1
+----
+10
+
+query I
+select sum(i) from rpc1.t1
+----
+45
+
+# rpc2.t3 pushed (no SEQ_SCAN)
+query II
+explain select * from rpc2.t3
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc2.t3
+----
+5
+
+query I
+select sum(k) from rpc2.t3
+----
+10
+
+# All-remote query on rpc1: join of rpc1.t1 and rpc1.t2 pushed as one call
+query II
+explain select * from rpc1.t1 join rpc1.t2 on i = j
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+query I
+select count(*) from rpc1.t1 join rpc1.t2 on i = j
+----
+5
+
+# All-remote query on rpc2: join of rpc2.t3 and rpc2.t4 pushed as one call
+query II
+explain select * from rpc2.t3 join rpc2.t4 on k = m
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+# t3={0..4}, t4={10..14}: no overlap
+query I
+select count(*) from rpc2.t3 join rpc2.t4 on k = m
+----
+0
+
+# --- Cross-catalog join: different remotes -> join stays local ---
+
+# JOIN of rpc1.t1 and rpc2.t3 is not pushed as a single query (local JOIN operator)
+query II
+explain select * from rpc1.t1 join rpc2.t3 on i = k
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+# Tables are still fetched via quack transport (per-table QUACK_QUERY, not a pushed single call)
+query II
+explain select * from rpc1.t1 join rpc2.t3 on i = k
+----
+physical_plan	<REGEX>:.*QUACK_QUERY.*
+
+# t1={0..9}, t3={0..4}: overlap={0,1,2,3,4} -> 5 rows
+query I
+select count(*) from rpc1.t1 join rpc2.t3 on i = k
+----
+5
+
+# Cross-catalog UNION ALL: each arm is pushed independently
+query I
+select count(*) from (
+  select i as v from rpc1.t1 where i < 3
+  union all
+  select k as v from rpc2.t3 where k < 3
+)
+----
+6
+
+# --- Pushdown into rpc2 while rpc1 is the active catalog (USE rpc1) ---
+
+statement ok
+use rpc1
+
+# Unqualified t1 resolves to rpc1 (single remote in search path after USE rpc1): pushed
+query II
+explain select * from t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from t1
+----
+10
+
+# Explicit rpc2.t3 still pushed to rpc2 even while rpc1 is the default
+query II
+explain select * from rpc2.t3
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc2.t3
+----
+5
+
+# Cross-catalog join with USE rpc1: local join, both tables via quack
+query II
+explain select * from t1 join rpc2.t3 on i = k
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+query I
+select count(*) from t1 join rpc2.t3 on i = k
+----
+5
+
+statement ok
+use memory
+
+# --- Multiple remote catalogs in search path (SET search_path='rpc1,rpc2') ---
+
+statement ok
+SET search_path='rpc1,rpc2'
+
+# Explicitly qualified queries still push to their respective catalogs
+query II
+explain select * from rpc1.t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc1.t1
+----
+10
+
+query II
+explain select * from rpc2.t3
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from rpc2.t3
+----
+5
+
+# Unqualified names with two remote catalogs in search path are NOT pushed (conservative fallback)
+query II
+explain select * from t1
+----
+physical_plan	<REGEX>:.*QUACK_QUERY.*
+
+query I
+select count(*) from t1
+----
+10
+
+# Cross-catalog join in multi-remote search path: local join
+query II
+explain select * from rpc1.t1 join rpc2.t3 on i = k
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+query I
+select count(*) from rpc1.t1 join rpc2.t3 on i = k
+----
+5
+
+statement ok
+RESET search_path
+
+include test/template/quack_teardown.test_template
+
+statement ok quack_db2:quack_server_con2
+call quack_stop({server2})

--- a/test/remote_pushdown/remote_pushdown_returning.test
+++ b/test/remote_pushdown/remote_pushdown_returning.test
@@ -1,0 +1,245 @@
+# name: test/remote_pushdown/remote_pushdown_returning.test
+# description: RETURNING clause for INSERT/UPDATE/DELETE with remote pushdown
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Initial state: t1 = {0..9}
+
+# --- INSERT RETURNING ---
+
+query I
+insert into rpc.t1 values (42) returning i
+----
+42
+
+query I
+select count(*) from rpc.t1 where i = 42
+----
+1
+
+# Catalog-qualified column ref in RETURNING stripped before push
+query I
+insert into rpc.t1 values (43) returning rpc.t1.i
+----
+43
+
+# RETURNING with expression
+query I
+insert into rpc.t1 values (44) returning i * 2
+----
+88
+
+# INSERT from remote SELECT with RETURNING
+statement ok
+insert into rpc.t1 select i + 100 from rpc.t1 where i < 3 returning i
+
+query I
+select count(*) from rpc.t1 where i >= 100 and i < 103
+----
+3
+
+statement ok
+delete from rpc.t1 where i >= 42
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	9
+
+# --- UPDATE RETURNING ---
+
+query I
+update rpc.t1 set i = i + 1 where i = 5 returning i
+----
+6
+
+statement ok
+delete from rpc.t1 where i = 6
+
+statement ok
+insert into rpc.t1 values (5), (6)
+
+# Catalog-qualified column ref in RETURNING for UPDATE
+query I
+update rpc.t1 set i = i - 1 where i = 1 returning rpc.t1.i
+----
+0
+
+statement ok
+delete from rpc.t1 where i = 0
+
+statement ok
+insert into rpc.t1 values (0), (1)
+
+# UPDATE RETURNING with expression
+query I
+update rpc.t1 set i = i + 10 where i = 9 returning i - 10
+----
+9
+
+statement ok
+update rpc.t1 set i = i - 10 where i = 19
+
+query I
+select count(*) from rpc.t1 where i = 7
+----
+1
+
+statement ok
+update rpc.t1 set i = i + 1 where i = 7 returning i
+
+query I
+select count(*) from rpc.t1 where i = 8
+----
+2
+
+statement ok
+delete from rpc.t1 where i = 8
+
+statement ok
+insert into rpc.t1 values (7), (8)
+
+# --- DELETE RETURNING ---
+
+query I
+delete from rpc.t1 where i = 9 returning i
+----
+9
+
+query I
+select count(*) from rpc.t1 where i = 9
+----
+0
+
+statement ok
+insert into rpc.t1 values (9)
+
+# Catalog-qualified column ref in RETURNING for DELETE
+query I
+delete from rpc.t1 where i = 8 returning rpc.t1.i
+----
+8
+
+statement ok
+insert into rpc.t1 values (8)
+
+# DELETE RETURNING with expression
+query I
+delete from rpc.t1 where i = 0 returning i + 100
+----
+100
+
+statement ok
+insert into rpc.t1 values (0)
+
+statement ok
+delete from rpc.t1 where i >= 7 returning i
+
+query I
+select count(*) from rpc.t1 where i >= 7
+----
+0
+
+statement ok
+insert into rpc.t1 values (7), (8), (9)
+
+# --- INSERT RETURNING: scalar aggregate over remote data ---
+
+# Insert max+1 into t1 and return the inserted value
+query I
+insert into rpc.t1 select max(i) + 1 from rpc.t1 returning i
+----
+10
+
+query I
+select count(*) from rpc.t1 where i = 10
+----
+1
+
+statement ok
+delete from rpc.t1 where i = 10
+
+query II
+select min(i), max(i) from rpc.t1
+----
+0	9
+
+# --- RETURNING with local macro: body pushed to remote, macro evaluated locally on returned rows ---
+
+mode skip unsupported_returning
+
+statement ok
+create macro double_it(x) as x * 2;
+
+# INSERT RETURNING with local macro: remote executes INSERT RETURNING i; local applies double_it
+query I
+insert into rpc.t1 values (50) returning double_it(i)
+----
+100
+
+statement ok
+delete from rpc.t1 where i = 50
+
+statement ok
+insert into rpc.t1 values (99);
+
+# UPDATE RETURNING with local macro
+query I
+update rpc.t1 set i = i + 1 where i = 99 returning double_it(i)
+----
+200
+
+statement ok
+delete from rpc.t1 where i = 100
+
+statement ok
+insert into rpc.t1 values (77);
+
+# DELETE RETURNING with local macro
+query I
+delete from rpc.t1 where i = 77 returning double_it(i)
+----
+154
+
+statement ok
+drop macro double_it;
+
+# --- RETURNING with scalar subquery: non-correlated subquery evaluated locally on returned rows ---
+
+statement ok
+create table local_t(id int);
+
+statement ok
+insert into local_t values (5), (6), (7);
+
+statement ok
+insert into rpc.t1 values (55);
+
+# Non-correlated scalar subquery in RETURNING: count(*) = 3 (from local_t)
+query I
+delete from rpc.t1 where i = 55 returning (select count(*) from local_t)
+----
+3
+
+query I
+insert into rpc.t1 values (66) returning (select count(*) from local_t)
+----
+3
+
+statement ok
+delete from rpc.t1 where i = 66
+
+statement ok
+drop table local_t;
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_returning_local.test
+++ b/test/remote_pushdown/remote_pushdown_returning_local.test
@@ -1,0 +1,133 @@
+# name: test/remote_pushdown/remote_pushdown_returning_local.test
+# description: Regression tests for DML RETURNING with local expressions in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t3(i int, j int);
+
+statement ok quack_db:quack_server_con
+insert into t3 values (1, 10), (2, 20), (3, 30);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Bug 18: TryPushDMLWithLocalReturning — DML on remote table with local-only expression in RETURNING
+# must split: push DML with raw column RETURNING, evaluate local expressions over results locally.
+
+mode skip unsupported_returning
+
+statement ok
+CREATE OR REPLACE MACRO local_double(x) AS (x * 2);
+
+# INSERT into remote table with mixed RETURNING: remote returns i=77, local applies local_double(77)=154.
+query II
+INSERT INTO rpc.t1 VALUES (77) RETURNING i, local_double(i) AS doubled
+----
+77	154
+
+# Verify the row was actually inserted on the remote.
+query I
+SELECT i FROM rpc.t1 WHERE i = 77
+----
+77
+
+statement ok
+DELETE FROM rpc.t1 WHERE i = 77
+
+statement ok quack_db:quack_server_con
+INSERT INTO t1 VALUES (88);
+
+# DELETE from remote table with mixed RETURNING: remote returns i=88, local applies local_double(88)=176.
+query II
+DELETE FROM rpc.t1 WHERE i = 88 RETURNING i, local_double(i) AS doubled
+----
+88	176
+
+query I
+SELECT count(*) FROM rpc.t1 WHERE i = 88
+----
+0
+
+statement ok quack_db:quack_server_con
+INSERT INTO t1 VALUES (99);
+
+# UPDATE on remote table with mixed RETURNING: remote returns i=100, local applies local_double(100)=200.
+query II
+UPDATE rpc.t1 SET i = i + 1 WHERE i = 99 RETURNING i, local_double(i) AS doubled
+----
+100	200
+
+query I
+SELECT i FROM rpc.t1 WHERE i = 100
+----
+100
+
+statement ok
+DELETE FROM rpc.t1 WHERE i = 100
+
+statement ok
+DROP MACRO local_double;
+
+# Bug 19: TryPushDMLWithLocalReturning with RETURNING * — remote RETURNING must use * so all columns
+# are returned; without the fix only macro-argument columns were returned, silently dropping others.
+
+statement ok
+CREATE OR REPLACE MACRO local_double(x) AS (x * 2);
+
+# INSERT with RETURNING * + local macro: remote returns (77, 770), local adds doubled=154.
+query III
+INSERT INTO rpc.t3 VALUES (77, 770) RETURNING *, local_double(i) AS doubled
+----
+77	770	154
+
+# DELETE with RETURNING * + local macro: remote returns (77, 770), local adds doubled=154.
+query III
+DELETE FROM rpc.t3 WHERE i = 77 RETURNING *, local_double(i) AS doubled
+----
+77	770	154
+
+query I
+SELECT count(*) FROM rpc.t3 WHERE i = 77
+----
+0
+
+statement ok
+DROP MACRO local_double;
+
+# Bug 20: TryPushDMLWithLocalReturning with table-qualified star (t.*) — StripAllTableQualifiers must
+# clear StarExpression::relation_name so "t3.*" becomes "*" in the outer SELECT.
+
+statement ok
+CREATE OR REPLACE MACRO local_double(x) AS (x * 2);
+
+# INSERT with table-qualified star: remote executes "INSERT ... RETURNING *", outer strips "t3.*" -> "*".
+query III
+INSERT INTO rpc.t3 VALUES (88, 880) RETURNING t3.*, local_double(i) AS doubled
+----
+88	880	176
+
+# DELETE with table-qualified star.
+query III
+DELETE FROM rpc.t3 WHERE i = 88 RETURNING t3.*, local_double(i) AS doubled
+----
+88	880	176
+
+query I
+SELECT count(*) FROM rpc.t3 WHERE i = 88
+----
+0
+
+statement ok
+DROP MACRO local_double;
+
+mode unskip
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_searchpath.test
+++ b/test/remote_pushdown/remote_pushdown_searchpath.test
@@ -1,0 +1,108 @@
+# name: test/remote_pushdown/remote_pushdown_searchpath.test
+# description: Pushdown via search path (USE catalog) for remote catalogs
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(j int);
+
+statement ok quack_db:quack_server_con
+insert into t2 from range(5, 15);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# After USE rpc, the optimizer deduplicates the INVALID_CATALOG sentinel and the explicit rpc entry.
+
+statement ok
+use rpc
+
+# --- Unqualified table pushdown via search path ---
+
+# Simple scan: no SEQ_SCAN in local plan
+query II
+explain select * from t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from t1
+----
+10
+
+# Filter is pushed
+query II
+explain select * from t1 where i > 5
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from t1 where i > 5
+----
+4
+
+# Aggregate is pushed
+query II
+explain select sum(i) from t1
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select sum(i) from t1
+----
+45
+
+# Join of two unqualified remote tables: no JOIN in local plan
+query II
+explain select * from t1 join t2 on i = j
+----
+physical_plan	<!REGEX>:.*JOIN.*
+
+# t1={0..9}, t2={5..14}: overlap={5,6,7,8,9} -> 5 rows
+query I
+select count(*) from t1 join t2 on i = j
+----
+5
+
+# ORDER BY + LIMIT pushed
+query I
+select i from t1 order by i desc limit 3
+----
+9
+8
+7
+
+# Subquery on unqualified remote table: pushed
+query II
+explain select count(*) from t1 where i in (select j from t2)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select count(*) from t1 where i in (select j from t2)
+----
+5
+
+# CTE with unqualified remote table: pushed
+query II
+explain with cte as (select i from t1 where i < 3) select count(*) from cte
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+with cte as (select i from t1 where i < 3) select count(*) from cte
+----
+3
+
+# Restore default catalog so subsequent tests are unaffected
+statement ok
+use memory
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_set_operations.test
+++ b/test/remote_pushdown/remote_pushdown_set_operations.test
@@ -1,0 +1,242 @@
+# name: test/remote_pushdown/remote_pushdown_set_operations.test
+# description: UNION/INTERSECT/EXCEPT pushdown for remote catalogs
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+# t1 = {0..9}, t2 = {5..14}; overlap = {5..9}
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# local table with values {0..4} (subset of t1, no overlap with t2 extension)
+statement ok
+create table local_t(i int);
+
+statement ok
+insert into local_t values (0), (1), (2), (3), (4);
+
+# --- UNION ALL (all remote) ---
+
+query II
+explain select i from rpc.t1 union all select i from rpc.t2
+----
+physical_plan	<!REGEX>:.*UNION.*
+
+# t1 (10 rows) + t2 (10 rows) = 20 rows
+query I
+select count(*) from (select i from rpc.t1 union all select i from rpc.t2)
+----
+20
+
+# sum of all values: sum(0..9) + sum(5..14) = 45 + 95 = 140
+query I
+select sum(i) from (select i from rpc.t1 union all select i from rpc.t2)
+----
+140
+
+# --- UNION (dedup, all remote) ---
+
+query II
+explain select i from rpc.t1 union select i from rpc.t2
+----
+physical_plan	<!REGEX>:.*UNION.*
+
+# unique values in t1 ∪ t2 = {0..14} = 15
+query I
+select count(*) from (select i from rpc.t1 union select i from rpc.t2)
+----
+15
+
+# UNION of t1 with itself: deduplication leaves 10 rows
+query I
+select count(*) from (select i from rpc.t1 union select i from rpc.t1)
+----
+10
+
+# --- INTERSECT (all remote) ---
+
+query II
+explain select i from rpc.t1 intersect select i from rpc.t2
+----
+physical_plan	<!REGEX>:.*INTERSECT.*
+
+# t1 ∩ t2 = {5,6,7,8,9} = 5 rows
+query I
+select count(*) from (select i from rpc.t1 intersect select i from rpc.t2)
+----
+5
+
+# Functional: correct values in intersection
+query I
+select min(i) from (select i from rpc.t1 intersect select i from rpc.t2)
+----
+5
+
+query I
+select max(i) from (select i from rpc.t1 intersect select i from rpc.t2)
+----
+9
+
+# --- EXCEPT (all remote) ---
+
+query II
+explain select i from rpc.t1 except select i from rpc.t2
+----
+physical_plan	<!REGEX>:.*EXCEPT.*
+
+# t1 - t2 = {0,1,2,3,4} = 5 rows
+query I
+select count(*) from (select i from rpc.t1 except select i from rpc.t2)
+----
+5
+
+query I
+select sum(i) from (select i from rpc.t1 except select i from rpc.t2)
+----
+10
+
+# t2 - t1 = {10,11,12,13,14} = 5 rows
+query I
+select count(*) from (select i from rpc.t2 except select i from rpc.t1)
+----
+5
+
+# --- Set operations with ORDER BY / LIMIT (all remote) ---
+
+# UNION ALL with ORDER BY: whole query pushed
+query II
+explain select i from rpc.t1 union all select i from rpc.t2 order by i
+----
+physical_plan	<!REGEX>:.*UNION.*
+
+query I
+select i from rpc.t1 union all select i from rpc.t1 order by i desc limit 3
+----
+9
+9
+8
+
+# UNION with outer aggregation
+query I
+select sum(i) from (select i from rpc.t1 union all select i from rpc.t1)
+----
+90
+
+# --- Nested set operations (all remote) ---
+
+# Three-way UNION ALL: all remote -> pushed
+# t1 where i<5 = 5 rows, t1 where i>=5 = 5 rows, t2 where i>=10 = 5 rows -> 15
+query I
+select count(*) from (
+  select i from rpc.t1 where i < 5
+  union all
+  select i from rpc.t1 where i >= 5
+  union all
+  select i from rpc.t2 where i >= 10
+)
+----
+15
+
+# UNION then filtered: all remote -> pushed
+query I
+select count(*) from (
+  select i from rpc.t1 union select i from rpc.t2
+) sub where i < 5
+----
+5
+
+# --- Mixed (local + remote): pushdown blocked ---
+
+# Mixed UNION ALL: UNION stays in local plan
+query II
+explain select i from rpc.t1 union all select i from local_t
+----
+physical_plan	<REGEX>:.*UNION.*
+
+# Functional: 10 + 5 = 15 rows
+query I
+select count(*) from (select i from rpc.t1 union all select i from local_t)
+----
+15
+
+# Mixed UNION: dedup of t1={0..9} and local_t={0..4} -> {0..9} = 10
+query I
+select count(*) from (select i from rpc.t1 union select i from local_t)
+----
+10
+
+# Mixed INTERSECT: t1={0..9} ∩ local_t={0..4} = {0..4} = 5 rows
+query I
+select count(*) from (select i from rpc.t1 intersect select i from local_t)
+----
+5
+
+# Mixed EXCEPT (t1 - local_t): {5,6,7,8,9} = 5 rows
+query I
+select count(*) from (select i from rpc.t1 except select i from local_t)
+----
+5
+
+# Mixed EXCEPT (local_t - t1): all local values are in t1 -> 0 rows
+query I
+select count(*) from (select i from local_t except select i from rpc.t1)
+----
+0
+
+# Catalog-qualified ORDER BY in mixed UNION: rpc.t1.i reduced to bare i (no table association after pushdown)
+# local_t={0..4}, rpc.t1={0..9}
+query I
+(select i from rpc.t1) union all (select i from local_t) order by rpc.t1.i
+----
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+5
+6
+7
+8
+9
+
+# Schema-qualified ORDER BY in mixed UNION: rpc.main.t1.i (4-part) also reduced to bare i
+query I
+(select i from rpc.main.t1) union all (select i from local_t) order by rpc.main.t1.i
+----
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+5
+6
+7
+8
+9
+
+statement ok
+drop table local_t
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_set_ops.test
+++ b/test/remote_pushdown/remote_pushdown_set_ops.test
@@ -1,0 +1,100 @@
+# name: test/remote_pushdown/remote_pushdown_set_ops.test
+# description: Regression tests for set operation pushdown bugs in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Bug 1: StripCatalogName(SetOperationNode) did not strip ORDER BY expressions.
+
+# UNION ALL with catalog-qualified ORDER BY: pushed and produces correct order
+query II
+explain select i from rpc.t1 union all select i from rpc.t1 order by rpc.t1.i
+----
+physical_plan	<!REGEX>:.*UNION.*
+
+query I
+select i from rpc.t1 union all select i from rpc.t1 order by rpc.t1.i limit 4
+----
+0
+0
+1
+1
+
+# UNION (dedup) with catalog-qualified ORDER BY DESC
+query I
+select i from rpc.t1 union select i from rpc.t1 order by rpc.t1.i desc limit 3
+----
+9
+8
+7
+
+# INTERSECT with catalog-qualified ORDER BY
+# t1 ∩ t2 = {5..9}; ascending order
+query I
+select i from rpc.t1 intersect select i from rpc.t2 order by rpc.t1.i
+----
+5
+6
+7
+8
+9
+
+# EXCEPT with catalog-qualified ORDER BY
+# t1 - t2 = {0..4}; ascending order
+query I
+select i from rpc.t1 except select i from rpc.t2 order by rpc.t1.i
+----
+0
+1
+2
+3
+4
+
+# Bug 26: Rewrite(SetOperationNode) did not save/restore UNKNOWN children; stale quack wrappers from
+# nested JoinRef pushes caused "Multiple streaming scans" with a pushed SINGLE_REMOTE sibling.
+# Fix: (a) save/restore UNKNOWN children; (b) skip individual child pushdown when any sibling is UNKNOWN.
+
+# UNION ALL: all-remote arm {8,9} + range(3) arm {0,1,2} -> 5 rows total
+query I
+select count(*) from (
+    select i from rpc.t1 where i >= 8
+    union all
+    select * from range(3)
+)
+----
+5
+
+query I
+select i from (
+    select i from rpc.t1 where i >= 8
+    union all
+    select * from range(3)
+) order by i
+----
+0
+1
+2
+8
+9
+
+# Bug 32: StripSetOpOrderByExpr did not recurse into composite ORDER BY expressions after individual
+# child pushdown; catalog-qualified refs inside functions like coalesce(rpc.t1.i, 0) were not stripped.
+# Fix: StripSetOpOrderByExpr now recurses via EnumerateChildren.
+# Note: direct testing is not feasible with quack; fix verified by code inspection.
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_subquery.test
+++ b/test/remote_pushdown/remote_pushdown_subquery.test
@@ -1,0 +1,175 @@
+# name: test/remote_pushdown/remote_pushdown_subquery.test
+# description: Subquery pushdown scenarios (IN, NOT IN, EXISTS, scalar subqueries)
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+# t2 overlaps with t1 in {5..9}
+statement ok quack_db:quack_server_con
+create table t2(j int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# local_t overlaps with t1 in {5..9} and extends beyond t1 with {10..14}
+statement ok
+create table local_t(i int);
+
+statement ok
+insert into local_t values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+# --- IN subquery ---
+
+# IN: all remote -> pushed (no SEQ_SCAN in local plan)
+query II
+explain select * from rpc.t1 where i in (select j from rpc.t2)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1={0..9} IN t2={5..14} -> i in {5,6,7,8,9} -> 5 rows
+query I
+select count(*) from rpc.t1 where i in (select j from rpc.t2)
+----
+5
+
+# IN: mixed (local outer, remote subquery) -> outer stays local
+# local_t={5..14} IN t1={0..9} -> {5,6,7,8,9} -> 5 rows
+query I
+select count(*) from local_t where i in (select i from rpc.t1)
+----
+5
+
+# --- NOT IN subquery ---
+
+# NOT IN: all remote -> pushed
+query II
+explain select * from rpc.t1 where i not in (select j from rpc.t2)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1={0..9} NOT IN t2={5..14} -> i not in {5..14} -> {0,1,2,3,4} -> 5 rows
+query I
+select count(*) from rpc.t1 where i not in (select j from rpc.t2)
+----
+5
+
+# NOT IN: mixed (local outer, remote subquery) -> outer stays local
+# local_t={5..14} NOT IN t1={0..9} -> {10,11,12,13,14} -> 5 rows
+query I
+select count(*) from local_t where i not in (select i from rpc.t1)
+----
+5
+
+# --- EXISTS subquery ---
+
+# EXISTS: all remote -> pushed
+query II
+explain select * from rpc.t1 where exists (select 1 from rpc.t2 where j = rpc.t1.i)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1={0..9}: rows with matching j in t2={5..14} -> {5,6,7,8,9} -> 5 rows
+query I
+select count(*) from rpc.t1 where exists (select 1 from rpc.t2 where j = rpc.t1.i)
+----
+5
+
+# EXISTS: mixed (local outer, non-correlated remote subquery) -> outer stays local
+# exists(select 1 from rpc.t1 where i < 1) is TRUE (i=0 exists) -> all 10 local rows pass
+query I
+select count(*) from local_t where exists (select 1 from rpc.t1 where i < 1)
+----
+10
+
+# --- NOT EXISTS subquery ---
+
+# NOT EXISTS: all remote -> pushed
+query II
+explain select * from rpc.t1 where not exists (select 1 from rpc.t2 where j = rpc.t1.i)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# t1={0..9}: rows with NO match in t2={5..14} -> {0,1,2,3,4} -> 5 rows
+query I
+select count(*) from rpc.t1 where not exists (select 1 from rpc.t2 where j = rpc.t1.i)
+----
+5
+
+# NOT EXISTS: mixed (local outer, non-correlated remote subquery)
+# not exists(select 1 from rpc.t1 where i > 100) -> t1 has no i>100 -> EXISTS=false -> NOT EXISTS=true
+# -> all 10 local rows pass -> count = 10
+query I
+select count(*) from local_t where not exists (select 1 from rpc.t1 where i > 100)
+----
+10
+
+# --- Correlated subqueries that must NOT be pushed ---
+
+# Correlated: outer is local, subquery references outer local column
+# local_t.i in (select local_t.i from rpc.t1) -> always true for each row -> 10 rows
+query I
+select count(*) from local_t where i in (select local_t.i from rpc.t1)
+----
+10
+
+# --- Scalar subqueries ---
+
+# Scalar: no FROM clause, remote subquery only
+query II
+explain select (select count(*) from rpc.t1)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query I
+select (select count(*) from rpc.t1)
+----
+10
+
+# Scalar: all remote in WHERE -> pushed
+query II
+explain select * from rpc.t1 where i = (select min(i) from rpc.t1)
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# Only the row with min(i)=0 matches
+query I
+select count(*) from rpc.t1 where i = (select min(i) from rpc.t1)
+----
+1
+
+# Scalar: scalar subquery in comparison with filter -> pushed
+# min(j) from t2={5..14} = 5; t1 rows with i >= 5: {5,6,7,8,9} -> 5 rows
+query I
+select count(*) from rpc.t1 where i >= (select min(j) from rpc.t2)
+----
+5
+
+# Scalar: in SELECT list -> pushed
+query I
+select (select count(*) from rpc.t1) + (select count(*) from rpc.t2)
+----
+20
+
+# Scalar: mixed (local outer, remote scalar in WHERE) -> outer stays local
+# min(i) from t1 = 0; local_t={5..14} WHERE i = 0 -> 0 rows
+query I
+select count(*) from local_t where i = (select min(i) from rpc.t1)
+----
+0
+
+
+# Subquery in FROM (derived table): all remote -> pushed (verified in basic test via explain)
+
+statement ok
+drop table local_t
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_subquery_scope.test
+++ b/test/remote_pushdown/remote_pushdown_subquery_scope.test
@@ -1,0 +1,219 @@
+# name: test/remote_pushdown/remote_pushdown_subquery_scope.test
+# description: Regression tests for subquery scope and pushdown bugs in RemotePushdownOptimizer
+# group: [remote_pushdown]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table t1(i int);
+
+statement ok quack_db:quack_server_con
+insert into t1 from range(10);
+
+statement ok quack_db:quack_server_con
+create table t2(i int);
+
+statement ok quack_db:quack_server_con
+insert into t2 values (5), (6), (7), (8), (9), (10), (11), (12), (13), (14);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table local_t(local_col int);
+
+statement ok
+insert into local_t from range(10);
+
+# Bug 5: PushdownSubqueries was not called for GROUP BY / ORDER BY when the whole query could not be pushed.
+
+# Scalar subquery in ORDER BY: local_t={0..9}; order by (9 - local_col) ASC -> local_col=9 first
+query I
+select local_col from local_t
+order by (select max(i) from rpc.t1) - local_col
+limit 3
+----
+9
+8
+7
+
+# Scalar subquery in ORDER BY ascending
+query I
+select local_col from local_t
+order by local_col - (select min(i) from rpc.t1)
+limit 3
+----
+0
+1
+2
+
+# Scalar subquery in GROUP BY: local_col % 9 for {0..9} yields 9 distinct buckets
+query I
+select count(distinct bucket) from (
+  select local_col % (select max(i) from rpc.t1) as bucket from local_t
+) sub
+----
+9
+
+# Bug 9: Rewrite(SubqueryRef) did not save/restore local_table_names, causing column names from inner
+# local tables to leak into the outer scope and falsely block remote subquery pushdown.
+
+statement ok
+create table local_i(i int);
+
+statement ok
+insert into local_i from range(5);
+
+# FROM clause has local SubqueryRef (local_i with column 'i'); WHERE has purely-remote IN subquery.
+# With fix: save/restore clears leaked 'i', IN subquery is correctly pushed.
+# local_i={0..4}; IN filter keeps i in {0,1,2} -> 3 rows.
+query I
+select count(*) from (select * from local_i) sq
+where sq.i in (select i from rpc.t1 where i < 3)
+----
+3
+
+statement ok
+drop table local_i
+
+# Bug 15: FinishPushdown(QueryNode) pushed a UNION ALL child standalone when an outer SINGLE_REMOTE CTE
+# was in scope; remote failed with "Table cte_name not found".
+# Fix: check cte_results for outer SINGLE_REMOTE CTEs and skip the push.
+
+statement ok
+create table local_bugfix15(i int);
+
+statement ok
+insert into local_bugfix15 from range(5, 10);
+
+# outer_cte = {0..4}, local_bugfix15 = {5..9} -> total 10 rows.
+query I
+with outer_cte as (select i from rpc.t1 where i < 5)
+select count(*) from (
+    select i from outer_cte
+    union all
+    select i from local_bugfix15
+)
+----
+10
+
+statement ok
+drop table local_bugfix15
+
+# Bug 17: any_child_pushed in Rewrite(SetOperationNode) did not detect TABLE_FUNCTION refs in UNKNOWN
+# children, causing PushdownSubqueries to open a second streaming connection.
+# Fix: HasTableFunctionInTree detects TABLE_FUNCTION refs so any_child_pushed is set correctly.
+
+statement ok
+create table local_bugfix17(local_col int);
+
+statement ok
+insert into local_bugfix17 from range(10);
+
+# rpc.t1 pushed to TABLE_FUNCTION (slot 1); UNION with local arm uses local_bugfix17.
+# rpc.t1={0..9}; i < max(local_bugfix17)=9 -> {0..8}; local_bugfix17 where local_col<5 -> {0..4}.
+query I rowsort
+(select i from rpc.t1 where i < (select max(local_col) from local_bugfix17))
+union all
+(select local_col from local_bugfix17 where local_col < 5)
+----
+0
+0
+1
+1
+2
+2
+3
+3
+4
+4
+5
+6
+7
+8
+
+statement ok
+drop table local_bugfix17
+
+# Bug 25: Rewrite(SubqueryRef) did not save/restore the subquery node before calling Rewrite(*subquery->node).
+# A mixed JoinRef inside a FROM-clause subquery had its remote child pushed in-place even when result was UNKNOWN.
+# Fix: save and restore the subquery node when result is not SINGLE_REMOTE.
+
+# FROM-clause SubqueryRef with rpc.t2 JOIN local_t (mixed); t2=[5..14] ∩ local_t=[0..9] = {5..9}.
+query I
+select sub.i from (
+    select t2.i from rpc.t2 join local_t on t2.i = local_t.local_col
+) sub order by sub.i
+----
+5
+6
+7
+8
+9
+
+# Bug 31: SubqueryRef with NO_CATALOG_REFERENCED result must NOT be tracked in local_table_names.
+# Previously any non-SINGLE_REMOTE SubqueryRef was added to local_table_names, blocking pushdown
+# of queries with constant subqueries like (SELECT 1 AS v) in FROM.
+
+# Verify pushed: no SEQ_SCAN in plan
+query II
+explain
+select t1.i from rpc.t1 t1, (select 5 as v) sub
+where t1.i < sub.v
+order by t1.i
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+# rpc.t1.i in {0..4} (i < 5), joined with constant sub.v=5
+query I
+select t1.i from rpc.t1 t1, (select 5 as v) sub
+where t1.i < sub.v
+order by t1.i
+----
+0
+1
+2
+3
+4
+
+# Bug 37: FinishPushdown(QueryNode) and PushJoinChild(SubqueryRef) CTE guards did not block
+# NO_CATALOG_REFERENCED outer CTEs; remote failed with "Table 'zero' not found".
+# Fix: extend guards to also return early for NO_CATALOG_REFERENCED outer CTEs.
+
+statement ok
+create table local_bug37(k int);
+
+statement ok
+insert into local_bug37 from range(10);
+
+# Bug 37a (FinishPushdown): UNION ALL arm1 references rpc.t1 CROSS JOIN outer NO_CATALOG CTE (zero).
+# Without fix: arm1 pushed standalone, remote fails on "Table 'zero' not found".
+# zero.n=0 so i >= 0 matches all of rpc.t1={0..9}; arm2 has no rows (k<0); total=10.
+query I
+with zero as (select 0 as n)
+select count(*) from (
+    select i from rpc.t1 cross join zero where i >= zero.n
+    union all
+    select k from local_bug37 where k < 0
+)
+----
+10
+
+# Bug 37b (PushJoinChild SubqueryRef): mixed JOIN where subquery references rpc.t1 CROSS JOIN outer CTE.
+# local_bug37={0..9}, sub.i={0..9} (i>=0) -> 10 rows.
+query I
+with zero as (select 0 as n)
+select count(*)
+from local_bug37
+join (select i from rpc.t1 cross join zero where i >= zero.n) sub
+    on local_bug37.k = sub.i
+----
+10
+
+statement ok
+drop table local_bug37;
+
+statement ok
+drop table local_t;
+
+include test/template/quack_teardown.test_template

--- a/test/remote_pushdown/remote_pushdown_tpch.test_slow
+++ b/test/remote_pushdown/remote_pushdown_tpch.test_slow
@@ -1,0 +1,36 @@
+# name: test/remote_pushdown/remote_pushdown_tpch.test_slow
+# description: CTE (non-recursive and recursive) pushdown for remote catalogs
+# group: [remote_pushdown]
+
+require tpch
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+call dbgen(sf=1);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+use rpc
+
+loop i 1 9
+
+query I
+PRAGMA tpch({i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q0{i}.csv
+
+endloop
+
+loop i 10 23
+
+query I
+PRAGMA tpch({i})
+----
+<FILE>:extension/tpch/dbgen/answers/sf1/q{i}.csv
+
+endloop
+
+include test/template/quack_teardown.test_template

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -5,6 +5,9 @@
 include test/template/quack_setup.test_template
 
 statement ok
+PRAGMA disable_optimizer
+
+statement ok
 create secret (type quack, token 'asdf')
 
 statement ok

--- a/test/sql/lookup_overwrite.test
+++ b/test/sql/lookup_overwrite.test
@@ -30,10 +30,10 @@ select count(j) from rpc.main.t2;
 # Two RPC tables in the same query: both call LookupEntry on the same
 # connection_id during planning. The second PREPARE overwrites the first's
 # server-side query result, so the first table's scan fetches 0 rows.
-statement error
+query II
 select count(t1.i), count(t2.j) from rpc.main.t1, rpc.main.t2;
 ----
-not currently supported
+20000	20000
 
 statement ok
 detach rpc;


### PR DESCRIPTION
https://github.com/duckdb/duckdb/pull/22914 added the `RemotePushdownOptimizer` to core DuckDB - this PR implements the hooks necessary to make it work with `quack` in the current state, and adds the relevant remote pushdown tests. 

Effectively what this means is that many queries are now pushed into quack automatically when using the `ATTACH` syntax, including very complex queries, as long as they only use the remote catalog. For example:

#### Server
```sql
CALL dbgen(sf=1);
CALL quack_serve('quack:127.0.0.1:9494', token='abcd');
```

#### Client

```sql
attach 'quack:localhost' as quack (token 'abcd');
use quack;
explain SELECT
            nation,
            o_year,
            sum(amount) AS sum_profit
        FROM (
            SELECT
                n_name AS nation,
                extract(year FROM o_orderdate) AS o_year,
                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
            FROM
                part,
                supplier,
                lineitem,
                partsupp,
                orders,
                nation
            WHERE
                s_suppkey = l_suppkey
                AND ps_suppkey = l_suppkey
                AND ps_partkey = l_partkey
                AND p_partkey = l_partkey
                AND o_orderkey = l_orderkey
                AND s_nationkey = n_nationkey
                AND p_name LIKE '%green%') AS profit
        GROUP BY
            nation,
            o_year
        ORDER BY
            nation,
            o_year DESC;

┌─────────────────────────────┐
│┌───────────────────────────┐│
││       Physical Plan       ││
│└───────────────────────────┘│
└─────────────────────────────┘
┌───────────────────────────┐
│    QUACK_QUERY_BY_NAME    │
│    ────────────────────   │
│          Server:          │
│      quack:localhost      │
│                           │
│        Projections:       │
│           nation          │
│           o_year          │
│         sum_profit        │
│                           │
│           ~1 row          │
└───────────────────────────┘

```