### PR TITLE
Add `use_transaction` flag to `quack_query_by_name`, which if set makes it use the transaction infrastructure

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -8,6 +8,7 @@
 #include "quack_scan.hpp"
 #include "quack_client.hpp"
 #include "include/storage/quack_catalog.hpp"
+#include "storage/quack_transaction.hpp"
 
 #include <queue>
 namespace duckdb {
@@ -82,11 +83,23 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
 		throw BinderException("catalog_name and query parameters cannot be NULL");
 	}
+	bool use_transaction = false;
+	auto entry = input.named_parameters.find("use_transaction");
+	if (entry != input.named_parameters.end()) {
+		if (entry->second.IsNull()) {
+			throw InvalidInputException("use_transaction cannot be null");
+		}
+		use_transaction = BooleanValue::Get(entry->second);
+	}
 
 	auto &catalog = GetQuackCatalog(context, input.inputs[0]);
+	if (use_transaction) {
+		// start a transaction if "use_transaction" is specified
+		auto &transaction = QuackTransaction::Get(context, catalog);
+		transaction.ForceStart();
+	}
 
 	// TODO some of this stuff below is duplicated af
-
 	auto query = input.inputs[1].GetValue<string>();
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = catalog.GetClientConnection();
@@ -404,6 +417,7 @@ TableFunction QuackScanByNameFunction::GetFunction() {
 	fun.serialize = QuackScanSerialize;
 	fun.deserialize = QuackScanDeserialize;
 	fun.get_bind_info = QuackScanGetBindInfo;
+	fun.named_parameters["use_transaction"] = LogicalType::BOOLEAN;
 	// fun.filter_pushdown = true;
 	// fun.filter_prune = true;
 	return fun;

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -137,6 +137,9 @@ unique_ptr<TableRef> QuackCatalog::RemoteExecute(ClientContext &context, const s
 	vector<unique_ptr<ParsedExpression>> args;
 	args.push_back(make_uniq<ConstantExpression>(Value(GetName())));
 	args.push_back(make_uniq<ConstantExpression>(Value(sql)));
+	auto use_transaction = make_uniq<ConstantExpression>(Value::BOOLEAN(true));
+	use_transaction->SetAlias("use_transaction");
+	args.push_back(std::move(use_transaction));
 	auto func_ref = make_uniq<TableFunctionRef>();
 	func_ref->function = make_uniq<FunctionExpression>("quack_query_by_name", std::move(args));
 	return func_ref;

--- a/test/sql/attach_transactions.test
+++ b/test/sql/attach_transactions.test
@@ -1,0 +1,26 @@
+# name: test/sql/attach_transactions.test
+# description: test attach with transactions
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table rpc.t(i INT)
+
+statement ok
+BEGIN
+
+statement ok
+insert into rpc.t values (42);
+
+statement ok
+rollback
+
+query I
+from rpc.t
+----
+
+include test/template/quack_teardown.test_template

--- a/test/sql/quack_activity.test
+++ b/test/sql/quack_activity.test
@@ -2,48 +2,39 @@
 # description: test quacktivity function for the quack extension
 # group: [sql]
 
-require quack
+include test/template/quack_setup.test_template
 
-require httpfs
-
-set ignore_error_messages __none__
-
-statement ok
+statement ok quack_db:quack_server_con
 create table fuu as values(42, 43);
 
-foreach server 'quack:localhost'
-
-statement ok con1
-call quack_serve({server}, token='asdf');
-
 # no connections yet
-query I con1
+query I
 select count(*) from quack_activity();
 ----
 0
 
 # attach creates a persistent QuackClientConnection
-statement ok con2
+statement ok
 attach {server} as rpc2 (token 'asdf');
 
-query I con1
+query I quack_db:quack_server_con
 select state from quack_activity();
 ----
 finished
 
 loop i 0 3
 
-query II con2
-from rpc2.fuu;
+query II
+from quack_query_by_name('rpc2', 'SELECT * FROM fuu');
 ----
 42	43
 
-query I con1
+query I quack_db:quack_server_con
 select count(*) from quack_activity();
 ----
 1
 
-query I con1
+query I quack_db:quack_server_con
 select starts_with(query, 'SELECT') from quack_activity();
 ----
 true
@@ -51,32 +42,29 @@ true
 endloop
 
 # two clients on the same server
-statement ok con1
+statement ok
 attach {server} as rpc3 (token 'asdf');
 
-query I con1
+query I quack_db:quack_server_con
 select count(*) from quack_activity();
 ----
 2
 
-statement ok con1
+statement ok
 detach rpc3;
 
-query I con1
+query I quack_db:quack_server_con
 select count(*) from quack_activity();
 ----
 1
 
 # detach removes the session
-statement ok con2
+statement ok
 detach rpc2;
 
-query I con1
+query I quack_db:quack_server_con
 select count(*) from quack_activity();
 ----
 0
 
-statement ok con1
-call quack_stop({server});
-
-endloop
+include test/template/quack_teardown.test_template


### PR DESCRIPTION
And also set this flag when triggering remote pushdown. This now makes pushed down queries correctly respect transactions. 