### PR TITLE
Fix ATTACH for tables with sequence-backed defaults

### DIFF
--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -3,6 +3,9 @@
 #include "quack_scan.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/column_list.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "storage/quack_view.hpp"
@@ -19,6 +22,30 @@ unique_ptr<CreateInfo> ParseCreateTable(const string &sql) {
 	}
 	auto &create = parser.statements[0]->Cast<CreateStatement>();
 	return std::move(create.info);
+}
+
+static bool DefaultContainsNextval(const ParsedExpression &expr) {
+	if (expr.GetExpressionClass() == ExpressionClass::FUNCTION) {
+		auto &func = expr.Cast<FunctionExpression>();
+		if (StringUtil::CIEquals(func.function_name, "nextval")) {
+			return true;
+		}
+		for (auto &child : func.children) {
+			if (DefaultContainsNextval(*child)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static void ClearColumnDefaults(CreateTableInfo &info) {
+	for (idx_t i = 0; i < info.columns.LogicalColumnCount(); i++) {
+		auto &col = info.columns.GetColumnMutable(LogicalIndex(i));
+		if (col.HasDefaultValue() && DefaultContainsNextval(col.DefaultValue())) {
+			col.SetDefaultValue(nullptr);
+		}
+	}
 }
 
 QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &parent,
@@ -39,6 +66,10 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			if (info->type != CatalogType::TABLE_ENTRY) {
 				throw InternalException("Expected a CREATE TABLE");
 			}
+			// Strip only defaults that reference server-only objects (e.g. nextval sequences)
+			// that don't exist on the client. Harmless defaults (e.g. DEFAULT 42) are preserved.
+			// Defaults are always evaluated server-side regardless.
+			ClearColumnDefaults(info->Cast<CreateTableInfo>());
 			// bind to resolve the types
 			auto binder = Binder::CreateBinder(context);
 			auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);

--- a/test/sql/attach_default_expression.test
+++ b/test/sql/attach_default_expression.test
@@ -1,0 +1,48 @@
+# name: test/sql/attach_default_expression.test
+# description: test rpc attach with ordinary column defaults (DEFAULT 42, etc.)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+create table t_defaults (
+    x INTEGER DEFAULT 42,
+    y VARCHAR DEFAULT 'hello'
+);
+
+statement ok con1
+insert into t_defaults (x) values (1);
+
+statement ok con1
+insert into t_defaults (y) values ('a');
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+statement ok con2
+attach {server} as rpc (token 'asdf')
+
+# Verify the table schema can be described without errors
+statement ok
+describe rpc.t_defaults;
+
+# Verify SELECT returns data correctly (defaults are evaluated server-side)
+query II
+from rpc.t_defaults order by x;
+----
+1	hello
+42	a
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop

--- a/test/sql/attach_default_sequence.test
+++ b/test/sql/attach_default_sequence.test
@@ -1,0 +1,46 @@
+# name: test/sql/attach_default_sequence.test
+# description: test rpc attach with sequence-based default primary key
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+create sequence id_sequence START 1;
+
+statement ok con1
+create table test_seq (
+    id INTEGER PRIMARY KEY DEFAULT nextval('id_sequence'),
+    s VARCHAR
+);
+
+statement ok con1
+insert into test_seq (s) values ('foo');
+
+statement ok con1
+insert into test_seq (s) values ('bar');
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+statement ok con2
+attach {server} as rpc (token 'asdf')
+
+query II
+from rpc.test_seq order by id;
+----
+1	foo
+2	bar
+
+statement ok con1
+call quack_stop({server});
+
+statement ok con2
+detach rpc;
+
+endloop


### PR DESCRIPTION
Related to duckdb/duckdb#22743

## Summary

Quack reconstructs remote table schemas during `ATTACH` by loading the server-side `CREATE TABLE` SQL and rebinding it locally.

For tables containing sequence-backed defaults such as:

```sql
CREATE SEQUENCE id_sequence START 1;

CREATE TABLE test (
    id INTEGER PRIMARY KEY DEFAULT nextval('id_sequence'),
    s VARCHAR
);
```

the local binder attempts to resolve the referenced sequence during catalog reconstruction. Since sequences are not loaded into the attached client catalog, binding fails and `ATTACH` does not complete successfully.

## Solution

Before local binding, detect column defaults that reference `nextval()` and remove those defaults from the client-side schema representation.

Only sequence-backed defaults are stripped; ordinary defaults such as `DEFAULT 42` and `DEFAULT 'hello'` are preserved.

This avoids binding failures caused by server-only sequence objects while maintaining normal schema metadata. Default expressions continue to be evaluated on the server side during inserts.

## Testing

Added regression tests covering:

* ATTACH against tables using `DEFAULT nextval(...)`
* ATTACH against tables using ordinary defaults (`DEFAULT 42`, `DEFAULT 'hello'`)

The sequence-backed default test reproduces the behavior reported in duckdb/duckdb#22743 and verifies that ATTACH succeeds and the remote table can be queried normally.

