### PR TITLE
Get connection id at client

### DIFF
--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -72,6 +72,7 @@ public:
 	const string &GetConnectionId();
 
 	shared_ptr<QuackClientConnection> GetClientConnection();
+	static QuackCatalog &GetQuackCatalog(ClientContext &context, Value &catalog_name);
 
 	void Refresh(ClientContext &context);
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -85,7 +85,7 @@ static void QuackDummyAuthorization(const DataChunk &args, ExpressionState &, Ve
 
 static void QuackConnectionIdFunc(const DataChunk &args, ExpressionState &state, Vector &result) {
 	auto catalog_name = args.GetValue(0, 0);
-	auto &quack_catalog = QuackCatalog::GetQuackCatalog( state.GetContext(), catalog_name);
+	auto &quack_catalog = QuackCatalog::GetQuackCatalog(state.GetContext(), catalog_name);
 	result.SetValue(0, Value(quack_catalog.GetConnectionId()));
 }
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -84,9 +84,8 @@ static void QuackDummyAuthorization(const DataChunk &args, ExpressionState &, Ve
 }
 
 static void QuackConnectionIdFunc(const DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &context = state.GetContext();
-	auto catalog_val = args.GetValue(0, 0);
-	auto &quack_catalog = QuackCatalog::GetQuackCatalog(context, catalog_val);
+	auto catalog_name = args.GetValue(0, 0);
+	auto &quack_catalog = QuackCatalog::GetQuackCatalog( state.GetContext(), catalog_name);
 	result.SetValue(0, Value(quack_catalog.GetConnectionId()));
 }
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -83,6 +83,13 @@ static void QuackDummyAuthorization(const DataChunk &args, ExpressionState &, Ve
 	result.SetValue(0, args.GetValue(1, 0)); // choose life
 }
 
+static void QuackConnectionIdFunc(const DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &context = state.GetContext();
+	auto catalog_val = args.GetValue(0, 0);
+	auto &quack_catalog = QuackCatalog::GetQuackCatalog(context, catalog_val);
+	result.SetValue(0, Value(quack_catalog.GetConnectionId()));
+}
+
 static void QuackIdentifyFun(ClientContext &, TableFunctionInput &, DataChunk &) {
 	// No-op: side effects are in bind.
 }
@@ -136,6 +143,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                                 LogicalType::VARCHAR, QuackDummyAuthorization);
 	rpc_authorization.SetVolatile();
 	loader.RegisterFunction(rpc_authorization);
+
+	ScalarFunction quack_connection_id("quack_connection_id", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                   QuackConnectionIdFunc);
+	quack_connection_id.SetVolatile();
+	loader.RegisterFunction(quack_connection_id);
 
 	loader.RegisterFunction(QuackParseUriFunction::GetFunction());
 

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -60,24 +60,6 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	return bind_data;
 }
 
-QuackCatalog &GetQuackCatalog(ClientContext &context, Value &catalog_name) {
-	if (catalog_name.IsNull()) {
-		throw BinderException("Catalog cannot be NULL");
-	}
-	// look up the database to query
-	auto db_name = catalog_name.GetValue<string>();
-	auto &db_manager = DatabaseManager::Get(context);
-	auto db = db_manager.GetDatabase(context, db_name);
-	if (!db) {
-		throw BinderException("Failed to find attached database \"%s\"", db_name);
-	}
-	auto &catalog = db->GetCatalog();
-	if (catalog.GetCatalogType() != "quack") {
-		throw BinderException("Attached database \"%s\" does not refer to a RPC database", db_name);
-	}
-	return catalog.Cast<QuackCatalog>();
-}
-
 static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context, TableFunctionBindInput &input,
                                                          vector<LogicalType> &return_types, vector<string> &names) {
 	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
@@ -92,7 +74,7 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 		use_transaction = BooleanValue::Get(entry->second);
 	}
 
-	auto &catalog = GetQuackCatalog(context, input.inputs[0]);
+	auto &catalog = QuackCatalog::GetQuackCatalog(context, input.inputs[0]);
 	if (use_transaction) {
 		// start a transaction if "use_transaction" is specified
 		auto &transaction = QuackTransaction::Get(context, catalog);

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -96,6 +96,24 @@ const string &QuackCatalog::GetConnectionId() {
 	return client_connection->ConnectionId();
 }
 
+QuackCatalog &QuackCatalog::GetQuackCatalog(ClientContext &context, Value &catalog_name) {
+	if (catalog_name.IsNull()) {
+		throw BinderException("Catalog cannot be NULL");
+	}
+	// look up the database to query
+	auto db_name = catalog_name.GetValue<string>();
+	auto &db_manager = DatabaseManager::Get(context);
+	auto db = db_manager.GetDatabase(context, db_name);
+	if (!db) {
+		throw BinderException("Failed to find attached database \"%s\"", db_name);
+	}
+	auto &catalog = db->GetCatalog();
+	if (catalog.GetCatalogType() != "quack") {
+		throw BinderException("Attached database \"%s\" does not refer to a Quack database", db_name);
+	}
+	return catalog.Cast<QuackCatalog>();
+}
+
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	// create schema remotely


### PR DESCRIPTION
Adding a scalar function `quack_connection_id('catalog_name')` which returns the current connection id of the attached catalog. Useful for cancellations.