### PR TITLE
Fixes for quack main

### DIFF
--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -66,6 +66,9 @@ public:
 	}
 	unique_ptr<TableRef> RemoteExecute(ClientContext &context, unique_ptr<QueryNode> node) override;
 	unique_ptr<TableRef> RemoteExecute(ClientContext &context, const string &sql) override;
+	string GetConnectDisplay() override {
+		return GetDBPath();
+	}
 
 	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(ClientContext &context, const string &query);
 	const QuackUri &GetServerUri();

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -28,7 +28,9 @@ public:
 	string GetCatalogType() override {
 		return "quack";
 	}
+
 	static bool IsQuackScan(const string &name);
+	bool SupportsPushdown(const TableRef &ref) override;
 	void Initialize(bool load_builtin) override;
 
 	optional_ptr<CatalogEntry> CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) override;

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -49,7 +49,7 @@ static unique_ptr<BaseSecret> CreateQuackSecretFromConfig(ClientContext &, Creat
 
 static void RegisterQuackSecretType(ExtensionLoader &loader) {
 	SecretType secret_type;
-	secret_type.name = QUACK_SECRET_TYPE;
+	secret_type.name = Identifier(QUACK_SECRET_TYPE);
 	secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
 	secret_type.default_provider = "config";
 	secret_type.extension = "quack";

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -414,7 +414,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 
 		std::unique_lock<std::mutex> lock(connection.lock);
 		auto &context = *connection.duckdb_connection->context;
-		auto table_info = context.TableInfo(append_request_message.SchemaName(), append_request_message.TableName());
+		auto table_info = context.TableInfo(Identifier(append_request_message.SchemaName()),
+		                                    Identifier(append_request_message.TableName()));
 		if (!table_info) {
 			return make_uniq<ErrorResponse>("Table %s.%s does not exist",
 			                                SQLIdentifier(append_request_message.SchemaName()),

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -103,7 +103,7 @@ QuackCatalog &QuackCatalog::GetQuackCatalog(ClientContext &context, Value &catal
 	// look up the database to query
 	auto db_name = catalog_name.GetValue<string>();
 	auto &db_manager = DatabaseManager::Get(context);
-	auto db = db_manager.GetDatabase(context, db_name);
+	auto db = db_manager.GetDatabase(context, Identifier(db_name));
 	if (!db) {
 		throw BinderException("Failed to find attached database \"%s\"", db_name);
 	}

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -175,4 +175,19 @@ void QuackCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 	throw NotImplementedException("DropSchema not implemented yet");
 }
 
+bool QuackCatalog::SupportsPushdown(const TableRef &ref) {
+	if (ref.type != TableReferenceType::TABLE_FUNCTION) {
+		return true;
+	}
+	auto &table_func_ref = ref.Cast<TableFunctionRef>();
+	if (table_func_ref.function->GetExpressionClass() != ExpressionClass::FUNCTION) {
+		return true;
+	}
+	auto &func_expr = table_func_ref.function->Cast<FunctionExpression>();
+	if (func_expr.FunctionName() == "query") {
+		return false;
+	}
+	return true;
+}
+
 } // namespace duckdb

--- a/src/storage/quack_catalog_set.cpp
+++ b/src/storage/quack_catalog_set.cpp
@@ -44,10 +44,10 @@ optional_ptr<CatalogEntry> QuackCatalogSet::CreateEntry(unique_ptr<CatalogEntry>
 	lock_guard<mutex> l(entry_lock);
 	auto &entry_name = entry->name;
 	if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-		entries[entry_name] = std::move(entry);
-		return entries[entry_name].get();
+		entries[entry_name.GetIdentifierName()] = std::move(entry);
+		return entries[entry_name.GetIdentifierName()].get();
 	} else {
-		auto inserted_entry = entries.insert(make_pair(entry_name, std::move(entry)));
+		auto inserted_entry = entries.insert(make_pair(entry_name.GetIdentifierName(), std::move(entry)));
 		return inserted_entry.first->second.get();
 	}
 }

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -56,8 +56,9 @@ SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	append_chunk->Initialize(context.client, chunk.GetTypes());
 	append_chunk->Reference(chunk);
 	auto chunk_wrapper = make_uniq<DataChunkWrapper>(*append_chunk);
-	auto append_message = make_uniq<AppendRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name, tbl.name,
-	                                                      std::move(chunk_wrapper));
+	auto append_message =
+	    make_uniq<AppendRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name.GetIdentifierName(),
+	                                    tbl.name.GetIdentifierName(), std::move(chunk_wrapper));
 
 	auto client_connection = quack_catalog.GetClientConnection();
 	auto client_wrapper = client_connection->GetClient(context.client);
@@ -97,7 +98,7 @@ string QuackInsert::GetName() const {
 
 InsertionOrderPreservingMap<string> QuackInsert::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
-	result["Table Name"] = table ? table->name : info->Base().table;
+	result["Table Name"] = table ? table->name.GetIdentifierName() : info->Base().table.GetIdentifierName();
 	return result;
 }
 

--- a/src/storage/quack_optimizer.cpp
+++ b/src/storage/quack_optimizer.cpp
@@ -22,7 +22,7 @@ void GatherQuackScans(LogicalOperator &op, QuackOperators &result) {
 	if (op.type == LogicalOperatorType::LOGICAL_GET) {
 		auto &get = op.Cast<LogicalGet>();
 		auto &table_scan = get.function;
-		if (QuackCatalog::IsQuackScan(table_scan.name)) {
+		if (QuackCatalog::IsQuackScan(table_scan.name.GetIdentifierName())) {
 			// add a quack scan
 			auto &bind_data = get.bind_data->Cast<QuackScanBindData>();
 			auto connection_id = bind_data.client_connection->ConnectionId();

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -20,8 +20,8 @@ void QuackSchemaSet::Reload(ClientContext &context, QuackCatalog &catalog, const
 	Clear();
 	for (auto &row : load_data.schemas->Rows()) {
 		CreateSchemaInfo info;
-		info.catalog = row.GetValue(0).GetValue<string>();
-		info.schema = row.GetValue(1).GetValue<string>();
+		info.catalog = Identifier(row.GetValue(0).GetValue<string>());
+		info.schema = Identifier(row.GetValue(1).GetValue<string>());
 		// TODO this will fail if there are two schemas with the same name in different catalogs :/
 		auto schema = make_uniq<QuackSchemaCatalogEntry>(context, catalog, info, load_data);
 		CreateEntry(std::move(schema), OnCreateConflict::REPLACE_ON_CONFLICT);
@@ -105,7 +105,8 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransactio
 	quack_transaction.Query(create_view_info->ToString());
 
 	// locally, override the query with a remote procedure call to ensure the view is evaluated remotely
-	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName(), name, info.view_name);
+	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName().GetIdentifierName(),
+	                                                name.GetIdentifierName(), info.view_name.GetIdentifierName());
 	info.query = CreateViewInfo::ParseSelect(info.sql);
 
 	auto quack_entry = make_uniq<QuackViewCatalogEntry>(catalog, *this, info);
@@ -149,7 +150,7 @@ void QuackSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p
 	}
 	auto &transaction = QuackTransaction::Get(context, ParentCatalog());
 	transaction.Query(drop_info->ToString());
-	tables->DropEntry(info_p.name);
+	tables->DropEntry(info_p.name.GetIdentifierName());
 }
 void QuackSchemaCatalogEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
 	throw NotImplementedException("Alter not implemented yet, Alter!");
@@ -165,8 +166,9 @@ static const DefaultTableMacro quack_table_macros[] = {
 // 'borrowed' from ducklake
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::LoadBuiltInFunction(DefaultTableMacro macro) {
 	string macro_def = macro.macro;
-	macro_def = StringUtil::Replace(macro_def, "{CATALOG}", KeywordHelper::WriteQuoted(catalog.GetName(), '\''));
-	macro_def = StringUtil::Replace(macro_def, "{SCHEMA}", KeywordHelper::WriteQuoted(name, '\''));
+	macro_def = StringUtil::Replace(macro_def, "{CATALOG}",
+	                                KeywordHelper::WriteQuoted(catalog.GetName().GetIdentifierName(), '\''));
+	macro_def = StringUtil::Replace(macro_def, "{SCHEMA}", KeywordHelper::WriteQuoted(name.GetIdentifierName(), '\''));
 	macro.macro = macro_def.c_str();
 	auto info = DefaultTableFunctionGenerator::CreateTableMacroInfo(macro);
 	auto table_macro =

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -49,8 +49,9 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			// bind a remote procedure call to the view on the server side
 			// we don't actually care what the view contains server-side, we just treat it like an opaque object we can
 			// query
-			CreateViewInfo info(schema, view_name);
-			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName(), schema.name, view_name);
+			CreateViewInfo info(schema, Identifier(view_name));
+			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName().GetIdentifierName(),
+			                                                schema.name.GetIdentifierName(), view_name);
 			info.query = CreateViewInfo::ParseSelect(info.sql);
 
 			// bind to resolve the types
@@ -79,9 +80,9 @@ TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, un
 	auto &quack_catalog = catalog.Cast<QuackCatalog>();
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = quack_catalog.GetClientConnection();
-	bind_data->table_name = name;
+	bind_data->table_name = name.GetIdentifierName();
 	for (auto &col : GetColumns().Physical()) {
-		bind_data->column_names.push_back(col.Name());
+		bind_data->column_names.emplace_back(col.Name());
 		bind_data->column_types.push_back(col.Type());
 	}
 	bind_data->table_entry = this;

--- a/test/remote_pushdown/remote_pushdown_advanced.test
+++ b/test/remote_pushdown/remote_pushdown_advanced.test
@@ -430,6 +430,9 @@ create table nulls(i int);
 statement ok quack_db:quack_server_con
 insert into nulls values (1), (NULL), (3), (NULL), (5);
 
+statement ok
+from quack_clear_cache();
+
 # COUNT(*) counts nulls, COUNT(i) skips them
 query II
 select count(*), count(i) from rpc.nulls

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -31,6 +31,24 @@ create secret (type quack, token 'asdf')
 statement ok
 attach {server} as rpc
 
+query I
+from quack_query_by_name('rpc', '
+BEGIN;
+select 42;
+COMMIT;
+')
+----
+42
+
+query I
+from rpc.query('BEGIN; select 42; COMMIT;')
+----
+42
+
+query I
+from rpc.query('select 42; select 48');
+----
+42
 
 query II
 from rpc.fuu;

--- a/test/sql/attach.test
+++ b/test/sql/attach.test
@@ -32,21 +32,7 @@ statement ok
 attach {server} as rpc
 
 query I
-from quack_query_by_name('rpc', '
-BEGIN;
-select 42;
-COMMIT;
-')
-----
-42
-
-query I
 from rpc.query('BEGIN; select 42; COMMIT;')
-----
-42
-
-query I
-from rpc.query('select 42; select 48');
 ----
 42
 

--- a/test/sql/pgbench.test
+++ b/test/sql/pgbench.test
@@ -36,7 +36,7 @@ UPDATE pgbench_tellers SET tbalance = tbalance + 2655 WHERE tid = 120;
 UPDATE pgbench_branches SET bbalance = bbalance + 2655 WHERE bid = 3;
 INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES (120, 3, 5445192, 2655, CURRENT_TIMESTAMP);
 COMMIT;
-')
+');
 
 endloop
 

--- a/test/sql/pgbench.test
+++ b/test/sql/pgbench.test
@@ -28,7 +28,7 @@ CALL enable_logging('Quack');
 loop i 0 10
 
 statement ok
-from quack_query_by_name('rpc','
+from rpc.query('
 BEGIN;
 UPDATE pgbench_accounts SET abalance = abalance + 2655 WHERE aid = 5445192;
 SELECT abalance FROM pgbench_accounts WHERE aid = 5445192;

--- a/test/sql/pgbench.test
+++ b/test/sql/pgbench.test
@@ -28,7 +28,7 @@ CALL enable_logging('Quack');
 loop i 0 10
 
 statement ok
-from rpc.query('
+from quack_query_by_name('rpc','
 BEGIN;
 UPDATE pgbench_accounts SET abalance = abalance + 2655 WHERE aid = 5445192;
 SELECT abalance FROM pgbench_accounts WHERE aid = 5445192;


### PR DESCRIPTION
This PR fixes (hopefully) the CI failures on quack main. In summary:

-  fixes `<quack_catalog>.query()` such that this function can take multiple statements by adding an overload  `QuackCatalog::SupportsPushdown(const TableRef &ref)`
- fixes `remote_pushdown_advanced.test` by adding `from quack_clear_cache()`
- It applied and propagated patches from duckdb/duckdb main
- bump duckdb submodule

fixes https://github.com/duckdblabs/duckdb-internal/issues/9657
