### PR TITLE
bump quack version

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -54,7 +54,7 @@ enum class QuackServerState { UNINITIALIZED, WAITING_TO_START, RUNNING, CLOSED }
 
 class QuackServer {
 public:
-	static constexpr const idx_t QUACK_VERSION = 1;
+	static constexpr const idx_t QUACK_VERSION = 2;
 
 public:
 	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -273,8 +273,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();
-		if (connection_request_message.MinimumSupportedQuackVersion() > 1ULL) {
-			return make_uniq<ErrorResponse>("Unsupported Quack version - server only supports version 1 of quack");
+		if (connection_request_message.MinimumSupportedQuackVersion() > 2ULL) {
+			return make_uniq<ErrorResponse>("Unsupported Quack version - server only supports version 2 of quack");
 		}
 		string session_id = GenerateSessionId();
 		auto auth_result = EvaluateAuthQuery(


### PR DESCRIPTION
bumps quack protocol version from 1 to 2 since this changed due to https://github.com/duckdb/duckdb-quack/pull/165. This is mainly to throw appropriate errors since quack v1.5.x and v2.x are not compatible anymore.

fixes https://github.com/duckdblabs/duckdb-internal/issues/9780