### PR TITLE
Start transaction before query

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -89,6 +89,10 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 	auto client_wrapper = bind_data->client_connection->GetClient(context);
 	auto &client = client_wrapper->GetClient();
 	bind_data->query_uuid = UUID::GenerateRandomUUID();
+
+	if (!context.transaction.IsAutoCommit()) {
+		QuackTransaction::Get(context, catalog).ForceStart();
+	}
 	auto bind_response = client.Request<PrepareResponseMessage>(
 	    context,
 	    make_uniq<PrepareRequestMessage>(bind_data->client_connection->ConnectionId(), query, bind_data->query_uuid));

--- a/test/sql/quack_query_by_name_rollback_repro.test
+++ b/test/sql/quack_query_by_name_rollback_repro.test
@@ -1,0 +1,38 @@
+# name: test/sql/quack_query_by_name_rollback_repro.test
+# description: quack_query_by_name should participate in the outer transaction rollback
+# group: [sql]
+
+require quack
+
+require httpfs
+
+statement ok con1
+CALL quack_serve('quack:localhost', token='asdf');
+
+statement ok con2
+CREATE SECRET (TYPE quack, TOKEN 'asdf');
+
+statement ok con2
+ATTACH 'quack:localhost' AS rpc;
+
+statement ok con2
+BEGIN;
+
+statement ok con2
+CALL system.main.quack_query_by_name('rpc', 'CREATE TABLE rollback_bug(i INTEGER); INSERT INTO rollback_bug VALUES (42);');
+
+statement ok con2
+ROLLBACK;
+
+# Refresh the attached catalog snapshot so we observe the remote server state.
+statement ok con2
+CALL quack_clear_cache();
+
+# Correct behavior: table creation/insert should have rolled back remotely too.
+statement error con2
+SELECT * FROM rpc.rollback_bug;
+----
+Table with name rollback_bug does not exist
+
+statement ok con1
+CALL quack_stop('quack:localhost');


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb-quack/issues/180

Hi team, when I was debugging a DuckLake issue with quack catalog, I found rollback doesn't seem to work properly (see analyze here https://github.com/duckdb/ducklake/issues/1267#issuecomment-4806040600)

In this PR, I explicitly start the transaction at both client and server side, so later rollback does execute.