### PR TITLE
Add optional client id upon attach

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -34,7 +34,8 @@ public:
 	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
-	static shared_ptr<QuackClientConnection> ConnectToServer(ClientContext &context, const QuackUri &uri, string token);
+	static shared_ptr<QuackClientConnection> ConnectToServer(ClientContext &context, const QuackUri &uri, string token,
+	                                                         string client_id = {});
 
 protected:
 	mutex request_mutex;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -195,11 +195,14 @@ class ConnectionRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_REQUEST;
 
-	explicit ConnectionRequestMessage(const string &auth_string_p);
+	explicit ConnectionRequestMessage(const string &auth_string_p, string client_id_p = {});
 
 public:
 	const string &AuthString() const {
 		return auth_string;
+	}
+	const string &ClientId() const {
+		return client_id;
 	}
 	const string &ClientVersion() const {
 		return client_duckdb_version;
@@ -222,6 +225,7 @@ protected:
 
 private:
 	string auth_string;
+	string client_id;
 	string client_duckdb_version;
 	string client_platform;
 	idx_t min_supported_quack_version;

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -37,6 +37,10 @@ struct QuackConnection {
 	//! Current query UUID
 	hugeint_t query_uuid;
 	string session_id;
+
+	//! hash(session_id + token + client_id)
+	//! empty if no client_id
+	string client_id_hash;
 	string sql_query;
 	QuackQueryState query_state = QuackQueryState::IDLE;
 	timestamp_t query_started_at {0};
@@ -45,6 +49,7 @@ struct QuackConnection {
 struct QuackConnectionSnapshot {
 	string server_id;
 	string session_id;
+	string client_id_hash;
 	string sql_query;
 	QuackQueryState query_state = QuackQueryState::IDLE;
 	timestamp_t query_started_at {0};
@@ -72,7 +77,7 @@ public:
 	virtual void Close() {};
 
 	shared_ptr<QuackConnection> GetConnection(const string &connection_id);
-	string CreateNewConnection(const string &session_id);
+	string CreateNewConnection(const string &session_id, const string &client_id_hash = {});
 	bool DisconnectConnection(const string &session_id);
 	// TODO need something to destroy connections
 

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -21,7 +21,7 @@ class QuackClientConnection;
 class QuackCatalog : public Catalog {
 public:
 	explicit QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p, ClientContext &context,
-	                      const string &token);
+	                      const string &token, string client_id = {});
 	~QuackCatalog() override;
 
 public:

--- a/src/quack_active_connections.cpp
+++ b/src/quack_active_connections.cpp
@@ -39,9 +39,9 @@ struct QuackActiveConnectionsData : FunctionData {
 
 static unique_ptr<FunctionData> QuackActiveConnectionsBind(ClientContext &, TableFunctionBindInput &,
                                                            vector<LogicalType> &return_types, vector<string> &names) {
-	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
-	                LogicalType::TIMESTAMP};
-	names = {"server_id", "connection_id", "query", "state", "query_started_at"};
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::TIMESTAMP};
+	names = {"server_id", "connection_id", "query", "state", "client_id_hash", "query_started_at"};
 	return make_uniq<QuackActiveConnectionsData>();
 }
 
@@ -59,10 +59,11 @@ static void QuackActiveConnectionsScan(ClientContext &context, TableFunctionInpu
 		output.SetValue(1, row, snap.session_id);
 		output.SetValue(2, row, snap.sql_query);
 		output.SetValue(3, row, Value(QueryStateToString(snap.query_state)));
+		output.SetValue(4, row, snap.client_id_hash.empty() ? Value(LogicalType::VARCHAR) : Value(snap.client_id_hash));
 		if (snap.query_state == QuackQueryState::IDLE) {
-			output.SetValue(4, row, Value(LogicalType::TIMESTAMP));
+			output.SetValue(5, row, Value(LogicalType::TIMESTAMP));
 		} else {
-			output.SetValue(4, row, Value::TIMESTAMP(snap.query_started_at));
+			output.SetValue(5, row, Value::TIMESTAMP(snap.query_started_at));
 		}
 		row++;
 	}

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -166,7 +166,7 @@ QuackClientConnection::~QuackClientConnection() {
 }
 
 shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &context, const QuackUri &uri,
-                                                               string token) {
+                                                               string token, string client_id) {
 	// if no token is provided fetch it from the secret manager
 	if (token.empty()) {
 		auto &secret_manager = SecretManager::Get(context);
@@ -185,8 +185,8 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	auto client = QuackClient::GetClient(context, uri);
 
 	// submit the connection request
-	auto connection_request_response =
-	    client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
+	auto connection_request_response = client->Request<ConnectionResponseMessage>(
+	    context, make_uniq<ConnectionRequestMessage>(token, std::move(client_id)));
 	// success! we got a connection id
 	// construct the client connection and return it
 	auto connection_id = connection_request_response->ConnectionId();

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -155,10 +155,10 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 	return result;
 }
 
-ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p)
-    : QuackMessage(TYPE), auth_string(auth_string_p), client_duckdb_version(DuckDB::LibraryVersion()),
-      client_platform(DuckDB::Platform()), min_supported_quack_version(QuackServer::QUACK_VERSION),
-      max_supported_quack_version(QuackServer::QUACK_VERSION) {
+ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p, string client_id_p)
+    : QuackMessage(TYPE), auth_string(auth_string_p), client_id(std::move(client_id_p)),
+      client_duckdb_version(DuckDB::LibraryVersion()), client_platform(DuckDB::Platform()),
+      min_supported_quack_version(QuackServer::QUACK_VERSION), max_supported_quack_version(QuackServer::QUACK_VERSION) {
 }
 
 ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p)

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -41,7 +41,11 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	if (input.named_parameters.find("token") != input.named_parameters.end()) {
 		token = input.named_parameters["token"].GetValue<string>();
 	}
-	bind_data->client_connection = QuackClient::ConnectToServer(context, server_uri, token);
+	string client_id;
+	if (input.named_parameters.find("client_id") != input.named_parameters.end()) {
+		client_id = input.named_parameters["client_id"].GetValue<string>();
+	}
+	bind_data->client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id));
 	auto &client_connection = *bind_data->client_connection;
 
 	auto client_wrapper = client_connection.GetClient(context);
@@ -383,6 +387,7 @@ TableFunction QuackScanFunction::GetFunction() {
 	                         QuackScanInitGlobal, QuackScanInitLocal);
 	fun.named_parameters["disable_ssl"] = LogicalType::BOOLEAN;
 	fun.named_parameters["token"] = LogicalType::VARCHAR;
+	fun.named_parameters["client_id"] = LogicalType::VARCHAR;
 
 	fun.projection_pushdown = true;
 	fun.get_partition_data = QuackScanGetPartitionData;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/crypto/md5.hpp"
 #include "duckdb/common/encryption_state.hpp"
 #include "duckdb/common/render_tree.hpp"
 #include "duckdb/common/types/blob.hpp"
@@ -42,6 +43,7 @@ vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
 	for (auto &[id, conn] : active_connections) {
 		QuackConnectionSnapshot snapshot;
 		snapshot.session_id = conn->session_id;
+		snapshot.client_id_hash = conn->client_id_hash;
 		snapshot.sql_query = conn->sql_query;
 		snapshot.query_state = conn->query_state;
 		snapshot.query_started_at = conn->query_started_at;
@@ -59,7 +61,7 @@ shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_
 	return nullptr;
 }
 
-string QuackServer::CreateNewConnection(const string &session_id) {
+string QuackServer::CreateNewConnection(const string &session_id, const string &client_id_hash) {
 	std::lock_guard<std::mutex> lock(active_connections_mutex);
 
 	D_ASSERT(active_connections.find(session_id) == active_connections.end());
@@ -69,6 +71,7 @@ string QuackServer::CreateNewConnection(const string &session_id) {
 		throw InternalException("Database was closed");
 	}
 	auto new_connection = make_shared_ptr<QuackConnection>(session_id);
+	new_connection->client_id_hash = client_id_hash;
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
 	// new_connection->duckdb_connection->context->config.streaming_buffer_size = 10 * 1000000; // 10 MB
@@ -115,6 +118,14 @@ static Value EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... 
 }
 
 static constexpr idx_t kTokenBytes = 16; // 128 bits
+
+static string ComputeSessionHash(const string &session_id, const string &token, const string &client_id) {
+	MD5Context context;
+	context.Add(session_id);
+	context.Add(token);
+	context.Add(client_id);
+	return context.FinishHex();
+}
 
 static string HexEncode(const data_t *bytes, idx_t n) {
 	string result(n * 2, '\0');
@@ -285,7 +296,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		    (auth_result.type().id() == LogicalTypeId::BOOLEAN && !auth_result.GetValue<bool>())) {
 			return make_uniq<ErrorResponse>("Authentication failed");
 		}
-		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id));
+		string client_id_hash;
+		if (!connection_request_message.ClientId().empty()) {
+			client_id_hash = ComputeSessionHash(session_id, Token(), connection_request_message.ClientId());
+		}
+		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id, client_id_hash));
 	}
 	case MessageType::DISCONNECT_MESSAGE: {
 		auto &connection = *connection_p;

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -97,7 +97,11 @@ static unique_ptr<Catalog> QuackAttach(optional_ptr<StorageExtensionInfo> storag
 	if (attach_options.options.find("token") != attach_options.options.end()) {
 		token = attach_options.options["token"].GetValue<string>();
 	}
-	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token);
+	string client_id;
+	if (attach_options.options.find("client_id") != attach_options.options.end()) {
+		client_id = attach_options.options["client_id"].GetValue<string>();
+	}
+	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token, client_id);
 }
 
 static unique_ptr<TransactionManager> QuackCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -29,6 +29,7 @@ void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(3, "client_platform", client_platform);
 	serializer.WritePropertyWithDefault<idx_t>(4, "min_supported_quack_version", min_supported_quack_version);
 	serializer.WritePropertyWithDefault<idx_t>(5, "max_supported_quack_version", max_supported_quack_version);
+	serializer.WritePropertyWithDefault<string>(6, "client_id", client_id);
 }
 
 unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -38,6 +39,7 @@ unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deser
 	deserializer.ReadPropertyWithDefault<string>(3, "client_platform", result->client_platform);
 	deserializer.ReadPropertyWithDefault<idx_t>(4, "min_supported_quack_version", result->min_supported_quack_version);
 	deserializer.ReadPropertyWithDefault<idx_t>(5, "max_supported_quack_version", result->max_supported_quack_version);
+	deserializer.ReadPropertyWithDefault<string>(6, "client_id", result->client_id);
 	return result;
 }
 

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -24,10 +24,10 @@
 namespace duckdb {
 
 QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, ClientContext &context,
-                           const string &token)
+                           const string &token, string client_id)
     : Catalog(db_p) {
 	// connect to the server
-	client_connection = QuackClient::ConnectToServer(context, server_uri, token);
+	client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id));
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);

--- a/test/sql/quack_active_connections.test
+++ b/test/sql/quack_active_connections.test
@@ -39,16 +39,27 @@ select starts_with(query, 'SELECT') from quack_active_connections();
 ----
 true
 
+# client id hash is NULL, because there is no client id input
+query I quack_db:quack_server_con
+select client_id_hash from quack_active_connections();
+----
+NULL
+
 endloop
 
 # two clients on the same server
 statement ok
-attach {server} as rpc3 (token 'asdf');
+attach {server} as rpc3 (token 'asdf', client_id 'random_client_id');
 
 query I quack_db:quack_server_con
 select count(*) from quack_active_connections();
 ----
 2
+
+query I quack_db:quack_server_con
+SELECT count(client_id_hash) from quack_active_connections() WHERE client_id_hash NOT NULL;
+----
+1
 
 statement ok
 detach rpc3;


### PR DESCRIPTION
This PR is part of multiple PRs to implement reconnects - extensive explanation in https://github.com/duckdblabs/duckdb-internal/issues/9576.

This PR adds the possibility to manually pass a `client_id`. The client optionally passes a client_id string when attaching:
`ATTACH {server} AS remote (token 'asdf', client_id 'random_client_id')`.  This client_id is propagated to the server, along with a token.

After successful authentication the server then computes a hash(session_id + token + client_id), since these 3 values produce a different hash for each server/token. This is stored in a `QuackConnection` , and the hash is exposed in the `quack_active_connections()`.

This could also be useful for e.g. logging, since this makes tracking a specific client more explicit. But this should be added to the logger.