### PR TITLE
ci: pin duckdb build to submodule commit via .github/duckdb-version

### DIFF
--- a/.github/duckdb-version
+++ b/.github/duckdb-version
@@ -1,0 +1,1 @@
+ff62f2bc89a2f899fc18652f4d7a4be2258f8fbd

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,19 +12,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Pin the duckdb build to the commit our submodule references (.github/duckdb-version), instead of
+  # tracking duckdb main — otherwise upstream-main API drift breaks CI on changes unrelated to this repo.
+  get-duckdb-version:
+    name: Get DuckDB version
+    runs-on: ubuntu-latest
+    outputs:
+      duckdb_version: ${{ steps.version.outputs.duckdb_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - id: version
+        run: echo "duckdb_version=$(cat .github/duckdb-version)" >> $GITHUB_OUTPUT
+
   duckdb-stable-build:
     name: Build extension binaries
+    needs: get-duckdb-version
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: main
+      duckdb_version: ${{ needs.get-duckdb-version.outputs.duckdb_version }}
       ci_tools_version: main
       extension_name: quack
 
   code-quality-check:
     name: Code Quality Check
+    needs: get-duckdb-version
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
-      duckdb_version: main
+      duckdb_version: ${{ needs.get-duckdb-version.outputs.duckdb_version }}
       ci_tools_version: main
       extension_name: quack
       format_checks: 'format'


### PR DESCRIPTION
## What

CI currently builds against `duckdb_version: main`, so unrelated upstream-main API drift breaks our pipeline on changes that have nothing to do with this repo.

This pins the build to the duckdb commit our submodule actually references, stored in `.github/duckdb-version`:

- New `get-duckdb-version` job reads `.github/duckdb-version` (sparse checkout of `.github`) and exposes it as an output.
- `duckdb-stable-build` and `code-quality-check` now consume that output instead of hardcoding `main`.

The pin is set to `ff62f2bc89a2f899fc18652f4d7a4be2258f8fbd`, matching the `duckdb` submodule commit on `main`. Bump `.github/duckdb-version` in lockstep whenever the submodule is updated.

## Why

Decouples CI stability from upstream duckdb main, so failures reflect real changes in this repo rather than unrelated core API drift.