### PR TITLE
Async, order-preserving batch INSERTs

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -31,6 +31,15 @@ public:
 		return unique_ptr_cast<QuackMessage, TARGET>(std::move(response_message));
 	}
 
+	//! POST already-serialized request bytes and return the raw response body, throwing on transport failure.
+	//! Lets an async sender serialize on a producer thread and perform the blocking POST from the ASYNC pool;
+	//! pass context=nullptr when called off the execution thread (parameters fall back to the database).
+	virtual string PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) = 0;
+
+	//! Emit a Quack request log entry. Safe to call from an async pool thread (uses db-level logger).
+	void LogRequest(MessageType request_type, const string &connection_id, optional_idx client_query_id,
+	                const string &query, int64_t duration_ms, MessageType response_type, const string &error);
+
 	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
@@ -91,9 +100,13 @@ public:
 	HttpsQuackClient(DatabaseInstance &db, const QuackUri &uri_p);
 	~HttpsQuackClient() override;
 
+	string PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) override;
+
 private:
 	unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
 	                                         unique_ptr<QuackMessage> request_message) override;
+	//! POST bytes assuming request_mutex is already held.
+	string PostRawLocked(const_data_ptr_t data, idx_t size);
 
 private:
 	unique_ptr<HTTPParams> http_params;

--- a/src/include/quack_data_stream.hpp
+++ b/src/include/quack_data_stream.hpp
@@ -9,73 +9,83 @@
 
 #include <condition_variable>
 #include <deque>
+#include <map>
 
 namespace duckdb {
 
-struct QuackStreamChunk {
-	unique_ptr<DataChunk> chunk;
-	//! Wire batch index (set by the future async/ordered client). Invalid for the current client,
-	//! in which case the scan assigns a constant batch index.
-	optional_idx batch_index;
-};
-
-//! Bounded, thread-safe queue feeding one server-side scan_data_from_quack_client INSERT. SEND_DATA
-//! handlers push chunks; the table function pops them; the bound backpressures the client.
+//! Thread-safe delivery queue for scan_data_from_quack_client. Producers push complete batches into
+//! ready_batches_; scan tasks claim one batch at a time via TryPopBatch for exclusive ownership.
 class QuackDataStream {
 public:
-	enum class PopStatus : uint8_t {
-		CHUNK,    //! a chunk was dequeued into `out`
-		EMPTY,    //! queue empty, more chunks may still arrive
-		FINISHED, //! queue empty and the stream is finished
-		ERRORED   //! the stream recorded a fatal error
+	enum class PopBatchStatus : uint8_t {
+		BATCH,
+		EMPTY,
+		FINISHED,
+		ERRORED,
 	};
 
-	explicit QuackDataStream(vector<LogicalType> types_p, idx_t capacity_p = 64)
-	    : types(std::move(types_p)), capacity(capacity_p) {
+	explicit QuackDataStream(vector<LogicalType> types_p, bool ordered_p = false)
+	    : types(std::move(types_p)), ordered(ordered_p) {
 	}
 
 	const vector<LogicalType> &Types() const {
 		return types;
 	}
 
-	//! Producer: enqueue a chunk, blocking while the queue is full (until the consumer drains or the
-	//! stream is finished/errored).
-	void Push(unique_ptr<DataChunk> chunk, optional_idx batch_index);
-	//! Producer: signal that no more chunks will arrive.
+	bool IsOrdered() const {
+		return ordered;
+	}
+
+	//! Publish all chunks from one unordered wire message as a single ready batch.
+	void PushUnordered(vector<unique_ptr<DataChunk>> chunks);
+
+	//! Buffer chunks for (batch, seq); drain complete batches to ready_batches_ in order.
+	//! `watermark` seeds the delivery cursor; once started the cursor only advances.
+	void PushOrdered(vector<unique_ptr<DataChunk>> chunks, idx_t batch, idx_t seq, bool is_last,
+	                 optional_idx watermark);
+
+	//! Seed the delivery cursor from FINALIZE if no per-message watermark arrived first.
+	void SetWatermarkAndDrain(optional_idx watermark);
+
 	void Finish();
-	//! Record a fatal error (also unblocks producer and consumer).
 	void SetError(ErrorData error_p);
 	bool HasError();
 	ErrorData GetError();
 
-	//! Consumer: non-blocking dequeue. Fills `out` and returns CHUNK if one is ready; otherwise returns
-	//! EMPTY / FINISHED / ERRORED. Never blocks.
-	PopStatus TryPop(QuackStreamChunk &out);
-	//! Consumer: bounded wait used by the async wait-task. Blocks until a chunk is available, the
-	//! stream is finished/errored, or a short timeout elapses (so the caller can re-check cancellation).
+	//! Atomically claim the next ready batch; moves chunks into chunks_out.
+	PopBatchStatus TryPopBatch(idx_t &batch_idx_out, vector<unique_ptr<DataChunk>> &chunks_out);
+	//! Block until a batch is ready, the stream ends, or a short timeout elapses.
 	void WaitForData();
 
 private:
+	void DrainOrderedBatches() DUCKDB_REQUIRES(lock);
+
 	annotated_mutex lock;
 	std::condition_variable cv_nonempty;
-	std::condition_variable cv_nonfull;
-	std::deque<QuackStreamChunk> queue DUCKDB_GUARDED_BY(lock);
+	std::deque<std::pair<idx_t, vector<unique_ptr<DataChunk>>>> ready_batches_ DUCKDB_GUARDED_BY(lock);
+	//! Monotonic counter for unordered batch indices (ignored by PhysicalInsert, kept for uniformity).
+	idx_t unordered_batch_seq_ DUCKDB_GUARDED_BY(lock) = 0;
 	vector<LogicalType> types;
-	idx_t capacity;
+	bool ordered;
 	bool finished DUCKDB_GUARDED_BY(lock) = false;
 	bool errored DUCKDB_GUARDED_BY(lock) = false;
 	ErrorData error DUCKDB_GUARDED_BY(lock);
+
+	// Ordered assembly state — all guarded by lock.
+	std::map<std::pair<idx_t, idx_t>, vector<unique_ptr<DataChunk>>> ordered_pending DUCKDB_GUARDED_BY(lock);
+	std::map<idx_t, idx_t> last_seq_for_batch DUCKDB_GUARDED_BY(lock);
+	optional_idx next_expected_batch_ DUCKDB_GUARDED_BY(lock);
+	bool any_batch_delivered_ DUCKDB_GUARDED_BY(lock) = false;
 };
 
-//! Process-global registry mapping a stream id to its QuackDataStream, letting the
-//! scan_data_from_quack_client table function find the stream the request handlers created.
+//! Process-global registry: maps stream id → QuackDataStream so the scan function can find it.
 class QuackStreamRegistry {
 public:
 	static QuackStreamRegistry &Get();
 
 	static string MakeId(const string &connection_id, hugeint_t query_uuid);
 
-	shared_ptr<QuackDataStream> Create(const string &id, vector<LogicalType> types);
+	shared_ptr<QuackDataStream> Create(const string &id, vector<LogicalType> types, bool ordered);
 	shared_ptr<QuackDataStream> Find(const string &id);
 	void Erase(const string &id);
 

--- a/src/include/quack_data_stream.hpp
+++ b/src/include/quack_data_stream.hpp
@@ -44,6 +44,10 @@ public:
 	void PushOrdered(vector<unique_ptr<DataChunk>> chunks, idx_t batch, idx_t seq, bool is_last,
 	                 optional_idx watermark);
 
+	//! Record that batches [dead_start, dead_end) are dead (never produced), so the cursor can skip the gap.
+	//! Safe under reordering: recorded, then applied when the cursor reaches it.
+	void PushDeadRange(idx_t dead_start, idx_t dead_end);
+
 	//! Seed the delivery cursor from FINALIZE if no per-message watermark arrived first.
 	void SetWatermarkAndDrain(optional_idx watermark);
 
@@ -76,6 +80,9 @@ private:
 	std::map<idx_t, idx_t> last_seq_for_batch DUCKDB_GUARDED_BY(lock);
 	optional_idx next_expected_batch_ DUCKDB_GUARDED_BY(lock);
 	bool any_batch_delivered_ DUCKDB_GUARDED_BY(lock) = false;
+	//! Dead batch ranges [lo, hi) reported by the client for filtered/pruned gaps the sink never crossed.
+	//! The drain skips the cursor over a covering range instead of waiting for data that never comes.
+	std::map<idx_t, idx_t> dead_ranges DUCKDB_GUARDED_BY(lock);
 };
 
 //! Process-global registry: maps stream id → QuackDataStream so the scan function can find it.

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -7,6 +7,9 @@
 
 namespace duckdb {
 
+//! Quack wire-protocol version. Client and server agree on it during the connection handshake.
+static constexpr idx_t QUACK_VERSION = 2;
+
 enum class MessageType : uint8_t {
 	INVALID = 0,
 	CONNECTION_REQUEST = 1,

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -355,6 +355,7 @@ public:
 	optional_idx BatchWatermark() const {
 		return batch_watermark;
 	}
+
 protected:
 	SendDataRequestMessage() : QuackMessage(TYPE) {
 	}

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -331,6 +331,19 @@ public:
 		batch_watermark = watermark;
 	}
 
+	//! Turn this into a dead-range marker: batches [batch_index, dead_range_end) produced no rows and will
+	//! never arrive. Carries no chunks; batch_index is the (low) range start so it stays near the cursor.
+	void SetDeadRange(idx_t dead_start, idx_t dead_end) {
+		batch_index = optional_idx(dead_start);
+		dead_range_end = optional_idx(dead_end);
+	}
+	bool IsDeadRange() const {
+		return dead_range_end.IsValid();
+	}
+	optional_idx DeadRangeEnd() const {
+		return dead_range_end;
+	}
+
 	vector<unique_ptr<DataChunkWrapper>> &Chunks() {
 		return chunks;
 	}
@@ -371,6 +384,9 @@ private:
 	//! Minimum batch index that will ever appear in this stream; piggybacked on every ordered message so
 	//! the server can initialise its delivery cursor and start draining as soon as batches are complete.
 	optional_idx batch_watermark;
+	//! Set only on dead-range markers: batches [batch_index, dead_range_end) are dead (a filtered/pruned
+	//! gap the sink never crossed). Lets the server skip the gap instead of stalling. Invalid on data messages.
+	optional_idx dead_range_end;
 };
 
 // Success reply to a SendDataRequestMessage. `accept_budget` is a placeholder for a future flow-control

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -305,23 +305,34 @@ private:
 	optional_idx batch_index;
 };
 
-// Streams one DataChunk of insert data to the server, keyed by (connection_id, query_uuid).
-// Answered by SendDataResponseMessage (or ErrorResponse on failure).
+// Streams one or more DataChunks of insert data to the server, keyed by (connection_id, query_uuid).
+// batch_index + sequence_index + is_last_in_batch are set for ordered inserts; invalid batch_index
+// means unordered (arrive and insert in any order). Answered by SendDataResponseMessage or ErrorResponse.
 class SendDataRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::SEND_DATA_REQUEST;
 
 	explicit SendDataRequestMessage(string connection_id_p, string schema_name_p, string table_name_p,
-	                                unique_ptr<DataChunkWrapper> append_chunk_p, hugeint_t query_uuid_p)
+	                                vector<unique_ptr<DataChunkWrapper>> chunks_p, hugeint_t query_uuid_p)
 	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)),
-	      table_name(std::move(table_name_p)), append_chunk(std::move(append_chunk_p)), query_uuid(query_uuid_p) {
+	      table_name(std::move(table_name_p)), chunks(std::move(chunks_p)), query_uuid(query_uuid_p) {
 	}
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<SendDataRequestMessage> Deserialize(Deserializer &deserializer);
 
-	DataChunk &AppendChunk() const {
-		return append_chunk->Chunk();
+	void SetOrdering(optional_idx batch_index_p, idx_t sequence_index_p, bool is_last_in_batch_p) {
+		batch_index = batch_index_p;
+		sequence_index = sequence_index_p;
+		is_last_in_batch = is_last_in_batch_p;
+	}
+
+	void SetBatchWatermark(optional_idx watermark) {
+		batch_watermark = watermark;
+	}
+
+	vector<unique_ptr<DataChunkWrapper>> &Chunks() {
+		return chunks;
 	}
 	const string &SchemaName() const {
 		return schema_name;
@@ -332,7 +343,18 @@ public:
 	hugeint_t QueryUUID() const {
 		return query_uuid;
 	}
-
+	optional_idx BatchIndex() const {
+		return batch_index;
+	}
+	idx_t SequenceIndex() const {
+		return sequence_index;
+	}
+	bool IsLastInBatch() const {
+		return is_last_in_batch;
+	}
+	optional_idx BatchWatermark() const {
+		return batch_watermark;
+	}
 protected:
 	SendDataRequestMessage() : QuackMessage(TYPE) {
 	}
@@ -340,8 +362,14 @@ protected:
 private:
 	string schema_name;
 	string table_name;
-	unique_ptr<DataChunkWrapper> append_chunk;
+	vector<unique_ptr<DataChunkWrapper>> chunks;
 	hugeint_t query_uuid;
+	optional_idx batch_index;
+	idx_t sequence_index = 0;
+	bool is_last_in_batch = false;
+	//! Minimum batch index that will ever appear in this stream; piggybacked on every ordered message so
+	//! the server can initialise its delivery cursor and start draining as soon as batches are complete.
+	optional_idx batch_watermark;
 };
 
 // Success reply to a SendDataRequestMessage. `accept_budget` is a placeholder for a future flow-control
@@ -377,8 +405,14 @@ public:
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<FinalizeMessage> Deserialize(Deserializer &deserializer);
 
+	void SetMinBatchWatermark(optional_idx watermark) {
+		min_batch_watermark = watermark;
+	}
 	hugeint_t QueryUUID() const {
 		return query_uuid;
+	}
+	optional_idx MinBatchWatermark() const {
+		return min_batch_watermark;
 	}
 
 protected:
@@ -387,6 +421,9 @@ protected:
 
 private:
 	hugeint_t query_uuid;
+	//! Minimum batch index in the stream; set when ordered mode was used. Server initialises its delivery
+	//! cursor from this value after all data has been received.
+	optional_idx min_batch_watermark;
 };
 
 class DisconnectMessage : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -143,6 +143,12 @@
         "name": "batch_watermark",
         "type": "optional_idx",
         "default": "optional_idx()"
+      },
+      {
+        "id": 9,
+        "name": "dead_range_end",
+        "type": "optional_idx",
+        "default": "optional_idx()"
       }
     ]
   },

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -43,6 +43,11 @@
         "id": 1,
         "name": "sql_query",
         "type": "string"
+      },
+      {
+        "id": 2,
+        "name": "query_uuid",
+        "type": "hugeint_t"
       }
     ]
   },
@@ -89,11 +94,11 @@
       },
       {
         "id": 5,
-        "name": "result_uuid",
+        "name": "query_uuid",
         "type": "hugeint_t"
       }
     ],
-    "constructor": ["result_types", "result_names",  "results", "needs_more_fetch", "result_uuid"]
+    "constructor": ["result_types", "result_names",  "results", "needs_more_fetch", "query_uuid"]
   },
   {
     "class": "SendDataRequestMessage",
@@ -110,13 +115,34 @@
       },
       {
         "id": 3,
-        "name": "append_chunk",
-        "type": "unique_ptr<DataChunkWrapper>"
+        "name": "chunks",
+        "type": "vector<unique_ptr<DataChunkWrapper>>"
       },
       {
         "id": 4,
         "name": "query_uuid",
         "type": "hugeint_t"
+      },
+      {
+        "id": 5,
+        "name": "batch_index",
+        "type": "optional_idx"
+      },
+      {
+        "id": 6,
+        "name": "sequence_index",
+        "type": "idx_t"
+      },
+      {
+        "id": 7,
+        "name": "is_last_in_batch",
+        "type": "bool"
+      },
+      {
+        "id": 8,
+        "name": "batch_watermark",
+        "type": "optional_idx",
+        "default": "optional_idx()"
       }
     ]
   },
@@ -137,6 +163,12 @@
         "id": 1,
         "name": "query_uuid",
         "type": "hugeint_t"
+      },
+      {
+        "id": 2,
+        "name": "min_batch_watermark",
+        "type": "optional_idx",
+        "default": "optional_idx()"
       }
     ]
   },
@@ -152,6 +184,16 @@
         "id": 2,
         "name": "batch_index",
         "type": "optional_idx"
+      }
+    ]
+  },
+  {
+    "class": "CancelRequestMessage",
+    "members": [
+      {
+        "id": 1,
+        "name": "query_uuid",
+        "type": "hugeint_t"
       }
     ]
   },
@@ -206,4 +248,3 @@
     ]
   }
 ]
-

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -48,6 +48,10 @@ struct QuackConnection {
 	shared_ptr<QuackDataStream> insert_stream DUCKDB_GUARDED_BY(insert_lifecycle_lock);
 	std::thread insert_thread DUCKDB_GUARDED_BY(insert_lifecycle_lock);
 	string insert_stream_id DUCKDB_GUARDED_BY(insert_lifecycle_lock);
+	//! Dead-range markers that arrived (via async reordering) before the stream-creating data message.
+	//! Applied to the stream once it is created. Keyed by `pending_dead_range_stream_id`.
+	string pending_dead_range_stream_id DUCKDB_GUARDED_BY(insert_lifecycle_lock);
+	vector<std::pair<idx_t, idx_t>> pending_dead_ranges DUCKDB_GUARDED_BY(insert_lifecycle_lock);
 };
 
 struct QuackConnectionSnapshot {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
@@ -23,8 +24,42 @@ class DatabaseInstance;
 class PreparedStatement;
 class EncryptionState;
 class QuackDataStream;
+class ErrorData;
 
 enum class QuackQueryState : uint8_t { IDLE, ACTIVE, FINISHED, CANCELLED, QUACK_ERROR };
+
+//! An insert stream + its driver thread, taken off a connection so finish/join can run unlocked.
+struct DetachedInsertStream {
+	shared_ptr<QuackDataStream> stream;
+	std::thread thread;
+	string id;
+	//! Finish + join + deregister; returns any INSERT error. Call WITHOUT a lock held.
+	ErrorData FinishAndJoin();
+	//! Roll the INSERT back (SetError) + join + deregister. Call WITHOUT a lock held.
+	void AbortAndJoin(const string &reason);
+};
+
+//! Server-side state for the INSERT a client is currently driving via a SEND_DATA stream on this
+//! connection (one at a time). `lock` is held only briefly — never across a Push or a join.
+struct QuackInsertState {
+	annotated_mutex lock;
+	shared_ptr<QuackDataStream> stream DUCKDB_GUARDED_BY(lock);
+	std::thread thread DUCKDB_GUARDED_BY(lock);
+	string stream_id DUCKDB_GUARDED_BY(lock);
+	//! Dead-range markers that arrived before the stream-creating data message, tagged with the stream
+	//! they belong to; applied once that stream is created.
+	string pending_marker_stream_id DUCKDB_GUARDED_BY(lock);
+	vector<std::pair<idx_t, idx_t>> pending_dead_ranges DUCKDB_GUARDED_BY(lock);
+
+	//! Take the active stream/thread/id off (briefly under the lock) for an unlocked finish/abort.
+	DetachedInsertStream Detach();
+	//! Detach only if the active stream is unrelated to `msg_stream_id` (else return an empty detach).
+	DetachedInsertStream DetachIfUnrelated(const string &msg_stream_id);
+	//! Detach + drain (`watermark`) + finish + join; returns any INSERT error. Empty if none active.
+	ErrorData Finalize(optional_idx watermark = optional_idx());
+	//! Active stream if it matches `sid` (caller pushes the range), else buffer the range and return null.
+	shared_ptr<QuackDataStream> StreamForDeadRangeOrBuffer(const string &sid, idx_t lo, idx_t hi);
+};
 
 struct QuackConnection {
 	explicit QuackConnection(string session_id_p);
@@ -42,16 +77,8 @@ struct QuackConnection {
 	QuackQueryState query_state = QuackQueryState::IDLE;
 	timestamp_t query_started_at {0};
 
-	//! Per-connection SEND_DATA stream + background INSERT thread (keyed by `insert_stream_id`).
-	//! The lock is held only briefly — never across a Push or a join.
-	annotated_mutex insert_lifecycle_lock;
-	shared_ptr<QuackDataStream> insert_stream DUCKDB_GUARDED_BY(insert_lifecycle_lock);
-	std::thread insert_thread DUCKDB_GUARDED_BY(insert_lifecycle_lock);
-	string insert_stream_id DUCKDB_GUARDED_BY(insert_lifecycle_lock);
-	//! Dead-range markers that arrived (via async reordering) before the stream-creating data message.
-	//! Applied to the stream once it is created. Keyed by `pending_dead_range_stream_id`.
-	string pending_dead_range_stream_id DUCKDB_GUARDED_BY(insert_lifecycle_lock);
-	vector<std::pair<idx_t, idx_t>> pending_dead_ranges DUCKDB_GUARDED_BY(insert_lifecycle_lock);
+	//! The INSERT this connection is currently driving via a client SEND_DATA stream (one at a time).
+	QuackInsertState insert;
 };
 
 struct QuackConnectionSnapshot {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -93,9 +93,6 @@ enum class QuackServerState { UNINITIALIZED, WAITING_TO_START, RUNNING, CLOSED }
 
 class QuackServer {
 public:
-	static constexpr const idx_t QUACK_VERSION = 2;
-
-public:
 	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
 	virtual ~QuackServer();
 

--- a/src/include/storage/quack_insert.hpp
+++ b/src/include/storage/quack_insert.hpp
@@ -13,6 +13,14 @@
 
 namespace duckdb {
 
+//! How an INSERT preserves source order when uploading rows to the server.
+enum class AppendOrderMode : uint8_t {
+	UNORDERED,        //! preserve_insertion_order=false → fast path, no stamp.
+	PARALLEL_ORDERED, //! parallel thread executors (table/parquet scans); each thread stamps chunks with
+	                  //! (executor batch_index, sequence_index, is_last_in_batch); server reorders.
+	SERIAL_ORDERED    //! single-threaded sink (e.g. range()); the lone producer mints a new batch per flush.
+};
+
 class QuackInsert : public PhysicalOperator {
 public:
 	//! INSERT INTO
@@ -28,6 +36,9 @@ public:
 	//! Create table info, in case of CREATE TABLE AS
 	unique_ptr<BoundCreateTableInfo> info;
 
+	//! Ordering strategy, set at plan time.
+	AppendOrderMode order_mode = AppendOrderMode::UNORDERED;
+
 protected:
 	// Source interface
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
@@ -36,9 +47,12 @@ protected:
 public:
 	// Sink interface
 	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
 	                          OperatorSinkFinalizeInput &input) const override;
+	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override;
 
 	bool IsSource() const override {
 		return true;
@@ -49,7 +63,14 @@ public:
 	}
 
 	bool ParallelSink() const override {
-		return false;
+		return order_mode != AppendOrderMode::SERIAL_ORDERED;
+	}
+
+	//! Request executor batch indices only for PARALLEL_ORDERED, so the executor's assertion never fires for
+	//! sources that don't supply a batch index.
+	OperatorPartitionInfo RequiredPartitionInfo() const override {
+		return order_mode == AppendOrderMode::PARALLEL_ORDERED ? OperatorPartitionInfo(/*batch_index=*/true)
+		                                                       : OperatorPartitionInfo();
 	}
 
 	string GetName() const override;

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -221,6 +221,11 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	// submit the connection request
 	auto connection_request_response =
 	    client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
+	// Validate the server's selected protocol version before trusting the connection (client speaks QUACK_VERSION).
+	if (connection_request_response->QuackVersion() != QUACK_VERSION) {
+		throw IOException("Incompatible Quack protocol version: server uses %llu, client supports %llu",
+		                  connection_request_response->QuackVersion(), QUACK_VERSION);
+	}
 	// success! we got a connection id
 	auto connection_id = connection_request_response->ConnectionId();
 	idx_t pool_size = MaxValue<idx_t>(1, (idx_t)TaskScheduler::GetScheduler(context).NumberOfAsyncThreads());

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -34,14 +34,13 @@ QuackClient::~QuackClient() {
 // TODO: This is not very clean, but I do think that for async IO we need
 // decoupling of requests from serialization
 void QuackClient::LogRequest(MessageType request_type, const string &connection_id, optional_idx client_query_id,
-                              const string &query, int64_t duration_ms, MessageType response_type,
-                              const string &error) {
+                             const string &query, int64_t duration_ms, MessageType response_type, const string &error) {
 	auto &logger = Logger::Get(db);
 	if (!logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
 		return;
 	}
 	auto msg = QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.Http(),
-	                                              duration_ms, response_type, error);
+	                                             duration_ms, response_type, error);
 	logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 }
 
@@ -159,9 +158,9 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		// Use context-level logger when available for per-query log attribution; fall back to db-level.
 		auto &logger = context ? Logger::Get(*context) : Logger::Get(db);
 		if (logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
-			auto msg = QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query,
-			                                              uri.Http(), end_time - start_time, response_message->Type(),
-			                                              error);
+			auto msg =
+			    QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.Http(),
+			                                      end_time - start_time, response_message->Type(), error);
 			logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 		}
 	}

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 #include "quack_client.hpp"
 #include "quack_uri.hpp"
@@ -30,9 +31,57 @@ QuackClient::QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_
 QuackClient::~QuackClient() {
 }
 
+// TODO: This is not very clean, but I do think that for async IO we need
+// decoupling of requests from serialization
+void QuackClient::LogRequest(MessageType request_type, const string &connection_id, optional_idx client_query_id,
+                              const string &query, int64_t duration_ms, MessageType response_type,
+                              const string &error) {
+	auto &logger = Logger::Get(db);
+	if (!logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
+		return;
+	}
+	auto msg = QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.Http(),
+	                                              duration_ms, response_type, error);
+	logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
+}
+
 HttpsQuackClient::HttpsQuackClient(DatabaseInstance &db, const QuackUri &uri_p) : QuackClient(db, uri_p) {};
 
 HttpsQuackClient::~HttpsQuackClient() {
+}
+
+string HttpsQuackClient::PostRawLocked(const_data_ptr_t data, idx_t size) {
+	D_ASSERT(http_params);
+	auto &http_util = HTTPUtil::Get(db);
+	auto request_url = uri.Http() + "/quack";
+	HTTPHeaders headers;
+	PostRequestInfo post_request(request_url, headers, *http_params, data, size);
+	unique_ptr<HTTPResponse> response;
+	try {
+		response = http_util.Request(post_request);
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		throw IOException("Failed to send message: %s", error.Message());
+	}
+	if (!response || !response->Success()) {
+		string error = response ? response->GetError() : "no response";
+		throw IOException("Failed to send message: %s", error);
+	}
+	return std::move(post_request.buffer_out);
+}
+
+string HttpsQuackClient::PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) {
+	lock_guard<mutex> guard(request_mutex);
+	if (!http_params) {
+		auto &http_util = HTTPUtil::Get(db);
+		auto request_url = uri.Http() + "/quack";
+		if (context && context->transaction.HasActiveTransaction()) {
+			http_params = http_util.InitializeParameters(*context, request_url);
+		} else {
+			http_params = http_util.InitializeParameters(db, request_url);
+		}
+	}
+	return PostRawLocked(data, size);
 }
 
 unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientContext> context,
@@ -51,8 +100,6 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		}
 	}
 
-	HTTPHeaders headers;
-
 	// Inject client_query_id from context into the message before sending.
 	// Guard against reading the active query during transaction start itself
 	// (e.g. BEGIN TRANSACTION via QuackCatalog::ExecuteCommand), where the
@@ -66,28 +113,14 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		}
 	}
 
-	request_message->ToMemoryStream(write_stream);
-	PostRequestInfo post_request(request_url, headers, *http_params, write_stream.GetData(),
-	                             write_stream.GetPosition());
-	unique_ptr<HTTPResponse> response;
-
-	// Time the request
 	int64_t start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 	                         .time_since_epoch()
 	                         .count();
 
-	try {
-		response = http_util.Request(post_request);
-	} catch (std::exception &ex) {
-		ErrorData error(ex);
-		throw IOException("Failed to send message: %s", error.Message());
-	}
-	if (!response || !response->Success()) {
-		string error = response ? response->GetError() : "no response";
-		throw IOException("Failed to send message: %s", error);
-	}
+	request_message->ToMemoryStream(write_stream);
+	auto buffer_out = PostRawLocked(write_stream.GetData(), write_stream.GetPosition());
 
-	MemoryStream non_owning_read_stream((data_ptr_t)post_request.buffer_out.data(), post_request.buffer_out.size());
+	MemoryStream non_owning_read_stream((data_ptr_t)buffer_out.data(), buffer_out.size());
 	auto response_message = QuackMessage::FromMemoryStream(non_owning_read_stream);
 
 	// logging stuff, own scope
@@ -99,7 +132,6 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		auto request_type = request_message->Type();
 		string connection_id;
 		string query;
-		optional_idx client_query_id;
 		switch (request_type) {
 		case MessageType::PREPARE_REQUEST: {
 			auto &msg = request_message->Cast<PrepareRequestMessage>();
@@ -120,16 +152,16 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 			break;
 		}
 
-		// Log RPC message
+		string error;
+		if (response_message->Type() == MessageType::ERROR_RESPONSE) {
+			error = response_message->Cast<ErrorResponse>().ErrorMessage();
+		}
+		// Use context-level logger when available for per-query log attribution; fall back to db-level.
 		auto &logger = context ? Logger::Get(*context) : Logger::Get(db);
 		if (logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
-			string error;
-			if (response_message->Type() == MessageType::ERROR_RESPONSE) {
-				error = response_message->Cast<ErrorResponse>().ErrorMessage();
-			}
-			auto msg =
-			    QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.Http(),
-			                                      end_time - start_time, response_message->Type(), error);
+			auto msg = QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query,
+			                                              uri.Http(), end_time - start_time, response_message->Type(),
+			                                              error);
 			logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 		}
 	}
@@ -191,9 +223,9 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	auto connection_request_response =
 	    client->Request<ConnectionResponseMessage>(context, make_uniq<ConnectionRequestMessage>(token));
 	// success! we got a connection id
-	// construct the client connection and return it
 	auto connection_id = connection_request_response->ConnectionId();
-	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id));
+	idx_t pool_size = MaxValue<idx_t>(1, (idx_t)TaskScheduler::GetScheduler(context).NumberOfAsyncThreads());
+	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id), pool_size);
 }
 
 unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &context) const {

--- a/src/quack_data_stream.cpp
+++ b/src/quack_data_stream.cpp
@@ -6,22 +6,82 @@
 
 namespace duckdb {
 
-void QuackDataStream::Push(unique_ptr<DataChunk> chunk, optional_idx batch_index) {
-	annotated_unique_lock<annotated_mutex> guard(lock);
-	// Wait while the queue is full (unless the stream ended). Written as an explicit loop rather than a
-	// cv predicate lambda so the guarded fields are read under `guard`, where the analysis can see it.
-	while (queue.size() >= capacity && !finished && !errored) {
-		cv_nonfull.wait(guard);
+void QuackDataStream::PushUnordered(vector<unique_ptr<DataChunk>> chunks) {
+	{
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (finished || errored) {
+			return;
+		}
+		ready_batches_.push_back({unordered_batch_seq_++, std::move(chunks)});
 	}
-	if (finished || errored) {
-		// Consumer is gone or the statement failed - drop the chunk; the error is surfaced elsewhere.
+	cv_nonempty.notify_one();
+}
+
+void QuackDataStream::PushOrdered(vector<unique_ptr<DataChunk>> chunks, idx_t batch, idx_t seq, bool is_last,
+                                  optional_idx watermark) {
+	annotated_unique_lock<annotated_mutex> guard(lock);
+	// Only lower the cursor before delivery starts; once started it must never retreat.
+	if (watermark.IsValid()) {
+		if (!next_expected_batch_.IsValid()) {
+			next_expected_batch_ = watermark;
+		} else if (!any_batch_delivered_ && watermark.GetIndex() < next_expected_batch_.GetIndex()) {
+			next_expected_batch_ = watermark;
+		}
+	}
+	if (is_last) {
+		last_seq_for_batch[batch] = seq;
+	}
+	// Always insert — zero-chunk is_last messages must be recorded so the drain loop can account for them.
+	ordered_pending[{batch, seq}] = std::move(chunks);
+	DrainOrderedBatches();
+}
+
+void QuackDataStream::SetWatermarkAndDrain(optional_idx watermark) {
+	annotated_unique_lock<annotated_mutex> guard(lock);
+	if (watermark.IsValid() && !next_expected_batch_.IsValid()) {
+		next_expected_batch_ = watermark;
+		DrainOrderedBatches();
+	}
+}
+
+void QuackDataStream::DrainOrderedBatches() {
+	if (!next_expected_batch_.IsValid()) {
 		return;
 	}
-	QuackStreamChunk entry;
-	entry.chunk = std::move(chunk);
-	entry.batch_index = batch_index;
-	queue.push_back(std::move(entry));
-	cv_nonempty.notify_one();
+	while (true) {
+		idx_t expected = next_expected_batch_.GetIndex();
+
+		auto last_seq_it = last_seq_for_batch.find(expected);
+		if (last_seq_it == last_seq_for_batch.end()) {
+			break;
+		}
+		idx_t last_seq = last_seq_it->second;
+
+		bool all_seqs_present = true;
+		for (idx_t seq = 0; seq <= last_seq; seq++) {
+			if (ordered_pending.find({expected, seq}) == ordered_pending.end()) {
+				all_seqs_present = false;
+				break;
+			}
+		}
+		if (!all_seqs_present) {
+			break;
+		}
+
+		vector<unique_ptr<DataChunk>> batch_chunks;
+		for (idx_t seq = 0; seq <= last_seq; seq++) {
+			auto it = ordered_pending.find({expected, seq});
+			for (auto &chunk : it->second) {
+				batch_chunks.push_back(std::move(chunk));
+			}
+			ordered_pending.erase(it);
+		}
+		last_seq_for_batch.erase(last_seq_it);
+		any_batch_delivered_ = true;
+		ready_batches_.push_back({expected, std::move(batch_chunks)});
+		next_expected_batch_ = optional_idx(expected + 1);
+		cv_nonempty.notify_all();
+	}
 }
 
 void QuackDataStream::Finish() {
@@ -30,7 +90,6 @@ void QuackDataStream::Finish() {
 		finished = true;
 	}
 	cv_nonempty.notify_all();
-	cv_nonfull.notify_all();
 }
 
 void QuackDataStream::SetError(ErrorData error_p) {
@@ -43,7 +102,6 @@ void QuackDataStream::SetError(ErrorData error_p) {
 		finished = true;
 	}
 	cv_nonempty.notify_all();
-	cv_nonfull.notify_all();
 }
 
 bool QuackDataStream::HasError() {
@@ -56,29 +114,30 @@ ErrorData QuackDataStream::GetError() {
 	return error;
 }
 
-QuackDataStream::PopStatus QuackDataStream::TryPop(QuackStreamChunk &out) {
+QuackDataStream::PopBatchStatus QuackDataStream::TryPopBatch(idx_t &batch_idx_out,
+                                                             vector<unique_ptr<DataChunk>> &chunks_out) {
 	annotated_lock_guard<annotated_mutex> guard(lock);
 	if (errored) {
-		return PopStatus::ERRORED;
+		return PopBatchStatus::ERRORED;
 	}
-	if (!queue.empty()) {
-		out = std::move(queue.front());
-		queue.pop_front();
-		cv_nonfull.notify_one();
-		return PopStatus::CHUNK;
+	if (!ready_batches_.empty()) {
+		batch_idx_out = ready_batches_.front().first;
+		chunks_out = std::move(ready_batches_.front().second);
+		ready_batches_.pop_front();
+		return PopBatchStatus::BATCH;
 	}
 	if (finished) {
-		return PopStatus::FINISHED;
+		return PopBatchStatus::FINISHED;
 	}
-	return PopStatus::EMPTY;
+	return PopBatchStatus::EMPTY;
 }
 
 void QuackDataStream::WaitForData() {
 	annotated_unique_lock<annotated_mutex> guard(lock);
-	if (!queue.empty() || finished || errored) {
+	if (!ready_batches_.empty() || finished || errored) {
 		return;
 	}
-	// Bounded wait: woken by Push/Finish/SetError, else times out so the scan can re-check cancellation.
+	// Bounded wait so the scan can re-check cancellation even if no batch arrives.
 	cv_nonempty.wait_for(guard, std::chrono::milliseconds(200));
 }
 
@@ -91,8 +150,8 @@ string QuackStreamRegistry::MakeId(const string &connection_id, hugeint_t query_
 	return connection_id + ":" + UUID::ToString(query_uuid);
 }
 
-shared_ptr<QuackDataStream> QuackStreamRegistry::Create(const string &id, vector<LogicalType> types) {
-	auto stream = make_shared_ptr<QuackDataStream>(std::move(types));
+shared_ptr<QuackDataStream> QuackStreamRegistry::Create(const string &id, vector<LogicalType> types, bool ordered) {
+	auto stream = make_shared_ptr<QuackDataStream>(std::move(types), ordered);
 	annotated_lock_guard<annotated_mutex> guard(lock);
 	streams[id] = stream;
 	return stream;

--- a/src/quack_data_stream.cpp
+++ b/src/quack_data_stream.cpp
@@ -44,6 +44,17 @@ void QuackDataStream::SetWatermarkAndDrain(optional_idx watermark) {
 	}
 }
 
+void QuackDataStream::PushDeadRange(idx_t dead_start, idx_t dead_end) {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	if (finished || errored) {
+		return;
+	}
+	if (dead_end > dead_start) {
+		dead_ranges[dead_start] = dead_end;
+	}
+	DrainOrderedBatches();
+}
+
 void QuackDataStream::DrainOrderedBatches() {
 	if (!next_expected_batch_.IsValid()) {
 		return;
@@ -52,35 +63,51 @@ void QuackDataStream::DrainOrderedBatches() {
 		idx_t expected = next_expected_batch_.GetIndex();
 
 		auto last_seq_it = last_seq_for_batch.find(expected);
-		if (last_seq_it == last_seq_for_batch.end()) {
-			break;
-		}
-		idx_t last_seq = last_seq_it->second;
+		if (last_seq_it != last_seq_for_batch.end()) {
+			idx_t last_seq = last_seq_it->second;
 
-		bool all_seqs_present = true;
-		for (idx_t seq = 0; seq <= last_seq; seq++) {
-			if (ordered_pending.find({expected, seq}) == ordered_pending.end()) {
-				all_seqs_present = false;
+			bool all_seqs_present = true;
+			for (idx_t seq = 0; seq <= last_seq; seq++) {
+				if (ordered_pending.find({expected, seq}) == ordered_pending.end()) {
+					all_seqs_present = false;
+					break;
+				}
+			}
+			if (!all_seqs_present) {
 				break;
 			}
-		}
-		if (!all_seqs_present) {
-			break;
+
+			vector<unique_ptr<DataChunk>> batch_chunks;
+			for (idx_t seq = 0; seq <= last_seq; seq++) {
+				auto it = ordered_pending.find({expected, seq});
+				for (auto &chunk : it->second) {
+					batch_chunks.push_back(std::move(chunk));
+				}
+				ordered_pending.erase(it);
+			}
+			last_seq_for_batch.erase(last_seq_it);
+			any_batch_delivered_ = true;
+			ready_batches_.push_back({expected, std::move(batch_chunks)});
+			next_expected_batch_ = optional_idx(expected + 1);
+			cv_nonempty.notify_all();
+			continue;
 		}
 
-		vector<unique_ptr<DataChunk>> batch_chunks;
-		for (idx_t seq = 0; seq <= last_seq; seq++) {
-			auto it = ordered_pending.find({expected, seq});
-			for (auto &chunk : it->second) {
-				batch_chunks.push_back(std::move(chunk));
+		// No data for `expected`. If it falls inside a client-reported dead range, skip the whole gap;
+		// otherwise it may still be in flight, so wait.
+		if (!dead_ranges.empty()) {
+			auto dr = dead_ranges.upper_bound(expected); // first range starting after `expected`
+			if (dr != dead_ranges.begin()) {
+				--dr; // range with lo <= expected
+				if (dr->second > expected) {
+					any_batch_delivered_ = true; // cursor is committed; it must never retreat
+					next_expected_batch_ = optional_idx(dr->second);
+					dead_ranges.erase(dr);
+					continue;
+				}
 			}
-			ordered_pending.erase(it);
 		}
-		last_seq_for_batch.erase(last_seq_it);
-		any_batch_delivered_ = true;
-		ready_batches_.push_back({expected, std::move(batch_chunks)});
-		next_expected_batch_ = optional_idx(expected + 1);
-		cv_nonempty.notify_all();
+		break;
 	}
 }
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -173,6 +173,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_fetch_batch_chunks", "Maximum number of DataChunks returned per FETCH response",
 	                          LogicalType::UBIGINT, Value::UBIGINT(12));
 
+	config.AddExtensionOption("quack_send_data_flush_rows",
+	                          "Rows a thread buffers before flushing one SEND_DATA_REQUEST (0 = default 204800)",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+
 	// Process-wide fallback anchor for whoami().uptime when whoami_started_at isn't set.
 	// Stored as BIGINT epoch-microseconds to stay TZ-invariant regardless of ICU state.
 	config.AddExtensionOption("quack_loaded_at_us", "Epoch microseconds at extension load", LogicalType::BIGINT,

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -5,7 +5,6 @@
 
 #include "quack_message.hpp"
 
-#include "quack_server.hpp"
 #include "duckdb/main/database.hpp"
 
 namespace duckdb {
@@ -171,13 +170,13 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 
 ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p)
     : QuackMessage(TYPE), auth_string(auth_string_p), client_duckdb_version(DuckDB::LibraryVersion()),
-      client_platform(DuckDB::Platform()), min_supported_quack_version(QuackServer::QUACK_VERSION),
-      max_supported_quack_version(QuackServer::QUACK_VERSION) {
+      client_platform(DuckDB::Platform()), min_supported_quack_version(QUACK_VERSION),
+      max_supported_quack_version(QUACK_VERSION) {
 }
 
 ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p)
     : QuackMessage(TYPE, std::move(connection_id_p)), server_duckdb_version(DuckDB::LibraryVersion()),
-      server_platform(DuckDB::Platform()), quack_version(QuackServer::QUACK_VERSION) {
+      server_platform(DuckDB::Platform()), quack_version(QUACK_VERSION) {
 }
 
 unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_stream) {

--- a/src/quack_scan_from_client.cpp
+++ b/src/quack_scan_from_client.cpp
@@ -1,19 +1,17 @@
 #include "quack_scan_from_client.hpp"
 
+#include "duckdb/common/enums/order_preservation_type.hpp"
 #include "duckdb/common/enums/task_scheduler_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/partition_info.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/async_result.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 #include "quack_data_stream.hpp"
 
 namespace duckdb {
 
-//! Async wait used when the stream has no chunk yet but is not finished: the scan returns BLOCKED
-//! with this task, the executor parks the pipeline thread and runs the task on the ASYNC pool, and
-//! reschedules the scan once the task completes (a chunk arrived, the stream finished, or the bounded
-//! wait timed out).
 class QuackWaitForChunkTask : public AsyncTask {
 public:
 	explicit QuackWaitForChunkTask(shared_ptr<QuackDataStream> stream_p) : stream(std::move(stream_p)) {
@@ -45,18 +43,17 @@ struct QuackScanFromClientBindData : public FunctionData {
 };
 
 struct QuackScanFromClientGlobalState : public GlobalTableFunctionState {
-	//! Single consumer: this matches the synchronous client and avoids multi-consumer coordination.
-	//! PhysicalBatchInsert is still selected because use_batch_index only needs the global scheduler
-	//! to have >1 thread plus a source that advertises batch-index partitioning (get_partition_data).
+	idx_t num_threads = 1;
 	idx_t MaxThreads() const override {
-		return 1;
+		return num_threads;
 	}
 };
 
 struct QuackScanFromClientLocalState : public LocalTableFunctionState {
 	idx_t current_batch_index = 0;
-	//! Holds the chunk currently referenced by the scan output, keeping it alive until the next call.
-	QuackStreamChunk current;
+	vector<unique_ptr<DataChunk>> batch_buffer;
+	size_t batch_pos = 0;
+	unique_ptr<DataChunk> current_chunk; // keeps the referenced chunk alive between scan calls
 };
 
 static unique_ptr<FunctionData> QuackScanFromClientBind(ClientContext &context, TableFunctionBindInput &input,
@@ -67,6 +64,12 @@ static unique_ptr<FunctionData> QuackScanFromClientBind(ClientContext &context, 
 		throw InvalidInputException("scan_data_from_quack_client: no active stream '%s' (this is an internal "
 		                            "function driven by the quack server)",
 		                            stream_id);
+	}
+
+	// Unordered streams signal NO_ORDER so the planner picks PhysicalInsert(parallel=true) instead of
+	// PhysicalBatchInsert. Mutates a query-scoped by-value copy — never touches the global catalog entry.
+	if (!stream->IsOrdered()) {
+		input.table_function.order_preservation_type = OrderPreservationType::NO_ORDER;
 	}
 
 	auto bind_data = make_uniq<QuackScanFromClientBindData>();
@@ -83,7 +86,9 @@ static unique_ptr<FunctionData> QuackScanFromClientBind(ClientContext &context, 
 
 static unique_ptr<GlobalTableFunctionState> QuackScanFromClientInitGlobal(ClientContext &context,
                                                                           TableFunctionInitInput &input) {
-	return make_uniq<QuackScanFromClientGlobalState>();
+	auto state = make_uniq<QuackScanFromClientGlobalState>();
+	state->num_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	return std::move(state);
 }
 
 static unique_ptr<LocalTableFunctionState>
@@ -96,44 +101,43 @@ static void QuackScanFromClient(ClientContext &context, TableFunctionInput &inpu
 	auto &local_state = input.local_state->Cast<QuackScanFromClientLocalState>();
 	auto &stream = *bind_data.stream;
 
-	// Re-entry point after a BLOCKED reschedule (or each synchronous retry): observe cancellation.
 	if (context.IsInterrupted()) {
 		throw InterruptException();
 	}
 
 	while (true) {
-		QuackStreamChunk entry;
-		switch (stream.TryPop(entry)) {
-		case QuackDataStream::PopStatus::CHUNK:
-			// Use the wire batch index if the (future async) client supplied one; otherwise a constant
-			// index keeps all chunks in one PhysicalBatchInsert collection.
-			local_state.current_batch_index = entry.batch_index.IsValid() ? entry.batch_index.GetIndex() : 0;
-			// Keep the chunk alive while `output` references it (until the next scan call).
-			local_state.current = std::move(entry);
-			output.Reference(*local_state.current.chunk);
+		if (local_state.batch_pos < local_state.batch_buffer.size()) {
+			local_state.current_chunk = std::move(local_state.batch_buffer[local_state.batch_pos++]);
+			output.Reference(*local_state.current_chunk);
 			return;
-		case QuackDataStream::PopStatus::FINISHED:
+		}
+		local_state.batch_buffer.clear();
+		local_state.batch_pos = 0;
+		idx_t batch_idx;
+		switch (stream.TryPopBatch(batch_idx, local_state.batch_buffer)) {
+		case QuackDataStream::PopBatchStatus::BATCH:
+			local_state.current_batch_index = batch_idx;
+			continue;
+		case QuackDataStream::PopBatchStatus::FINISHED:
 			output.SetCardinality(0);
 			return;
-		case QuackDataStream::PopStatus::ERRORED:
+		case QuackDataStream::PopBatchStatus::ERRORED:
 			stream.GetError().Throw();
-			return; // unreachable
-		case QuackDataStream::PopStatus::EMPTY: {
-			// No data yet but the stream isn't finished: hand off a wait task on the ASYNC pool.
+			return;
+		case QuackDataStream::PopBatchStatus::EMPTY: {
 			vector<unique_ptr<AsyncTask>> tasks;
 			tasks.push_back(make_uniq<QuackWaitForChunkTask>(bind_data.stream));
 			AsyncResult res(std::move(tasks), TaskSchedulerType::ASYNC);
 			if (input.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {
-				// Park the pipeline thread; the executor reschedules this scan when the task completes.
 				input.async_result = std::move(res);
 				return;
 			}
-			// SYNCHRONOUS mode (e.g. async_threads=0): run the wait inline, then retry.
+			// Synchronous fallback (async_threads=0): run the wait inline, then retry.
 			res.ExecuteTasksSynchronously();
 			if (context.IsInterrupted()) {
 				throw InterruptException();
 			}
-			break; // retry TryPop
+			break;
 		}
 		}
 	}
@@ -148,7 +152,6 @@ static OperatorPartitionData QuackScanFromClientGetPartitionData(ClientContext &
 TableFunction QuackScanFromClientFunction::GetFunction() {
 	TableFunction fun("scan_data_from_quack_client", {LogicalType::VARCHAR}, QuackScanFromClient,
 	                  QuackScanFromClientBind, QuackScanFromClientInitGlobal, QuackScanFromClientInitLocal);
-	// Advertise batch-index partitioning so the planner selects PhysicalBatchInsert.
 	fun.get_partition_data = QuackScanFromClientGetPartitionData;
 	return fun;
 }

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -19,58 +19,85 @@ namespace duckdb {
 QuackConnection::QuackConnection(string session_id_p) : session_id(std::move(session_id_p)) {
 }
 
-//! An insert stream + its driver thread, taken off a connection so finish/join can run unlocked.
-struct DetachedInsertStream {
-	shared_ptr<QuackDataStream> stream;
-	std::thread thread;
-	string id;
-};
-
-//! Atomically take the connection's active insert stream/thread/id, briefly under the lifecycle lock.
-static DetachedInsertStream DetachInsertStream(QuackConnection &connection) {
-	annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
-	DetachedInsertStream detached;
-	detached.stream = std::move(connection.insert_stream);
-	detached.thread = std::move(connection.insert_thread);
-	detached.id = std::move(connection.insert_stream_id);
-	connection.insert_stream.reset();
-	connection.insert_stream_id.clear();
-	return detached;
-}
-
-//! Commit a detached stream (Finish) + join, returning any INSERT error. Call WITHOUT the lock held.
-static ErrorData FinalizeDetached(DetachedInsertStream &detached) {
+//! Finish + join + deregister a detached insert stream; returns any INSERT error. Call WITHOUT the lock.
+ErrorData DetachedInsertStream::FinishAndJoin() {
 	ErrorData error;
-	if (!detached.stream) {
+	if (!stream) {
 		return error;
 	}
-	detached.stream->Finish();
-	if (detached.thread.joinable()) {
-		detached.thread.join();
+	stream->Finish();
+	if (thread.joinable()) {
+		thread.join();
 	}
-	if (detached.stream->HasError()) {
-		error = detached.stream->GetError();
+	if (stream->HasError()) {
+		error = stream->GetError();
 	}
-	QuackStreamRegistry::Get().Erase(detached.id);
+	QuackStreamRegistry::Get().Erase(id);
 	return error;
 }
 
-//! Abort a detached stream (roll the INSERT back) + join. Call WITHOUT the lock held.
-static void AbortDetached(DetachedInsertStream &detached, const string &reason) {
-	if (!detached.stream) {
+//! Roll the INSERT back + join + deregister a detached insert stream. Call WITHOUT the lock.
+void DetachedInsertStream::AbortAndJoin(const string &reason) {
+	if (!stream) {
 		return;
 	}
-	detached.stream->SetError(ErrorData(ExceptionType::INVALID_INPUT, reason));
-	if (detached.thread.joinable()) {
-		detached.thread.join();
+	stream->SetError(ErrorData(ExceptionType::INVALID_INPUT, reason));
+	if (thread.joinable()) {
+		thread.join();
 	}
-	QuackStreamRegistry::Get().Erase(detached.id);
+	QuackStreamRegistry::Get().Erase(id);
+}
+
+DetachedInsertStream QuackInsertState::Detach() {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	DetachedInsertStream detached;
+	detached.stream = std::move(stream);
+	detached.thread = std::move(thread);
+	detached.id = std::move(stream_id);
+	stream.reset();
+	stream_id.clear();
+	return detached;
+}
+
+DetachedInsertStream QuackInsertState::DetachIfUnrelated(const string &msg_stream_id) {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	DetachedInsertStream detached;
+	if (!stream || stream_id == msg_stream_id) {
+		return detached; // nothing active, or this message continues the active stream
+	}
+	detached.stream = std::move(stream);
+	detached.thread = std::move(thread);
+	detached.id = std::move(stream_id);
+	stream.reset();
+	stream_id.clear();
+	return detached;
+}
+
+ErrorData QuackInsertState::Finalize(optional_idx watermark) {
+	auto detached = Detach();
+	if (watermark.IsValid() && detached.stream) {
+		detached.stream->SetWatermarkAndDrain(watermark);
+	}
+	return detached.FinishAndJoin();
+}
+
+shared_ptr<QuackDataStream> QuackInsertState::StreamForDeadRangeOrBuffer(const string &sid, idx_t lo, idx_t hi) {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	if (stream && stream_id == sid) {
+		return stream;
+	}
+	// Marker arrived before its stream existed (reordering): buffer it for when the stream is created.
+	if (pending_marker_stream_id != sid) {
+		pending_marker_stream_id = sid;
+		pending_dead_ranges.clear();
+	}
+	pending_dead_ranges.emplace_back(lo, hi);
+	return nullptr;
 }
 
 QuackConnection::~QuackConnection() {
 	// Abort + join any in-flight INSERT before members are destroyed.
-	auto detached = DetachInsertStream(*this);
-	AbortDetached(detached, "connection closed during insert");
+	insert.Detach().AbortAndJoin("connection closed during insert");
 	duckdb_query_result.reset();
 }
 
@@ -93,16 +120,6 @@ static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackData
 	stream->Finish();
 }
 
-//! Detach the active stream (briefly under the lifecycle lock) then finish + join it. Returns any
-//! error the INSERT produced. Safe to call when there is no active stream (returns an empty error).
-static ErrorData FinalizeInsertStream(QuackConnection &connection, optional_idx watermark = optional_idx()) {
-	auto detached = DetachInsertStream(connection);
-	if (watermark.IsValid() && detached.stream) {
-		detached.stream->SetWatermarkAndDrain(watermark);
-	}
-	return FinalizeDetached(detached);
-}
-
 //! Stream id a SEND_DATA/FINALIZE belongs to, or "" for any other message.
 static string StreamIdForMessage(QuackMessage &msg) {
 	if (msg.Type() == MessageType::SEND_DATA_REQUEST) {
@@ -116,24 +133,6 @@ static string StreamIdForMessage(QuackMessage &msg) {
 	return string();
 }
 
-//! A message unrelated to the active insert stream means it was abandoned (client source failed,
-//! no FINALIZE) — abort it so it rolls back and releases the connection lock.
-static void AbortActiveStreamIfUnrelated(QuackConnection &connection, QuackMessage &msg) {
-	auto msg_stream_id = StreamIdForMessage(msg);
-	DetachedInsertStream detached;
-	{
-		annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
-		if (!connection.insert_stream || connection.insert_stream_id == msg_stream_id) {
-			return; // nothing active, or this message continues the active stream
-		}
-		detached.stream = std::move(connection.insert_stream);
-		detached.thread = std::move(connection.insert_thread);
-		detached.id = std::move(connection.insert_stream_id);
-		connection.insert_stream.reset();
-		connection.insert_stream_id.clear();
-	}
-	AbortDetached(detached, "insert stream abandoned");
-}
 
 void QuackServer::ValidateToken(const string &token) {
 	if (token.size() < 4) {
@@ -385,7 +384,9 @@ static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, un
 unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
                                                             optional_ptr<QuackConnection> connection_p) {
 	if (connection_p) {
-		AbortActiveStreamIfUnrelated(*connection_p, received_message);
+		// A message unrelated to the active insert stream means it was abandoned (client source failed, no
+		// FINALIZE) — abort it so it rolls back and releases the connection lock.
+		connection_p->insert.DetachIfUnrelated(StreamIdForMessage(received_message)).AbortAndJoin("insert stream abandoned");
 	}
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {
@@ -542,23 +543,10 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &incoming_chunks = send_data_message.Chunks();
 
 		// Dead-range marker: no chunks, tells the server batches [lo, hi) are dead so the cursor can skip them.
-		// A marker can overtake the first data message, so buffer it on the connection until the stream exists.
 		if (send_data_message.IsDeadRange()) {
 			auto lo = send_data_message.BatchIndex().GetIndex();
 			auto hi = send_data_message.DeadRangeEnd().GetIndex();
-			shared_ptr<QuackDataStream> dead_stream;
-			{
-				annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
-				if (connection.insert_stream && connection.insert_stream_id == stream_id) {
-					dead_stream = connection.insert_stream;
-				} else {
-					if (connection.pending_dead_range_stream_id != stream_id) {
-						connection.pending_dead_range_stream_id = stream_id;
-						connection.pending_dead_ranges.clear();
-					}
-					connection.pending_dead_ranges.emplace_back(lo, hi);
-				}
-			}
+			auto dead_stream = connection.insert.StreamForDeadRangeOrBuffer(stream_id, lo, hi);
 			if (dead_stream) {
 				dead_stream->PushDeadRange(lo, hi);
 			}
@@ -568,9 +556,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		shared_ptr<QuackDataStream> stream;
 		vector<std::pair<idx_t, idx_t>> buffered_dead_ranges;
 		{
-			annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
-			if (connection.insert_stream) {
-				stream = connection.insert_stream;
+			annotated_lock_guard<annotated_mutex> guard(connection.insert.lock);
+			if (connection.insert.stream) {
+				stream = connection.insert.stream;
 			} else {
 				if (incoming_chunks.empty()) {
 					// Zero-chunk first message — the client shouldn't produce this (FlushBuffer skips empty
@@ -579,15 +567,15 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				}
 				auto types = incoming_chunks[0]->Chunk().GetTypes();
 				stream = QuackStreamRegistry::Get().Create(stream_id, types, ordered);
-				connection.insert_stream = stream;
-				connection.insert_stream_id = stream_id;
-				connection.insert_thread = std::thread(RunInsertStatement, std::ref(connection), stream, stream_id,
+				connection.insert.stream = stream;
+				connection.insert.stream_id = stream_id;
+				connection.insert.thread = std::thread(RunInsertStatement, std::ref(connection), stream, stream_id,
 				                                       send_data_message.SchemaName(), send_data_message.TableName());
 				// Apply any dead-range markers that arrived before the stream existed.
-				if (connection.pending_dead_range_stream_id == stream_id) {
-					buffered_dead_ranges = std::move(connection.pending_dead_ranges);
-					connection.pending_dead_ranges.clear();
-					connection.pending_dead_range_stream_id.clear();
+				if (connection.insert.pending_marker_stream_id == stream_id) {
+					buffered_dead_ranges = std::move(connection.insert.pending_dead_ranges);
+					connection.insert.pending_dead_ranges.clear();
+					connection.insert.pending_marker_stream_id.clear();
 				}
 			}
 		}
@@ -616,7 +604,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		}
 
 		if (stream->HasError()) {
-			auto error = FinalizeInsertStream(connection);
+			auto error = connection.insert.Finalize();
 			return make_uniq<ErrorResponse>(error);
 		}
 		return make_uniq<SendDataResponseMessage>(); // accept_budget unset = unbounded (future flow control)
@@ -626,12 +614,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &connection = *connection_p;
 		auto stream_id = QuackStreamRegistry::MakeId(finalize_message.ConnectionId(), finalize_message.QueryUUID());
 		{
-			annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
-			if (connection.insert_stream_id != stream_id) {
+			annotated_lock_guard<annotated_mutex> guard(connection.insert.lock);
+			if (connection.insert.stream_id != stream_id) {
 				return make_uniq<SuccessResponse>(); // no matching stream (e.g. zero-chunk insert)
 			}
 		}
-		auto error = FinalizeInsertStream(connection, finalize_message.MinBatchWatermark());
+		auto error = connection.insert.Finalize(finalize_message.MinBatchWatermark());
 		if (error.HasError()) {
 			return make_uniq<ErrorResponse>(error);
 		}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -391,8 +391,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {
 		auto &connection_request_message = received_message.Cast<ConnectionRequestMessage>();
-		if (connection_request_message.MinimumSupportedQuackVersion() > 2ULL) {
-			return make_uniq<ErrorResponse>("Unsupported Quack version - server only supports version 2 of quack");
+		// The server speaks exactly QUACK_VERSION; reject unless the client's [min, max] range includes it.
+		if (connection_request_message.MinimumSupportedQuackVersion() > QUACK_VERSION ||
+		    connection_request_message.MaximumSupportedQuackVersion() < QUACK_VERSION) {
+			return make_uniq<ErrorResponse>(StringUtil::Format(
+			    "Unsupported Quack version - server only supports version %llu of quack", QUACK_VERSION));
 		}
 		string session_id = GenerateSessionId();
 		auto auth_result = EvaluateAuthQuery(

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -540,7 +540,33 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto stream_id = QuackStreamRegistry::MakeId(send_data_message.ConnectionId(), send_data_message.QueryUUID());
 		bool ordered = send_data_message.BatchIndex().IsValid();
 		auto &incoming_chunks = send_data_message.Chunks();
+
+		// Dead-range marker: no chunks, tells the server batches [lo, hi) are dead so the cursor can skip them.
+		// A marker can overtake the first data message, so buffer it on the connection until the stream exists.
+		if (send_data_message.IsDeadRange()) {
+			auto lo = send_data_message.BatchIndex().GetIndex();
+			auto hi = send_data_message.DeadRangeEnd().GetIndex();
+			shared_ptr<QuackDataStream> dead_stream;
+			{
+				annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
+				if (connection.insert_stream && connection.insert_stream_id == stream_id) {
+					dead_stream = connection.insert_stream;
+				} else {
+					if (connection.pending_dead_range_stream_id != stream_id) {
+						connection.pending_dead_range_stream_id = stream_id;
+						connection.pending_dead_ranges.clear();
+					}
+					connection.pending_dead_ranges.emplace_back(lo, hi);
+				}
+			}
+			if (dead_stream) {
+				dead_stream->PushDeadRange(lo, hi);
+			}
+			return make_uniq<SendDataResponseMessage>();
+		}
+
 		shared_ptr<QuackDataStream> stream;
+		vector<std::pair<idx_t, idx_t>> buffered_dead_ranges;
 		{
 			annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
 			if (connection.insert_stream) {
@@ -557,7 +583,17 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				connection.insert_stream_id = stream_id;
 				connection.insert_thread = std::thread(RunInsertStatement, std::ref(connection), stream, stream_id,
 				                                       send_data_message.SchemaName(), send_data_message.TableName());
+				// Apply any dead-range markers that arrived before the stream existed.
+				if (connection.pending_dead_range_stream_id == stream_id) {
+					buffered_dead_ranges = std::move(connection.pending_dead_ranges);
+					connection.pending_dead_ranges.clear();
+					connection.pending_dead_range_stream_id.clear();
+				}
 			}
+		}
+
+		for (auto &r : buffered_dead_ranges) {
+			stream->PushDeadRange(r.first, r.second);
 		}
 
 		// Reference the chunks from the message. DataChunkWrapper.Deserialize uses DataChunk::Reference()

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -133,7 +133,6 @@ static string StreamIdForMessage(QuackMessage &msg) {
 	return string();
 }
 
-
 void QuackServer::ValidateToken(const string &token) {
 	if (token.size() < 4) {
 		throw InvalidInputException("Quack server token must be at least 4 characters long");
@@ -386,7 +385,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 	if (connection_p) {
 		// A message unrelated to the active insert stream means it was abandoned (client source failed, no
 		// FINALIZE) — abort it so it rolls back and releases the connection lock.
-		connection_p->insert.DetachIfUnrelated(StreamIdForMessage(received_message)).AbortAndJoin("insert stream abandoned");
+		connection_p->insert.DetachIfUnrelated(StreamIdForMessage(received_message))
+		    .AbortAndJoin("insert stream abandoned");
 	}
 	switch (received_message.Type()) {
 	case MessageType::CONNECTION_REQUEST: {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -95,8 +95,12 @@ static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackData
 
 //! Detach the active stream (briefly under the lifecycle lock) then finish + join it. Returns any
 //! error the INSERT produced. Safe to call when there is no active stream (returns an empty error).
-static ErrorData FinalizeInsertStream(QuackConnection &connection) {
+static ErrorData FinalizeInsertStream(QuackConnection &connection,
+                                      optional_idx watermark = optional_idx()) {
 	auto detached = DetachInsertStream(connection);
+	if (watermark.IsValid() && detached.stream) {
+		detached.stream->SetWatermarkAndDrain(watermark);
+	}
 	return FinalizeDetached(detached);
 }
 
@@ -533,15 +537,23 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			}
 		}
 
-		// First chunk lazily creates the stream + background INSERT (any different-id stream was aborted above).
+		// Lazily create the stream + background INSERT on the first message (stream is keyed by query_uuid).
 		auto stream_id = QuackStreamRegistry::MakeId(send_data_message.ConnectionId(), send_data_message.QueryUUID());
+		bool ordered = send_data_message.BatchIndex().IsValid();
+		auto &incoming_chunks = send_data_message.Chunks();
 		shared_ptr<QuackDataStream> stream;
 		{
 			annotated_lock_guard<annotated_mutex> guard(connection.insert_lifecycle_lock);
 			if (connection.insert_stream) {
 				stream = connection.insert_stream;
 			} else {
-				stream = QuackStreamRegistry::Get().Create(stream_id, send_data_message.AppendChunk().GetTypes());
+				if (incoming_chunks.empty()) {
+					// Zero-chunk first message — the client shouldn't produce this (FlushBuffer skips empty
+					// unstarted batches), but guard against it gracefully.
+					return make_uniq<SendDataResponseMessage>();
+				}
+				auto types = incoming_chunks[0]->Chunk().GetTypes();
+				stream = QuackStreamRegistry::Get().Create(stream_id, types, ordered);
 				connection.insert_stream = stream;
 				connection.insert_stream_id = stream_id;
 				connection.insert_thread = std::thread(RunInsertStatement, std::ref(connection), stream, stream_id,
@@ -549,11 +561,24 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			}
 		}
 
-		// Copy the chunk for the stream (the message is freed after this handler returns).
-		auto chunk = make_uniq<DataChunk>();
-		chunk->Initialize(Allocator::DefaultAllocator(), send_data_message.AppendChunk().GetTypes());
-		send_data_message.AppendChunk().Copy(*chunk);
-		stream->Push(std::move(chunk), optional_idx());
+		// Reference the chunks from the message. DataChunkWrapper.Deserialize uses DataChunk::Reference()
+		// internally, so the underlying VectorBuffers are ref-counted and outlive the message.
+		vector<unique_ptr<DataChunk>> owned_chunks;
+		owned_chunks.reserve(incoming_chunks.size());
+		for (auto &wrapper : incoming_chunks) {
+			auto owned = make_uniq<DataChunk>();
+			owned->InitializeEmpty(wrapper->Chunk().GetTypes());
+			owned->Reference(wrapper->Chunk());
+			owned_chunks.push_back(std::move(owned));
+		}
+
+		if (ordered) {
+			stream->PushOrdered(std::move(owned_chunks), send_data_message.BatchIndex().GetIndex(),
+			                    send_data_message.SequenceIndex(), send_data_message.IsLastInBatch(),
+			                    send_data_message.BatchWatermark());
+		} else {
+			stream->PushUnordered(std::move(owned_chunks));
+		}
 
 		if (stream->HasError()) {
 			auto error = FinalizeInsertStream(connection);
@@ -571,7 +596,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				return make_uniq<SuccessResponse>(); // no matching stream (e.g. zero-chunk insert)
 			}
 		}
-		auto error = FinalizeInsertStream(connection);
+		auto error = FinalizeInsertStream(connection, finalize_message.MinBatchWatermark());
 		if (error.HasError()) {
 			return make_uniq<ErrorResponse>(error);
 		}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -95,8 +95,7 @@ static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackData
 
 //! Detach the active stream (briefly under the lifecycle lock) then finish + join it. Returns any
 //! error the INSERT produced. Safe to call when there is no active stream (returns an empty error).
-static ErrorData FinalizeInsertStream(QuackConnection &connection,
-                                      optional_idx watermark = optional_idx()) {
+static ErrorData FinalizeInsertStream(QuackConnection &connection, optional_idx watermark = optional_idx()) {
 	auto detached = DetachInsertStream(connection);
 	if (watermark.IsValid() && detached.stream) {
 		detached.stream->SetWatermarkAndDrain(watermark);

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -158,6 +158,7 @@ void SendDataRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<idx_t>(6, "sequence_index", sequence_index);
 	serializer.WritePropertyWithDefault<bool>(7, "is_last_in_batch", is_last_in_batch);
 	serializer.WritePropertyWithDefault<optional_idx>(8, "batch_watermark", batch_watermark, optional_idx());
+	serializer.WritePropertyWithDefault<optional_idx>(9, "dead_range_end", dead_range_end, optional_idx());
 }
 
 unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -170,6 +171,8 @@ unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deseriali
 	deserializer.ReadPropertyWithDefault<idx_t>(6, "sequence_index", result->sequence_index);
 	deserializer.ReadPropertyWithDefault<bool>(7, "is_last_in_batch", result->is_last_in_batch);
 	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(8, "batch_watermark", result->batch_watermark,
+	                                                           optional_idx());
+	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(9, "dead_range_end", result->dead_range_end,
 	                                                           optional_idx());
 	return result;
 }

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -9,49 +9,13 @@
 
 namespace duckdb {
 
-void SendDataRequestMessage::Serialize(Serializer &serializer) const {
-	serializer.WritePropertyWithDefault<string>(1, "schema_name", schema_name);
-	serializer.WritePropertyWithDefault<string>(2, "table_name", table_name);
-	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(3, "chunks", chunks);
-	serializer.WriteProperty<hugeint_t>(4, "query_uuid", query_uuid);
-	serializer.WriteProperty<optional_idx>(5, "batch_index", batch_index);
-	serializer.WritePropertyWithDefault<idx_t>(6, "sequence_index", sequence_index, 0);
-	serializer.WritePropertyWithDefault<bool>(7, "is_last_in_batch", is_last_in_batch, false);
-	serializer.WritePropertyWithDefault<optional_idx>(8, "batch_watermark", batch_watermark, optional_idx());
-}
-
-unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<SendDataRequestMessage>(new SendDataRequestMessage());
-	deserializer.ReadPropertyWithDefault<string>(1, "schema_name", result->schema_name);
-	deserializer.ReadPropertyWithDefault<string>(2, "table_name", result->table_name);
-	deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(3, "chunks", result->chunks);
-	deserializer.ReadProperty<hugeint_t>(4, "query_uuid", result->query_uuid);
-	deserializer.ReadProperty<optional_idx>(5, "batch_index", result->batch_index);
-	deserializer.ReadPropertyWithDefault<idx_t>(6, "sequence_index", result->sequence_index);
-	deserializer.ReadPropertyWithDefault<bool>(7, "is_last_in_batch", result->is_last_in_batch);
-	deserializer.ReadPropertyWithDefault<optional_idx>(8, "batch_watermark", result->batch_watermark);
-	return result;
-}
-
-void SendDataResponseMessage::Serialize(Serializer &serializer) const {
-	serializer.WriteProperty<optional_idx>(1, "accept_budget", accept_budget);
-}
-
-unique_ptr<SendDataResponseMessage> SendDataResponseMessage::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<SendDataResponseMessage>(new SendDataResponseMessage());
-	deserializer.ReadProperty<optional_idx>(1, "accept_budget", result->accept_budget);
-	return result;
-}
-
-void FinalizeMessage::Serialize(Serializer &serializer) const {
+void CancelRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<hugeint_t>(1, "query_uuid", query_uuid);
-	serializer.WritePropertyWithDefault<optional_idx>(2, "min_batch_watermark", min_batch_watermark, optional_idx());
 }
 
-unique_ptr<FinalizeMessage> FinalizeMessage::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<FinalizeMessage>(new FinalizeMessage());
+unique_ptr<CancelRequestMessage> CancelRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<CancelRequestMessage>(new CancelRequestMessage());
 	deserializer.ReadProperty<hugeint_t>(1, "query_uuid", result->query_uuid);
-	deserializer.ReadPropertyWithDefault<optional_idx>(2, "min_batch_watermark", result->min_batch_watermark);
 	return result;
 }
 
@@ -127,6 +91,19 @@ unique_ptr<FetchResponseMessage> FetchResponseMessage::Deserialize(Deserializer 
 	return result;
 }
 
+void FinalizeMessage::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<hugeint_t>(1, "query_uuid", query_uuid);
+	serializer.WritePropertyWithDefault<optional_idx>(2, "min_batch_watermark", min_batch_watermark, optional_idx());
+}
+
+unique_ptr<FinalizeMessage> FinalizeMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<FinalizeMessage>(new FinalizeMessage());
+	deserializer.ReadProperty<hugeint_t>(1, "query_uuid", result->query_uuid);
+	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(2, "min_batch_watermark", result->min_batch_watermark,
+	                                                           optional_idx());
+	return result;
+}
+
 void MessageHeader::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<MessageType>(1, "type", type);
 	serializer.WritePropertyWithDefault<string>(2, "connection_id", connection_id);
@@ -172,21 +149,46 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	return result;
 }
 
+void SendDataRequestMessage::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(1, "schema_name", schema_name);
+	serializer.WritePropertyWithDefault<string>(2, "table_name", table_name);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(3, "chunks", chunks);
+	serializer.WriteProperty<hugeint_t>(4, "query_uuid", query_uuid);
+	serializer.WriteProperty<optional_idx>(5, "batch_index", batch_index);
+	serializer.WritePropertyWithDefault<idx_t>(6, "sequence_index", sequence_index);
+	serializer.WritePropertyWithDefault<bool>(7, "is_last_in_batch", is_last_in_batch);
+	serializer.WritePropertyWithDefault<optional_idx>(8, "batch_watermark", batch_watermark, optional_idx());
+}
+
+unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<SendDataRequestMessage>(new SendDataRequestMessage());
+	deserializer.ReadPropertyWithDefault<string>(1, "schema_name", result->schema_name);
+	deserializer.ReadPropertyWithDefault<string>(2, "table_name", result->table_name);
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(3, "chunks", result->chunks);
+	deserializer.ReadProperty<hugeint_t>(4, "query_uuid", result->query_uuid);
+	deserializer.ReadProperty<optional_idx>(5, "batch_index", result->batch_index);
+	deserializer.ReadPropertyWithDefault<idx_t>(6, "sequence_index", result->sequence_index);
+	deserializer.ReadPropertyWithDefault<bool>(7, "is_last_in_batch", result->is_last_in_batch);
+	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(8, "batch_watermark", result->batch_watermark,
+	                                                           optional_idx());
+	return result;
+}
+
+void SendDataResponseMessage::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<optional_idx>(1, "accept_budget", accept_budget);
+}
+
+unique_ptr<SendDataResponseMessage> SendDataResponseMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<SendDataResponseMessage>(new SendDataResponseMessage());
+	deserializer.ReadProperty<optional_idx>(1, "accept_budget", result->accept_budget);
+	return result;
+}
+
 void SuccessResponse::Serialize(Serializer &serializer) const {
 }
 
 unique_ptr<SuccessResponse> SuccessResponse::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<SuccessResponse>(new SuccessResponse());
-	return result;
-}
-
-void CancelRequestMessage::Serialize(Serializer &serializer) const {
-	serializer.WriteProperty<hugeint_t>(1, "query_uuid", query_uuid);
-}
-
-unique_ptr<CancelRequestMessage> CancelRequestMessage::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<CancelRequestMessage>(new CancelRequestMessage());
-	deserializer.ReadProperty<hugeint_t>(1, "query_uuid", result->query_uuid);
 	return result;
 }
 

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -12,16 +12,24 @@ namespace duckdb {
 void SendDataRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "schema_name", schema_name);
 	serializer.WritePropertyWithDefault<string>(2, "table_name", table_name);
-	serializer.WritePropertyWithDefault<unique_ptr<DataChunkWrapper>>(3, "append_chunk", append_chunk);
+	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(3, "chunks", chunks);
 	serializer.WriteProperty<hugeint_t>(4, "query_uuid", query_uuid);
+	serializer.WriteProperty<optional_idx>(5, "batch_index", batch_index);
+	serializer.WritePropertyWithDefault<idx_t>(6, "sequence_index", sequence_index, 0);
+	serializer.WritePropertyWithDefault<bool>(7, "is_last_in_batch", is_last_in_batch, false);
+	serializer.WritePropertyWithDefault<optional_idx>(8, "batch_watermark", batch_watermark, optional_idx());
 }
 
 unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<SendDataRequestMessage>(new SendDataRequestMessage());
 	deserializer.ReadPropertyWithDefault<string>(1, "schema_name", result->schema_name);
 	deserializer.ReadPropertyWithDefault<string>(2, "table_name", result->table_name);
-	deserializer.ReadPropertyWithDefault<unique_ptr<DataChunkWrapper>>(3, "append_chunk", result->append_chunk);
+	deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(3, "chunks", result->chunks);
 	deserializer.ReadProperty<hugeint_t>(4, "query_uuid", result->query_uuid);
+	deserializer.ReadProperty<optional_idx>(5, "batch_index", result->batch_index);
+	deserializer.ReadPropertyWithDefault<idx_t>(6, "sequence_index", result->sequence_index);
+	deserializer.ReadPropertyWithDefault<bool>(7, "is_last_in_batch", result->is_last_in_batch);
+	deserializer.ReadPropertyWithDefault<optional_idx>(8, "batch_watermark", result->batch_watermark);
 	return result;
 }
 
@@ -37,11 +45,13 @@ unique_ptr<SendDataResponseMessage> SendDataResponseMessage::Deserialize(Deseria
 
 void FinalizeMessage::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<hugeint_t>(1, "query_uuid", query_uuid);
+	serializer.WritePropertyWithDefault<optional_idx>(2, "min_batch_watermark", min_batch_watermark, optional_idx());
 }
 
 unique_ptr<FinalizeMessage> FinalizeMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FinalizeMessage>(new FinalizeMessage());
 	deserializer.ReadProperty<hugeint_t>(1, "query_uuid", result->query_uuid);
+	deserializer.ReadPropertyWithDefault<optional_idx>(2, "min_batch_watermark", result->min_batch_watermark);
 	return result;
 }
 

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -1,13 +1,18 @@
-#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+
+#include "duckdb/common/serializer/async_task_queue.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
 
 #include "storage/quack_catalog.hpp"
 #include "quack_message.hpp"
 #include "storage/quack_insert.hpp"
 #include "storage/quack_table.hpp"
 #include "quack_client.hpp"
+
+#include <chrono>
 
 using namespace duckdb;
 
@@ -26,27 +31,212 @@ QuackInsert::QuackInsert(PhysicalPlan &physical_plan, LogicalOperator &op, Schem
 //===--------------------------------------------------------------------===//
 class QuackInsertGlobalState : public GlobalSinkState {
 public:
-	explicit QuackInsertGlobalState(QuackTableCatalogEntry &table_p)
-	    : table(table_p), insert_count(0), query_uuid(UUID::GenerateRandomUUID()) {
+	QuackInsertGlobalState(QuackTableCatalogEntry &table_p, idx_t flush_rows_p)
+	    : table(table_p), insert_count(0), flush_rows(flush_rows_p), query_uuid(UUID::GenerateRandomUUID()) {
+	}
+	~QuackInsertGlobalState() override {
+		if (queue) {
+			try {
+				queue->Close();
+			} catch (...) { // NOLINT: destructor must not throw
+			}
+		}
 	}
 
 	QuackTableCatalogEntry &table;
-	idx_t insert_count;
-	//! Per-statement id for the server-side insert stream. Sent on every SEND_DATA and the FINALIZE so
-	//! the server keys the stream by (connection_id, query_uuid).
+	atomic<idx_t> insert_count;
+	idx_t flush_rows;
+	//! Per-statement id for the server-side insert stream.
 	hugeint_t query_uuid;
+	//! Shared async upload queue: regular threads register serialized messages, ASYNC-pool threads POST them.
+	unique_ptr<ManagedAsyncTaskQueue> queue;
+	//! Monotonic batch counter for SERIAL_ORDERED mode (single-threaded, so plain idx_t is fine).
+	idx_t serial_batch_counter = 0;
+	//! Minimum batch index sent across all threads; passed to the server in FINALIZE so it can drain
+	//! ordered_pending in ascending order. Protected by min_batch_lock.
+	optional_idx stream_min_batch;
+	annotated_mutex min_batch_lock;
 };
 
-unique_ptr<GlobalSinkState> QuackInsert::GetGlobalSinkState(ClientContext &context) const {
-	if (table) {
-		return make_uniq<QuackInsertGlobalState>(table.get_mutable()->Cast<QuackTableCatalogEntry>());
-	}
-	// CREATE TABLE AS path: create the table on the remote side first
-	auto &quack_schema = schema.get_mutable()->Cast<QuackSchemaCatalogEntry>();
-	auto &quack_catalog = quack_schema.catalog.Cast<QuackCatalog>();
+class QuackInsertLocalState : public LocalSinkState {
+public:
+	vector<unique_ptr<DataChunk>> buffer;
+	idx_t buffered_rows = 0;
+	idx_t local_count = 0;
+	//! PARALLEL_ORDERED: executor batch currently being buffered (invalid before first Sink/NextBatch).
+	optional_idx current_batch;
+	//! PARALLEL_ORDERED: monotonic per-batch sequence counter, reset at each NextBatch transition.
+	idx_t sequence_counter = 0;
+};
 
-	auto entry = quack_schema.CreateTable(CatalogTransaction(quack_catalog, context), *info);
-	return make_uniq<QuackInsertGlobalState>(entry->Cast<QuackTableCatalogEntry>());
+static constexpr idx_t QUACK_SEND_DATA_FLUSH_ROWS = STANDARD_VECTOR_SIZE * 100ULL;
+
+static idx_t GetFlushRows(ClientContext &context) {
+	Value val;
+	if (context.TryGetCurrentSetting("quack_send_data_flush_rows", val) && !val.IsNull()) {
+		auto rows = val.GetValue<uint64_t>();
+		if (rows > 0) {
+			return rows;
+		}
+	}
+	return QUACK_SEND_DATA_FLUSH_ROWS;
+}
+
+unique_ptr<GlobalSinkState> QuackInsert::GetGlobalSinkState(ClientContext &context) const {
+	auto flush_rows = GetFlushRows(context);
+	unique_ptr<QuackInsertGlobalState> global_state;
+	if (table) {
+		global_state =
+		    make_uniq<QuackInsertGlobalState>(table.get_mutable()->Cast<QuackTableCatalogEntry>(), flush_rows);
+	} else {
+		auto &quack_schema = schema.get_mutable()->Cast<QuackSchemaCatalogEntry>();
+		auto &quack_catalog = quack_schema.catalog.Cast<QuackCatalog>();
+		auto entry = quack_schema.CreateTable(CatalogTransaction(quack_catalog, context), *info);
+		global_state = make_uniq<QuackInsertGlobalState>(entry->Cast<QuackTableCatalogEntry>(), flush_rows);
+	}
+	global_state->queue = make_uniq<ManagedAsyncTaskQueue>(context);
+	return std::move(global_state);
+}
+
+unique_ptr<LocalSinkState> QuackInsert::GetLocalSinkState(ExecutionContext &context) const {
+	return make_uniq<QuackInsertLocalState>();
+}
+
+//===--------------------------------------------------------------------===//
+// Async send task
+//===--------------------------------------------------------------------===//
+static int64_t NowMillis() {
+	return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+	    .time_since_epoch()
+	    .count();
+}
+
+// Performs the blocking SEND_DATA POST on an ASYNC-pool thread. The payload was serialized on
+// the producing (regular) execution thread; this task only does the network send and checks the ack.
+class QuackSendDataTask : public AsyncTask {
+public:
+	QuackSendDataTask(unique_ptr<QuackClientWrapper> client_wrapper_p, unique_ptr<MemoryStream> payload_p,
+	                  idx_t payload_size_p, string connection_id_p, optional_idx client_query_id_p)
+	    : client_wrapper(std::move(client_wrapper_p)), payload(std::move(payload_p)), payload_size(payload_size_p),
+	      connection_id(std::move(connection_id_p)), client_query_id(client_query_id_p) {
+	}
+
+	void Execute() override {
+		auto &client = client_wrapper->GetClient();
+		auto start_time = NowMillis();
+		// context=nullptr: called off the execution thread, must not touch ClientContext.
+		auto response_body = client.PostRaw(nullptr, payload->GetData(), payload_size);
+		auto duration_ms = NowMillis() - start_time;
+
+		MemoryStream read_stream((data_ptr_t)response_body.data(), response_body.size());
+		auto response = QuackMessage::FromMemoryStream(read_stream);
+
+		string error;
+		if (response->Type() == MessageType::ERROR_RESPONSE) {
+			error = response->Cast<ErrorResponse>().ErrorMessage();
+		}
+		client.LogRequest(MessageType::SEND_DATA_REQUEST, connection_id, client_query_id, string(), duration_ms,
+		                  response->Type(), error);
+
+		if (response->Type() == MessageType::ERROR_RESPONSE) {
+			response->Cast<ErrorResponse>().Error().Throw();
+		}
+		if (response->Type() != SendDataResponseMessage::TYPE) {
+			throw IOException("Expected send_data_response, got %s instead",
+			                  MessageTypeToString(response->Type()));
+		}
+	}
+
+private:
+	unique_ptr<QuackClientWrapper> client_wrapper;
+	unique_ptr<MemoryStream> payload;
+	idx_t payload_size;
+	string connection_id;
+	optional_idx client_query_id;
+};
+
+//===--------------------------------------------------------------------===//
+// Send helpers
+//===--------------------------------------------------------------------===//
+// Serialize `chunks` into one SEND_DATA_REQUEST and register it with the async queue. The payload is
+// serialized on this (regular) execution thread; an ASYNC-pool thread does the blocking POST.
+// For PARALLEL_ORDERED: lstate.current_batch and lstate.sequence_counter must already be set.
+// For SERIAL_ORDERED: gstate.serial_batch_counter is incremented here (single-threaded path).
+static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackInsertGlobalState &gstate,
+                       QuackInsertLocalState &lstate, vector<unique_ptr<DataChunk>> chunks, bool is_last_in_batch) {
+	auto &tbl = gstate.table;
+	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
+
+	vector<unique_ptr<DataChunkWrapper>> wrappers;
+	wrappers.reserve(chunks.size());
+	for (auto &chunk : chunks) {
+		wrappers.push_back(make_uniq<DataChunkWrapper>(*chunk));
+	}
+
+	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(),
+	                                                   tbl.schema.name.GetIdentifierName(),
+	                                                   tbl.name.GetIdentifierName(), std::move(wrappers),
+	                                                   gstate.query_uuid);
+
+	switch (insert.order_mode) {
+	case AppendOrderMode::PARALLEL_ORDERED:
+		D_ASSERT(lstate.current_batch.IsValid());
+		send_msg->SetOrdering(lstate.current_batch, lstate.sequence_counter++, is_last_in_batch);
+		send_msg->SetBatchWatermark(gstate.stream_min_batch);
+		break;
+	case AppendOrderMode::SERIAL_ORDERED: {
+		idx_t batch = gstate.serial_batch_counter++;
+		if (batch == 0) {
+			annotated_lock_guard<annotated_mutex> lk(gstate.min_batch_lock);
+			gstate.stream_min_batch = optional_idx(0);
+		}
+		send_msg->SetOrdering(optional_idx(batch), 0, true);
+		send_msg->SetBatchWatermark(gstate.stream_min_batch);
+		break;
+	}
+	case AppendOrderMode::UNORDERED:
+		break;
+	}
+
+	// Read client_query_id on this regular thread; the async task must not touch ClientContext.
+	optional_idx client_query_id;
+	if (context.transaction.HasActiveTransaction()) {
+		auto raw_query_id = context.transaction.GetActiveQuery();
+		if (raw_query_id != DConstants::INVALID_INDEX) {
+			client_query_id = raw_query_id;
+			send_msg->SetClientQueryId(raw_query_id);
+		}
+	}
+
+	auto payload = make_uniq<MemoryStream>();
+	send_msg->ToMemoryStream(*payload);
+	auto payload_size = payload->GetPosition();
+
+	auto connection_id = quack_catalog.GetConnectionId();
+	auto client_wrapper = quack_catalog.GetClientConnection()->GetClient(context);
+	gstate.queue->Register(make_uniq<QuackSendDataTask>(std::move(client_wrapper), std::move(payload), payload_size,
+	                                                     std::move(connection_id), client_query_id),
+	                        payload_size);
+}
+
+// Flush lstate.buffer with the given is_last_in_batch flag. For PARALLEL_ORDERED, sends a zero-chunk
+// end-of-batch marker even if buffer is empty (so the server knows the batch is complete).
+// For other modes, skips if the buffer is empty.
+static void FlushBuffer(ClientContext &context, const QuackInsert &insert, QuackInsertGlobalState &gstate,
+                        QuackInsertLocalState &lstate, bool is_last_in_batch) {
+	bool parallel_ordered = insert.order_mode == AppendOrderMode::PARALLEL_ORDERED;
+	if (lstate.buffer.empty() && !parallel_ordered) {
+		return;
+	}
+	if (parallel_ordered && !lstate.current_batch.IsValid()) {
+		lstate.buffer.clear();
+		lstate.buffered_rows = 0;
+		return;
+	}
+	auto chunks = std::move(lstate.buffer);
+	lstate.buffer.clear();
+	lstate.buffered_rows = 0;
+	SendChunks(context, insert, gstate, lstate, std::move(chunks), is_last_in_batch);
 }
 
 //===--------------------------------------------------------------------===//
@@ -54,24 +244,81 @@ unique_ptr<GlobalSinkState> QuackInsert::GetGlobalSinkState(ClientContext &conte
 //===--------------------------------------------------------------------===//
 SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<QuackInsertGlobalState>();
-	auto &tbl = global_state.table;
-	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
-	// Wrap (references chunk, no copy); serialized synchronously in Request below while `chunk` is alive.
-	auto chunk_wrapper = make_uniq<DataChunkWrapper>(chunk);
-	auto append_message = make_uniq<SendDataRequestMessage>(
-	    quack_catalog.GetConnectionId(), tbl.schema.name.GetIdentifierName(), tbl.name.GetIdentifierName(),
-	    std::move(chunk_wrapper), global_state.query_uuid);
+	auto &local_state = input.local_state.Cast<QuackInsertLocalState>();
 
-	auto client_connection = quack_catalog.GetClientConnection();
-	auto client_wrapper = client_connection->GetClient(context.client);
-	auto &client = client_wrapper->GetClient();
-	// The response carries a placeholder accept-budget for future flow control; errors arrive as an
-	// ErrorResponse, which Request<>() rethrows.
-	client.Request<SendDataResponseMessage>(context.client, std::move(append_message));
+	// Update current_batch before the empty check so NextBatch can always flush the right batch.
+	if (order_mode == AppendOrderMode::PARALLEL_ORDERED) {
+		local_state.current_batch = input.local_state.partition_info.batch_index;
+	}
+	if (chunk.size() == 0) {
+		return SinkResultType::NEED_MORE_INPUT;
+	}
 
-	// Client-side optimistic count (rows sent); exact because any server failure throws above before reporting.
-	global_state.insert_count += chunk.size();
+	// Deep-copy the chunk: the executor reuses the source chunk across Sink calls.
+	auto owned = make_uniq<DataChunk>();
+	owned->Initialize(context.client, chunk.GetTypes(), chunk.size());
+	owned->Append(chunk);
+	local_state.buffered_rows += owned->size();
+	local_state.local_count += chunk.size();
+	local_state.buffer.push_back(std::move(owned));
+
+	// Flush when the row threshold is reached. For PARALLEL_ORDERED, mid-batch flushes use is_last=false
+	// (the batch boundary is determined by NextBatch, not the row count); others always use is_last=true.
+	if (local_state.buffered_rows >= global_state.flush_rows) {
+		bool is_last = (order_mode != AppendOrderMode::PARALLEL_ORDERED);
+		FlushBuffer(context.client, *this, global_state, local_state, is_last);
+		global_state.queue->ApplyBackpressure();
+	}
 	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// NextBatch (PARALLEL_ORDERED path)
+//===--------------------------------------------------------------------===//
+// The executor has crossed a batch boundary. Flush all data for lstate.current_batch (the batch that
+// just ended) with is_last=true, then advance to the new batch. NextBatch fires BEFORE Sink() is called
+// for the new batch's first chunk, so lstate.current_batch is the OLD batch when we enter here.
+SinkNextBatchType QuackInsert::NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const {
+	if (order_mode != AppendOrderMode::PARALLEL_ORDERED) {
+		return SinkNextBatchType::READY;
+	}
+	auto &global_state = input.global_state.Cast<QuackInsertGlobalState>();
+	auto &local_state = input.local_state.Cast<QuackInsertLocalState>();
+	auto new_batch = input.local_state.partition_info.batch_index;
+
+	// Track the minimum batch index seen across all threads for the FINALIZE watermark.
+	if (!local_state.current_batch.IsValid() && new_batch.IsValid()) {
+		annotated_lock_guard<annotated_mutex> lk(global_state.min_batch_lock);
+		if (!global_state.stream_min_batch.IsValid() ||
+		    new_batch.GetIndex() < global_state.stream_min_batch.GetIndex()) {
+			global_state.stream_min_batch = new_batch;
+		}
+	}
+
+	// Flush old batch (or send zero-chunk end-of-batch marker if no data came through).
+	// current_batch is invalid only before the very first NextBatch call; skip in that case.
+	if (local_state.current_batch.IsValid()) {
+		FlushBuffer(context.client, *this, global_state, local_state, /*is_last=*/true);
+		global_state.queue->ApplyBackpressure();
+	}
+
+	// Advance to the new batch.
+	local_state.current_batch = new_batch;
+	local_state.sequence_counter = 0;
+	return SinkNextBatchType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+SinkCombineResultType QuackInsert::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
+	auto &global_state = input.global_state.Cast<QuackInsertGlobalState>();
+	auto &local_state = input.local_state.Cast<QuackInsertLocalState>();
+
+	// Flush remaining buffer as the final (is_last=true) message for the current batch/serial batch.
+	FlushBuffer(context.client, *this, global_state, local_state, /*is_last=*/true);
+	global_state.insert_count += local_state.local_count;
+	return SinkCombineResultType::FINISHED;
 }
 
 //===--------------------------------------------------------------------===//
@@ -82,13 +329,16 @@ SinkFinalizeType QuackInsert::Finalize(Pipeline &pipeline, Event &event, ClientC
 	auto &global_state = input.global_state.Cast<QuackInsertGlobalState>();
 	auto &tbl = global_state.table;
 	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
+
+	// Drain all async sends before FINALIZE: ensures every row is committed atomically on the server.
+	global_state.queue->Close();
+
 	auto client_connection = quack_catalog.GetClientConnection();
 	auto client_wrapper = client_connection->GetClient(context);
 	auto &client = client_wrapper->GetClient();
-	// Signal end-of-stream so the server drains the source, completes the INSERT statement, and
-	// commits it. A server-side failure (e.g. a constraint violation) surfaces here as an error.
-	client.Request<SuccessResponse>(
-	    context, make_uniq<FinalizeMessage>(quack_catalog.GetConnectionId(), global_state.query_uuid));
+	auto finalize_msg = make_uniq<FinalizeMessage>(quack_catalog.GetConnectionId(), global_state.query_uuid);
+	finalize_msg->SetMinBatchWatermark(global_state.stream_min_batch);
+	client.Request<SuccessResponse>(context, std::move(finalize_msg));
 	return SinkFinalizeType::READY;
 }
 
@@ -98,7 +348,7 @@ SinkFinalizeType QuackInsert::Finalize(Pipeline &pipeline, Event &event, ClientC
 SourceResultType QuackInsert::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                               OperatorSourceInput &input) const {
 	auto &insert_gstate = sink_state->Cast<QuackInsertGlobalState>();
-	chunk.data[0].Append(Value::BIGINT(NumericCast<int64_t>(insert_gstate.insert_count)));
+	chunk.data[0].Append(Value::BIGINT(NumericCast<int64_t>(insert_gstate.insert_count.load())));
 	chunk.SetCardinality(1);
 	return SourceResultType::FINISHED;
 }
@@ -116,6 +366,20 @@ InsertionOrderPreservingMap<string> QuackInsert::ParamsToString() const {
 	return result;
 }
 
+// Decide ordering strategy at plan time (mirrors core's plan_insert.cpp):
+//  - preserve_insertion_order=false → UNORDERED: no stamps, server applies on arrival.
+//  - preserve order + source has executor batch index → PARALLEL_ORDERED: stamp with (batch, seq, is_last).
+//  - preserve order + no batch index → SERIAL_ORDERED: single producer mints a new batch per flush.
+static void ConfigureOrdering(ClientContext &context, QuackInsert &insert, PhysicalOperator &source) {
+	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, source)) {
+		insert.order_mode = AppendOrderMode::UNORDERED;
+	} else if (PhysicalPlanGenerator::UseBatchIndex(context, source)) {
+		insert.order_mode = AppendOrderMode::PARALLEL_ORDERED;
+	} else {
+		insert.order_mode = AppendOrderMode::SERIAL_ORDERED;
+	}
+}
+
 PhysicalOperator &QuackCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
                                            optional_ptr<PhysicalOperator> plan) {
 	if (op.return_chunk) {
@@ -127,6 +391,7 @@ PhysicalOperator &QuackCatalog::PlanInsert(ClientContext &context, PhysicalPlanG
 	}
 	auto &insert = planner.Make<QuackInsert>(op, op.table);
 	insert.children.push_back(*plan);
+	ConfigureOrdering(context, insert.Cast<QuackInsert>(), *plan);
 	return insert;
 }
 
@@ -134,5 +399,6 @@ PhysicalOperator &QuackCatalog::PlanCreateTableAs(ClientContext &context, Physic
                                                   LogicalCreateTable &op, PhysicalOperator &plan) {
 	auto &insert = planner.Make<QuackInsert>(op, op.schema, std::move(op.info));
 	insert.children.push_back(plan);
+	ConfigureOrdering(context, insert.Cast<QuackInsert>(), plan);
 	return insert;
 }

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -142,8 +142,7 @@ public:
 			response->Cast<ErrorResponse>().Error().Throw();
 		}
 		if (response->Type() != SendDataResponseMessage::TYPE) {
-			throw IOException("Expected send_data_response, got %s instead",
-			                  MessageTypeToString(response->Type()));
+			throw IOException("Expected send_data_response, got %s instead", MessageTypeToString(response->Type()));
 		}
 	}
 
@@ -173,10 +172,9 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 		wrappers.push_back(make_uniq<DataChunkWrapper>(*chunk));
 	}
 
-	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(),
-	                                                   tbl.schema.name.GetIdentifierName(),
-	                                                   tbl.name.GetIdentifierName(), std::move(wrappers),
-	                                                   gstate.query_uuid);
+	auto send_msg =
+	    make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name.GetIdentifierName(),
+	                                      tbl.name.GetIdentifierName(), std::move(wrappers), gstate.query_uuid);
 
 	switch (insert.order_mode) {
 	case AppendOrderMode::PARALLEL_ORDERED:
@@ -215,8 +213,8 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 	auto connection_id = quack_catalog.GetConnectionId();
 	auto client_wrapper = quack_catalog.GetClientConnection()->GetClient(context);
 	gstate.queue->Register(make_uniq<QuackSendDataTask>(std::move(client_wrapper), std::move(payload), payload_size,
-	                                                     std::move(connection_id), client_query_id),
-	                        payload_size);
+	                                                    std::move(connection_id), client_query_id),
+	                       payload_size);
 }
 
 // Flush lstate.buffer with the given is_last_in_batch flag. For PARALLEL_ORDERED, sends a zero-chunk

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -53,10 +53,6 @@ public:
 	unique_ptr<ManagedAsyncTaskQueue> queue;
 	//! Monotonic batch counter for SERIAL_ORDERED mode (single-threaded, so plain idx_t is fine).
 	idx_t serial_batch_counter = 0;
-	//! Minimum batch index sent across all threads; passed to the server in FINALIZE so it can drain
-	//! ordered_pending in ascending order. Protected by min_batch_lock.
-	optional_idx stream_min_batch;
-	annotated_mutex min_batch_lock;
 
 	//! Dead-range gap tracking (PARALLEL_ORDERED), guarded by gap_lock: a batch index is "live" once a thread
 	//! produces rows for it; never-claimed indices below the floor are dead and get a dead-range marker.
@@ -66,6 +62,8 @@ public:
 	idx_t max_floor = 0;
 	//! Largest settled live batch; the lower bound for the next inter-batch dead range.
 	optional_idx last_settled_live;
+	//! Firm lower bound on the lowest batch, sent as the constant seed watermark. Set in CloseDeadGaps.
+	optional_idx stream_floor;
 };
 
 class QuackInsertLocalState : public LocalSinkState {
@@ -187,19 +185,21 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 	                                      tbl.name.GetIdentifierName(), std::move(wrappers), gstate.query_uuid);
 
 	switch (insert.order_mode) {
-	case AppendOrderMode::PARALLEL_ORDERED:
+	case AppendOrderMode::PARALLEL_ORDERED: {
 		D_ASSERT(lstate.current_batch.IsValid());
 		send_msg->SetOrdering(lstate.current_batch, lstate.sequence_counter++, is_last_in_batch);
-		send_msg->SetBatchWatermark(gstate.stream_min_batch);
+		annotated_lock_guard<annotated_mutex> lk(gstate.gap_lock);
+		send_msg->SetBatchWatermark(gstate.stream_floor);
 		break;
+	}
 	case AppendOrderMode::SERIAL_ORDERED: {
 		idx_t batch = gstate.serial_batch_counter++;
-		if (batch == 0) {
-			annotated_lock_guard<annotated_mutex> lk(gstate.min_batch_lock);
-			gstate.stream_min_batch = optional_idx(0);
-		}
 		send_msg->SetOrdering(optional_idx(batch), 0, true);
-		send_msg->SetBatchWatermark(gstate.stream_min_batch);
+		annotated_lock_guard<annotated_mutex> lk(gstate.gap_lock);
+		if (!gstate.stream_floor.IsValid()) {
+			gstate.stream_floor = optional_idx(0); // serial batches are dense from 0
+		}
+		send_msg->SetBatchWatermark(gstate.stream_floor);
 		break;
 	}
 	case AppendOrderMode::UNORDERED:
@@ -277,6 +277,13 @@ static void CloseDeadGaps(ClientContext &context, const QuackInsert &insert, Qua
 		if (floor > gstate.max_floor) {
 			gstate.max_floor = floor;
 		}
+		// Lowest min_batch_index seen (skip the idx_t max that FINALIZE passes to flush everything): a firm lower
+		// bound sent as the server's constant seed watermark. It can be one below the lowest real batch (an
+		// unproduced thread's placeholder), which the leading marker covers.
+		if (floor != NumericLimits<idx_t>::Maximum() &&
+		    (!gstate.stream_floor.IsValid() || floor < gstate.stream_floor.GetIndex())) {
+			gstate.stream_floor = optional_idx(floor);
+		}
 		// Settle every live batch now strictly below the floor, emitting the dead gap to its predecessor.
 		while (!gstate.live_batches.empty()) {
 			idx_t b = *gstate.live_batches.begin();
@@ -284,8 +291,13 @@ static void CloseDeadGaps(ClientContext &context, const QuackInsert &insert, Qua
 				break; // not settled — a lower batch could still appear
 			}
 			gstate.live_batches.erase(gstate.live_batches.begin());
-			if (gstate.last_settled_live.IsValid() && b > gstate.last_settled_live.GetIndex() + 1) {
-				to_emit.emplace_back(gstate.last_settled_live.GetIndex() + 1, b);
+			if (gstate.last_settled_live.IsValid()) {
+				if (b > gstate.last_settled_live.GetIndex() + 1) {
+					to_emit.emplace_back(gstate.last_settled_live.GetIndex() + 1, b);
+				}
+			} else if (gstate.stream_floor.IsValid() && b > gstate.stream_floor.GetIndex()) {
+				// Leading gap: advance the server's cursor from the seed up to the first real batch.
+				to_emit.emplace_back(gstate.stream_floor.GetIndex(), b);
 			}
 			gstate.last_settled_live = optional_idx(b);
 		}
@@ -362,16 +374,7 @@ SinkNextBatchType QuackInsert::NextBatch(ExecutionContext &context, OperatorSink
 	auto &local_state = input.local_state.Cast<QuackInsertLocalState>();
 	auto new_batch = input.local_state.partition_info.batch_index;
 
-	// Track the minimum batch index seen across all threads for the FINALIZE watermark.
-	if (!local_state.current_batch.IsValid() && new_batch.IsValid()) {
-		annotated_lock_guard<annotated_mutex> lk(global_state.min_batch_lock);
-		if (!global_state.stream_min_batch.IsValid() ||
-		    new_batch.GetIndex() < global_state.stream_min_batch.GetIndex()) {
-			global_state.stream_min_batch = new_batch;
-		}
-	}
-
-	// Record the new batch as live and emit dead-range markers for any gaps the rising floor has confirmed.
+	// Record the new batch as live, capture the firm floor, and emit dead-range markers for confirmed gaps.
 	auto floor = input.local_state.partition_info.min_batch_index;
 	CloseDeadGaps(context.client, *this, global_state, new_batch, floor.IsValid() ? floor.GetIndex() : 0);
 
@@ -421,7 +424,12 @@ SinkFinalizeType QuackInsert::Finalize(Pipeline &pipeline, Event &event, ClientC
 	auto client_wrapper = client_connection->GetClient(context);
 	auto &client = client_wrapper->GetClient();
 	auto finalize_msg = make_uniq<FinalizeMessage>(quack_catalog.GetConnectionId(), global_state.query_uuid);
-	finalize_msg->SetMinBatchWatermark(global_state.stream_min_batch);
+	optional_idx stream_floor;
+	{
+		annotated_lock_guard<annotated_mutex> lk(global_state.gap_lock);
+		stream_floor = global_state.stream_floor;
+	}
+	finalize_msg->SetMinBatchWatermark(stream_floor);
 	client.Request<SuccessResponse>(context, std::move(finalize_msg));
 	return SinkFinalizeType::READY;
 }

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -13,6 +13,7 @@
 #include "quack_client.hpp"
 
 #include <chrono>
+#include <set>
 
 using namespace duckdb;
 
@@ -56,6 +57,15 @@ public:
 	//! ordered_pending in ascending order. Protected by min_batch_lock.
 	optional_idx stream_min_batch;
 	annotated_mutex min_batch_lock;
+
+	//! Dead-range gap tracking (PARALLEL_ORDERED), guarded by gap_lock: a batch index is "live" once a thread
+	//! produces rows for it; never-claimed indices below the floor are dead and get a dead-range marker.
+	annotated_mutex gap_lock;
+	std::set<idx_t> live_batches;
+	//! Max min_batch_index observed. A live batch strictly below it is settled: no lower batch can appear.
+	idx_t max_floor = 0;
+	//! Largest settled live batch; the lower bound for the next inter-batch dead range.
+	optional_idx last_settled_live;
 };
 
 class QuackInsertLocalState : public LocalSinkState {
@@ -217,6 +227,74 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 	                       payload_size);
 }
 
+// Emit a dead-range marker: batches [lo, hi) produced no rows and will never arrive. Carries no chunks;
+// the server records the range so its delivery cursor can skip the gap instead of stalling on it.
+static void SendDeadRange(ClientContext &context, QuackInsertGlobalState &gstate, idx_t lo, idx_t hi) {
+	auto &tbl = gstate.table;
+	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
+
+	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(),
+	                                                  tbl.schema.name.GetIdentifierName(), tbl.name.GetIdentifierName(),
+	                                                  vector<unique_ptr<DataChunkWrapper>>(), gstate.query_uuid);
+	send_msg->SetDeadRange(lo, hi);
+
+	optional_idx client_query_id;
+	if (context.transaction.HasActiveTransaction()) {
+		auto raw_query_id = context.transaction.GetActiveQuery();
+		if (raw_query_id != DConstants::INVALID_INDEX) {
+			client_query_id = raw_query_id;
+			send_msg->SetClientQueryId(raw_query_id);
+		}
+	}
+
+	auto payload = make_uniq<MemoryStream>();
+	send_msg->ToMemoryStream(*payload);
+	auto payload_size = payload->GetPosition();
+
+	auto connection_id = quack_catalog.GetConnectionId();
+	auto client_wrapper = quack_catalog.GetClientConnection()->GetClient(context);
+	gstate.queue->Register(make_uniq<QuackSendDataTask>(std::move(client_wrapper), std::move(payload), payload_size,
+	                                                    std::move(connection_id), client_query_id),
+	                       payload_size);
+}
+
+// PARALLEL_ORDERED only: record `current_batch` as live and, as the floor rises, emit one dead-range marker
+// per run of never-claimed indices bounded above by a live batch. `floor` is min_batch_index (idx_t max at finalize).
+static void CloseDeadGaps(ClientContext &context, const QuackInsert &insert, QuackInsertGlobalState &gstate,
+                          optional_idx current_batch, idx_t floor) {
+	if (insert.order_mode != AppendOrderMode::PARALLEL_ORDERED) {
+		return;
+	}
+	vector<std::pair<idx_t, idx_t>> to_emit;
+	{
+		annotated_lock_guard<annotated_mutex> guard(gstate.gap_lock);
+		if (current_batch.IsValid()) {
+			// A live batch must never appear at or below already-settled territory.
+			D_ASSERT(!gstate.last_settled_live.IsValid() ||
+			         current_batch.GetIndex() > gstate.last_settled_live.GetIndex());
+			gstate.live_batches.insert(current_batch.GetIndex());
+		}
+		if (floor > gstate.max_floor) {
+			gstate.max_floor = floor;
+		}
+		// Settle every live batch now strictly below the floor, emitting the dead gap to its predecessor.
+		while (!gstate.live_batches.empty()) {
+			idx_t b = *gstate.live_batches.begin();
+			if (b >= gstate.max_floor) {
+				break; // not settled — a lower batch could still appear
+			}
+			gstate.live_batches.erase(gstate.live_batches.begin());
+			if (gstate.last_settled_live.IsValid() && b > gstate.last_settled_live.GetIndex() + 1) {
+				to_emit.emplace_back(gstate.last_settled_live.GetIndex() + 1, b);
+			}
+			gstate.last_settled_live = optional_idx(b);
+		}
+	}
+	for (auto &r : to_emit) {
+		SendDeadRange(context, gstate, r.first, r.second);
+	}
+}
+
 // Flush lstate.buffer with the given is_last_in_batch flag. For PARALLEL_ORDERED, sends a zero-chunk
 // end-of-batch marker even if buffer is empty (so the server knows the batch is complete).
 // For other modes, skips if the buffer is empty.
@@ -293,6 +371,10 @@ SinkNextBatchType QuackInsert::NextBatch(ExecutionContext &context, OperatorSink
 		}
 	}
 
+	// Record the new batch as live and emit dead-range markers for any gaps the rising floor has confirmed.
+	auto floor = input.local_state.partition_info.min_batch_index;
+	CloseDeadGaps(context.client, *this, global_state, new_batch, floor.IsValid() ? floor.GetIndex() : 0);
+
 	// Flush old batch (or send zero-chunk end-of-batch marker if no data came through).
 	// current_batch is invalid only before the very first NextBatch call; skip in that case.
 	if (local_state.current_batch.IsValid()) {
@@ -327,6 +409,10 @@ SinkFinalizeType QuackInsert::Finalize(Pipeline &pipeline, Event &event, ClientC
 	auto &global_state = input.global_state.Cast<QuackInsertGlobalState>();
 	auto &tbl = global_state.table;
 	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
+
+	// At finalize the floor is effectively +inf: settle every remaining live batch, emitting the last
+	// internal-gap markers before the queue is drained.
+	CloseDeadGaps(context, *this, global_state, optional_idx(), NumericLimits<idx_t>::Maximum());
 
 	// Drain all async sends before FINALIZE: ensures every row is committed atomically on the server.
 	global_state.queue->Close();

--- a/test/sql/attach_insert_order.test
+++ b/test/sql/attach_insert_order.test
@@ -245,6 +245,38 @@ select count(*), sum(i) from rpc.t_fast;
 statement ok
 reset preserve_insertion_order;
 
+# --- Seeding race: a slow leading row group (expensive md5 column on group 0) means a later batch is
+# produced and sent before the earlier one. The watermark must be a firm lower bound so the server does
+# not seed its delivery cursor too high and drop the slow earlier batch.
+statement ok
+SET threads=2;
+
+statement ok
+copy (
+    select i, case when i < 50000 then md5(i::varchar) else 'x' end as s
+    from range(300000) t(i)
+) to '{TEST_DIR}/slow_leading.parquet' (row_group_size 50000);
+
+statement ok
+create table rpc.t_race(i bigint, l bigint);
+
+statement ok
+insert into rpc.t_race
+select i, length(s)
+from read_parquet('{TEST_DIR}/slow_leading.parquet')
+where i < 4096 or (i >= 200000 and i < 204096);
+
+query III
+select count(*), min(i), max(i) from rpc.t_race;
+----
+8192	0	204095
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_race)
+where (rn < 4096 and i != rn) or (rn >= 4096 and i != rn + 195904);
+----
+0
+
 statement ok con2
 detach rpc;
 

--- a/test/sql/attach_insert_order.test
+++ b/test/sql/attach_insert_order.test
@@ -144,6 +144,55 @@ where (rn < 4096 and i != rn) or (rn >= 4096 and i != rn + 195904);
 ----
 0
 
+# All row groups filtered out: no live batch, no stream, 0 rows — must not hang.
+statement ok
+create table rpc.t_alldead(i bigint);
+
+statement ok
+insert into rpc.t_alldead select i from read_parquet('{TEST_DIR}/gap.parquet') where i > 1000000;
+
+query I
+select count(*) from rpc.t_alldead;
+----
+0
+
+# Leading dead row group (0) + an internal one (2): live groups are 1 and 3.
+statement ok
+create table rpc.t_lead(i bigint);
+
+statement ok
+insert into rpc.t_lead
+select i from read_parquet('{TEST_DIR}/gap.parquet') where (i >= 50000 and i < 54096) or (i >= 150000 and i < 154096);
+
+query III
+select count(*), min(i), max(i) from rpc.t_lead;
+----
+8192	50000	154095
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_lead)
+where (rn < 4096 and i != rn + 50000) or (rn >= 4096 and i != rn + 145904);
+----
+0
+
+# Alternating live/dead row groups (0,2,4 live; 1,3,5 dead): multiple gaps -> multiple dead-range markers.
+statement ok
+create table rpc.t_alt(i bigint);
+
+statement ok
+insert into rpc.t_alt select i from read_parquet('{TEST_DIR}/gap.parquet') where (i % 100000) < 4096;
+
+query III
+select count(*), min(i), max(i) from rpc.t_alt;
+----
+12288	0	204095
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_alt)
+where (rn < 4096 and i != rn) or (rn >= 4096 and rn < 8192 and i != rn + 95904) or (rn >= 8192 and i != rn + 191808);
+----
+0
+
 # --- async_threads sweep: order holds for synchronous (=0), single-async (=1), and wide (=8) modes.
 foreach at 0 1 8
 

--- a/test/sql/attach_insert_order.test
+++ b/test/sql/attach_insert_order.test
@@ -1,5 +1,5 @@
 # name: test/sql/attach_insert_order.test
-# description: order-preserving rpc INSERT: PARALLEL_ORDERED (scan/parquet), SERIAL_ORDERED (range), flush splitting, sparse-batch gaps, async sweep, CTAS, unordered fast path
+# description: order-preserving rpc INSERT: PARALLEL_ORDERED (scan/parquet), SERIAL_ORDERED (range), flush splitting, trailing + internal batch-index gaps (dead-range markers), async sweep, CTAS, unordered fast path
 # group: [sql]
 
 require parquet
@@ -101,9 +101,8 @@ reset quack_send_data_flush_rows;
 statement ok
 CALL disable_logging();
 
-# --- Sparse batch indices: a WHERE predicate can empty entire morsels, leaving gaps in the
-# executor's batch-index sequence. The server delivers complete batches in ascending index order,
-# skipping missing indices transparently. Row count and order must still be exact.
+# --- Trailing gap: a WHERE predicate empties the high morsels, so the batch-index sequence runs
+# 0..M then stops. The server delivers 0..M and finishes; there is nothing above to skip.
 statement ok
 create table rpc.t_filt(i bigint);
 
@@ -117,6 +116,31 @@ select count(*), (select count(*) from src where i < 150000) from rpc.t_filt;
 
 query I
 select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_filt) where i != rn;
+----
+0
+
+# --- Internal gap: a predicate empties whole parquet row groups *between* live ones, leaving a gap in
+# the middle of the batch-index sequence. The client emits dead-range markers so the server skips the
+# dead indices and delivers the batches after the gap, in order, instead of stalling and dropping them.
+statement ok
+copy (select * from range(300000) t(i)) to '{TEST_DIR}/gap.parquet' (row_group_size 50000);
+
+statement ok
+create table rpc.t_gap(i bigint);
+
+statement ok
+insert into rpc.t_gap
+select i from read_parquet('{TEST_DIR}/gap.parquet') where i < 4096 or (i >= 200000 and i < 204096);
+
+query III
+select count(*), min(i), max(i) from rpc.t_gap;
+----
+8192	0	204095
+
+# rows land in source order across the gap: 0..4095 then 200000..204095
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_gap)
+where (rn < 4096 and i != rn) or (rn >= 4096 and i != rn + 195904);
 ----
 0
 

--- a/test/sql/attach_insert_order.test
+++ b/test/sql/attach_insert_order.test
@@ -1,0 +1,178 @@
+# name: test/sql/attach_insert_order.test
+# description: order-preserving rpc INSERT: PARALLEL_ORDERED (scan/parquet), SERIAL_ORDERED (range), flush splitting, sparse-batch gaps, async sweep, CTAS, unordered fast path
+# group: [sql]
+
+require parquet
+
+include test/template/quack_setup.test_template
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# Local ordered source. Parallel table scan supplies executor batch indices (PARALLEL_ORDERED path).
+statement ok
+create table src as select * from range(300000) t(i);
+
+statement ok
+SET threads=4;
+
+# --- PARALLEL_ORDERED: parallel table-scan source must land in source order despite concurrent producers.
+statement ok
+create table rpc.t_scan(i bigint);
+
+statement ok
+insert into rpc.t_scan select i from src;
+
+query III
+select count(*), min(i), max(i) from rpc.t_scan;
+----
+300000	0	299999
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_scan) where i != rn;
+----
+0
+
+# First stored row must be 0.
+query I
+select i from (select i, row_number() over () as rn from rpc.t_scan) where rn = 1;
+----
+0
+
+# --- SERIAL_ORDERED: range() has no executor batch index; the single producer mints one batch per flush.
+# Upload still runs async; order must be exact.
+statement ok
+create table rpc.t_range(i bigint);
+
+statement ok
+insert into rpc.t_range select * from range(300000) t(i);
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_range) where i != rn;
+----
+0
+
+# --- Parquet multi-row-group source (PARALLEL_ORDERED via parallel parquet scan).
+statement ok
+copy (select * from range(300000) t(i)) to '{TEST_DIR}/ord.parquet' (row_group_size 50000);
+
+statement ok
+create table rpc.t_parq(i bigint);
+
+statement ok
+insert into rpc.t_parq select i from read_parquet('{TEST_DIR}/ord.parquet');
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_parq) where i != rn;
+----
+0
+
+# --- Flush splitting: quack_send_data_flush_rows controls when a SEND_DATA_REQUEST is dispatched.
+# Setting it to 2048 means each row group is split into many messages; order must still be exact
+# and the client must emit far more SEND_DATA_REQUEST messages than there are row groups.
+statement ok
+CALL enable_logging(['Quack'], storage='memory');
+
+statement ok
+SET quack_send_data_flush_rows=2048;
+
+statement ok
+create table rpc.t_split(i bigint);
+
+statement ok
+insert into rpc.t_split select i from src;
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_split) where i != rn;
+----
+0
+
+# server != '' selects only client-side outgoing requests (not server-side echoes).
+# 300000 rows at flush_rows=2048 → ~147 messages, well above the 1 message without splitting.
+query I
+select count(*) > 50 from duckdb_logs_parsed('Quack')
+where message_type = 'SEND_DATA_REQUEST' and server is not null and server != '';
+----
+true
+
+statement ok
+reset quack_send_data_flush_rows;
+
+statement ok
+CALL disable_logging();
+
+# --- Sparse batch indices: a WHERE predicate can empty entire morsels, leaving gaps in the
+# executor's batch-index sequence. The server delivers complete batches in ascending index order,
+# skipping missing indices transparently. Row count and order must still be exact.
+statement ok
+create table rpc.t_filt(i bigint);
+
+statement ok
+insert into rpc.t_filt select i from src where i < 150000;
+
+query II
+select count(*), (select count(*) from src where i < 150000) from rpc.t_filt;
+----
+150000	150000
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_filt) where i != rn;
+----
+0
+
+# --- async_threads sweep: order holds for synchronous (=0), single-async (=1), and wide (=8) modes.
+foreach at 0 1 8
+
+statement ok
+SET async_threads={at};
+
+statement ok
+create table rpc.t_at(i bigint);
+
+statement ok
+insert into rpc.t_at select i from src;
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_at) where i != rn;
+----
+0
+
+statement ok
+drop table rpc.t_at;
+
+endloop
+
+statement ok
+reset async_threads;
+
+# --- CTAS preserves order.
+statement ok
+create table rpc.t_ctas as select i from src;
+
+query I
+select count(*) from (select i, row_number() over () - 1 as rn from rpc.t_ctas) where i != rn;
+----
+0
+
+# --- UNORDERED fast path (preserve_insertion_order=false): all rows arrive, order not asserted.
+statement ok
+SET preserve_insertion_order=false;
+
+statement ok
+create table rpc.t_fast(i bigint);
+
+statement ok
+insert into rpc.t_fast select i from src;
+
+query II
+select count(*), sum(i) from rpc.t_fast;
+----
+300000	44999850000
+
+statement ok
+reset preserve_insertion_order;
+
+statement ok con2
+detach rpc;
+
+include test/template/quack_teardown.test_template


### PR DESCRIPTION

#189 moved the server-side append onto a real `INSERT INTO t SELECT * FROM scan_data_from_quack_client('<id>')` driven by `PhysicalBatchInsert`, but left the client deliberately dumb: it sent one chunk per `QUACK_SEND_DATA_REQUEST` and blocked the execution thread on each POST. That serializes the whole upload behind the network, and it throws away source order the moment more than one thread is producing.

This PR is the async/parallel client #189 said would come later, plus the server-side machinery needed to put the rows back in order. The upload now runs off the execution threads, multiple requests are in flight at once, and a remote `INSERT ... SELECT` lands rows in the same order it would locally. This supersedes https://github.com/duckdb/duckdb-quack/pull/179 and is also 2 to 2.5x faster in localhost.

This builds on #189 and keeps the read path untouched.

## Async upload

The sink no longer POSTs inline. A regular execution thread serializes its buffered chunks into a `QUACK_SEND_DATA_REQUEST` and registers the payload with a per-statement `ManagedAsyncTaskQueue`; an ASYNC-pool thread then does the blocking POST and checks the ack. So the producer threads keep scanning and serializing while the network work happens elsewhere, and several sends are outstanding at the same time.

To make that split clean I added `QuackClient::PostRaw`, which takes already-serialized bytes and returns the raw response body. The serialize step runs on the producer thread (where the `ClientContext` is live), and the POST runs on the async pool with `context=nullptr`, falling back to database-level params and logging. `FINALIZE` drains the queue before it returns, so an autocommit insert is still atomic on the server.

## Ordering modes

Order preservation is decided at plan time in `ConfigureOrdering`, mirroring core's `plan_insert.cpp`, and stored on the operator as an `AppendOrderMode`:

- `UNORDERED` (`preserve_insertion_order=false`): the fast path. No stamps, the server inserts chunks as they arrive.
- `PARALLEL_ORDERED`: parallel sources (table/parquet scans). Each thread stamps its chunks with `(batch_index, sequence_index, is_last_in_batch)` taken from the executor's batch index, and the server reassembles.
- `SERIAL_ORDERED`: single-threaded sources like `range()` that have no executor batch index. The lone producer mints a fresh batch per flush.

`RequiredPartitionInfo` only asks for executor batch indices in `PARALLEL_ORDERED`, so the executor's batch-index assertion never fires for sources that don't supply one. `ParallelSink` is true for everything except `SERIAL_ORDERED`.

## Wire protocol

`SEND_DATA_REQUEST` now carries a vector of chunks instead of a single one (one message is one flush), plus the ordering stamp and a `batch_watermark`. `FINALIZE` carries a `min_batch_watermark`.

The watermark is the piece that makes ordered delivery safe. It is the minimum batch index that will ever appear in the stream, piggybacked on every ordered message. Without it the server cannot tell whether a low batch is still coming or simply never existed, so it could deliver batch 5 before batch 4 ever arrives and trip `PhysicalBatchInsert`'s monotonicity check. With the watermark the server initialises its delivery cursor and only drains a batch once every batch below it is accounted for. `FINALIZE` repeats it as a safety net in case all messages arrived before any per-message watermark was valid.

## Server side: reassembly and parallel insert

`QuackDataStream` grew an ordered-assembly stage. `PushOrdered` buffers `(batch, seq)` fragments and, as soon as a batch's full sequence range has arrived, drains it as one unit into a `ready_batches_` queue in ascending batch order. Unordered streams skip all of that: `PushUnordered` drops one wire message's chunks straight onto the same queue.

On the scan side, `scan_data_from_quack_client` now raises `MaxThreads` to the live thread count. Each scan task claims one complete batch from `ready_batches_` via `TryPopBatch` and owns it exclusively until it is drained, so `PhysicalBatchInsert` sees a stable, unique batch index per task and can write row groups in parallel without interleaving rows across a batch boundary. When no batch is ready the task returns `BLOCKED` with an ASYNC-pool wait task, same as before.

Unordered streams take a different operator entirely: the bind signals `NO_ORDER`, which makes the planner pick `PhysicalInsert(parallel=true)` instead of `PhysicalBatchInsert`. That sink ignores batch indices, so concurrent tasks can append freely. Both modes share the one `ready_batches_` queue and the one scan loop; the only thing that differs is how the producer fills the queue and which insert operator drains it.

## Follow-ups

- `ready_batches_` is unbounded for now. Real flow control / backpressure management (the server handing the client an accept budget through the `SEND_DATA_RESPONSE` placeholder) is out of scope for this PR.
- Decoupling serialization from request (or a good abstraction that can be reused and does this) is a separate transport change that now is implemented partially for the purpose of async posting but could be reused in different parts (like the fetch path)
- Also memory in `QuackDataStream` is not really tracked by the buffer manager. Maybe we'd like this to be the case although I am not sure. Maybe just doing a good job on the backpressure side is enough. Or as Mark mentioned, make CollumnDataCollection serializable and use this in the transport (ColumnDataCollection is buffer managed)
