### PR TITLE
Enable serve_canonical test on Windows

### DIFF
--- a/test/sql/serve_canonical.test
+++ b/test/sql/serve_canonical.test
@@ -2,8 +2,6 @@
 # description: quack_serve URI keying is canonical (quack:host:port), so equivalent forms collide.
 # group: [sql]
 
-require notwindows
-
 require quack
 
 require httpfs
@@ -49,10 +47,19 @@ Server already exists for quack:127.0.0.1:9494
 statement ok
 CALL quack_stop('quack:127.0.0.1:9494');
 
-# Port 1 is privileged — bind() will fail unless the test runs as root.
+# On Linux and macOS port 1 is privileged — bind() will fail unless the test runs as root.
+# On Windows bind() to port 1 will succeed.
 # `statement maybe` accepts either outcome but matches the expected error
 # string when the bind does fail.
 statement maybe
 FROM quack_serve('quack:127.0.0.1:1', token='abcd');
 ----
 Failed to bind DuckDB Quack RPC server
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:1');
+
+query I quack_db:quack_server_con
+SELECT count(*) FROM quack_server_list();
+----
+0


### PR DESCRIPTION
In local checks the `serve_canonical` test passes on Windows (also when running it many times in a loop).

This PR enables it back (and adds the explicit stop for Windows) with the intention to revisit it if hanging problems on CI reappear.

Ref: duckdblabs/duckdb-internal#9402