### PR TITLE
Enable tests that were disabled in Windows

### DIFF
--- a/test/sql/self_stop.test
+++ b/test/sql/self_stop.test
@@ -2,8 +2,6 @@
 # description: A client may instruct a quack server to stop itself via `CALL quack_stop(...)` over RPC. Must not deadlock or crash.
 # group: [sql]
 
-require notwindows
-
 require quack
 
 require httpfs

--- a/test/sql/serve_canonical.test
+++ b/test/sql/serve_canonical.test
@@ -2,8 +2,6 @@
 # description: quack_serve URI keying is canonical (quack:host:port), so equivalent forms collide.
 # group: [sql]
 
-require notwindows
-
 require quack
 
 require httpfs
@@ -49,10 +47,19 @@ Server already exists for quack:127.0.0.1:9494
 statement ok
 CALL quack_stop('quack:127.0.0.1:9494');
 
-# Port 1 is privileged — bind() will fail unless the test runs as root.
+# On Linux and macOS port 1 is privileged — bind() will fail unless the test runs as root.
+# On Windows bind() to port 1 will succeed.
 # `statement maybe` accepts either outcome but matches the expected error
 # string when the bind does fail.
 statement maybe
 FROM quack_serve('quack:127.0.0.1:1', token='abcd');
 ----
 Failed to bind DuckDB Quack RPC server
+
+statement ok
+CALL quack_stop('quack:127.0.0.1:1');
+
+query I quack_db:quack_server_con
+SELECT count(*) FROM quack_server_list();
+----
+0

--- a/test/sql/server_list.test
+++ b/test/sql/server_list.test
@@ -2,8 +2,6 @@
 # description: quack_server_list returns rows for active servers
 # group: [sql]
 
-require notwindows
-
 require quack
 
 require httpfs


### PR DESCRIPTION
This is a backport of the PR #192 to `v1.5-variegata` branch. In addition to `serve_canonical` it also enables 2 other tests that were confirmed to pass locally on Windows.

In local checks the serve_canonical test passes on Windows (also when running it many times in a loop).

This PR enables it back (and adds the explicit stop for Windows) with the intention to revisit it if hanging problems on CI reappear.

Ref: duckdblabs/duckdb-internal#9402