### PR TITLE
Refactor/request internal primitives

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -36,8 +36,17 @@ public:
 	//! pass context=nullptr when called off the execution thread (parameters fall back to the database).
 	virtual string PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) = 0;
 
-	//! Emit a Quack request log entry. Safe to call from an async pool thread (uses db-level logger).
-	void LogRequest(MessageType request_type, const string &connection_id, optional_idx client_query_id,
+	//! Encode a request (inject client_query_id when a query is active, then serialize) into `out`.
+	//! Protocol-level and lock-free; the caller owns `out` and any locking around it.
+	static void EncodeRequest(optional_ptr<ClientContext> context, QuackMessage &message, MemoryStream &out);
+
+	//! Decode a response body (owned bytes) into a message. Protocol-level and lock-free.
+	static unique_ptr<QuackMessage> DecodeResponse(const string &response_body);
+
+	//! Emit a Quack request log entry through `logger`. Pass the query's context logger for per-query
+	//! attribution (connection/transaction/query id columns); the db logger only fits context-less
+	//! teardown. Safe from an async pool thread when handed a captured context logger.
+	void LogRequest(Logger &logger, MessageType request_type, const string &connection_id, optional_idx client_query_id,
 	                const string &query, int64_t duration_ms, MessageType response_type, const string &error);
 
 	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
@@ -46,8 +55,11 @@ public:
 	static shared_ptr<QuackClientConnection> ConnectToServer(ClientContext &context, const QuackUri &uri, string token);
 
 protected:
+	//! Resolve the logger for a request: the context (per-query) logger when available, else the db logger.
+	Logger &GetRequestLogger(optional_ptr<ClientContext> context);
+
 	mutex request_mutex;
-	MemoryStream read_stream, write_stream;
+	MemoryStream write_stream;
 	DatabaseInstance &db;
 	QuackUri uri;
 
@@ -107,6 +119,8 @@ private:
 	                                         unique_ptr<QuackMessage> request_message) override;
 	//! POST bytes assuming request_mutex is already held.
 	string PostRawLocked(const_data_ptr_t data, idx_t size);
+	//! Lazily initialise http_params (context-aware); assumes request_mutex is held.
+	void EnsureHttpParams(optional_ptr<ClientContext> context);
 
 private:
 	unique_ptr<HTTPParams> http_params;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -110,6 +110,12 @@ public:
 		return header.connection_id;
 	}
 
+	//! SQL text to record in request logs; empty for message types that carry none.
+	virtual const string &LoggableQuery() const {
+		static const string empty;
+		return empty;
+	}
+
 	void SetHeader(MessageHeader header_p) {
 		header = std::move(header_p);
 	}
@@ -132,6 +138,9 @@ public:
 
 public:
 	const string &Query() const {
+		return sql_query;
+	}
+	const string &LoggableQuery() const override {
 		return sql_query;
 	}
 	hugeint_t QueryUUID() const {

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -6,7 +6,16 @@
 #include "quack_client.hpp"
 #include "quack_uri.hpp"
 
+#include <chrono>
+
 namespace duckdb {
+
+static int64_t NowMillis() {
+	return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
+	    .time_since_epoch()
+	    .count();
+}
+
 template <class T>
 string GetUriPart(T ele) {
 	if (ele.afterLast - ele.first < 1) {
@@ -31,11 +40,31 @@ QuackClient::QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_
 QuackClient::~QuackClient() {
 }
 
-// TODO: This is not very clean, but I do think that for async IO we need
-// decoupling of requests from serialization
-void QuackClient::LogRequest(MessageType request_type, const string &connection_id, optional_idx client_query_id,
-                             const string &query, int64_t duration_ms, MessageType response_type, const string &error) {
-	auto &logger = Logger::Get(db);
+void QuackClient::EncodeRequest(optional_ptr<ClientContext> context, QuackMessage &message, MemoryStream &out) {
+	// Inject client_query_id from the active query so client and server logs correlate. Guard against
+	// transaction start (e.g. BEGIN via QuackCatalog::ExecuteCommand), where the transaction isn't yet
+	// installed on the TransactionContext and there is no active query to read.
+	if (context && context->transaction.HasActiveTransaction()) {
+		auto raw_query_id = context->transaction.GetActiveQuery();
+		if (raw_query_id != DConstants::INVALID_INDEX) {
+			message.SetClientQueryId(raw_query_id);
+		}
+	}
+	message.ToMemoryStream(out);
+}
+
+unique_ptr<QuackMessage> QuackClient::DecodeResponse(const string &response_body) {
+	MemoryStream read_stream((data_ptr_t)response_body.data(), response_body.size());
+	return QuackMessage::FromMemoryStream(read_stream);
+}
+
+Logger &QuackClient::GetRequestLogger(optional_ptr<ClientContext> context) {
+	return context ? Logger::Get(*context) : Logger::Get(db);
+}
+
+void QuackClient::LogRequest(Logger &logger, MessageType request_type, const string &connection_id,
+                             optional_idx client_query_id, const string &query, int64_t duration_ms,
+                             MessageType response_type, const string &error) {
 	if (!logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
 		return;
 	}
@@ -69,17 +98,22 @@ string HttpsQuackClient::PostRawLocked(const_data_ptr_t data, idx_t size) {
 	return std::move(post_request.buffer_out);
 }
 
+void HttpsQuackClient::EnsureHttpParams(optional_ptr<ClientContext> context) {
+	if (http_params) {
+		return;
+	}
+	auto &http_util = HTTPUtil::Get(db);
+	auto request_url = uri.Http() + "/quack";
+	if (context && context->transaction.HasActiveTransaction()) {
+		http_params = http_util.InitializeParameters(*context, request_url);
+	} else {
+		http_params = http_util.InitializeParameters(db, request_url);
+	}
+}
+
 string HttpsQuackClient::PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) {
 	lock_guard<mutex> guard(request_mutex);
-	if (!http_params) {
-		auto &http_util = HTTPUtil::Get(db);
-		auto request_url = uri.Http() + "/quack";
-		if (context && context->transaction.HasActiveTransaction()) {
-			http_params = http_util.InitializeParameters(*context, request_url);
-		} else {
-			http_params = http_util.InitializeParameters(db, request_url);
-		}
-	}
+	EnsureHttpParams(context);
 	return PostRawLocked(data, size);
 }
 
@@ -88,82 +122,21 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 	D_ASSERT(request_message);
 
 	lock_guard<mutex> guard(request_mutex);
+	EnsureHttpParams(context);
 
-	auto &http_util = HTTPUtil::Get(db);
-	auto request_url = uri.Http() + "/quack";
-	if (!http_params) {
-		if (context && context->transaction.HasActiveTransaction()) {
-			http_params = http_util.InitializeParameters(*context, request_url);
-		} else {
-			http_params = http_util.InitializeParameters(db, request_url);
-		}
+	int64_t start_time = NowMillis();
+	EncodeRequest(context, *request_message, write_stream);
+	auto response_body = PostRawLocked(write_stream.GetData(), write_stream.GetPosition());
+	auto response_message = DecodeResponse(response_body);
+	int64_t duration_ms = NowMillis() - start_time;
+
+	string error;
+	if (response_message->Type() == MessageType::ERROR_RESPONSE) {
+		error = response_message->Cast<ErrorResponse>().ErrorMessage();
 	}
-
-	// Inject client_query_id from context into the message before sending.
-	// Guard against reading the active query during transaction start itself
-	// (e.g. BEGIN TRANSACTION via QuackCatalog::ExecuteCommand), where the
-	// transaction isn't yet installed on the TransactionContext.
-	optional_idx client_query_id;
-	if (context && context->transaction.HasActiveTransaction()) {
-		auto raw_query_id = context->transaction.GetActiveQuery();
-		if (raw_query_id != DConstants::INVALID_INDEX) {
-			client_query_id = raw_query_id;
-			request_message->SetClientQueryId(client_query_id);
-		}
-	}
-
-	int64_t start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-	                         .time_since_epoch()
-	                         .count();
-
-	request_message->ToMemoryStream(write_stream);
-	auto buffer_out = PostRawLocked(write_stream.GetData(), write_stream.GetPosition());
-
-	MemoryStream non_owning_read_stream((data_ptr_t)buffer_out.data(), buffer_out.size());
-	auto response_message = QuackMessage::FromMemoryStream(non_owning_read_stream);
-
-	// logging stuff, own scope
-	{
-		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-		                       .time_since_epoch()
-		                       .count();
-
-		auto request_type = request_message->Type();
-		string connection_id;
-		string query;
-		switch (request_type) {
-		case MessageType::PREPARE_REQUEST: {
-			auto &msg = request_message->Cast<PrepareRequestMessage>();
-			connection_id = msg.ConnectionId();
-			query = msg.Query();
-			break;
-		}
-		case MessageType::FETCH_REQUEST:
-			connection_id = request_message->Cast<FetchRequestMessage>().ConnectionId();
-			break;
-		case MessageType::SEND_DATA_REQUEST:
-			connection_id = request_message->Cast<SendDataRequestMessage>().ConnectionId();
-			break;
-		case MessageType::FINALIZE:
-			connection_id = request_message->Cast<FinalizeMessage>().ConnectionId();
-			break;
-		default:
-			break;
-		}
-
-		string error;
-		if (response_message->Type() == MessageType::ERROR_RESPONSE) {
-			error = response_message->Cast<ErrorResponse>().ErrorMessage();
-		}
-		// Use context-level logger when available for per-query log attribution; fall back to db-level.
-		auto &logger = context ? Logger::Get(*context) : Logger::Get(db);
-		if (logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL)) {
-			auto msg =
-			    QuackLogType::ConstructLogMessage(request_type, connection_id, client_query_id, query, uri.Http(),
-			                                      end_time - start_time, response_message->Type(), error);
-			logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
-		}
-	}
+	LogRequest(GetRequestLogger(context), request_message->Type(), request_message->ConnectionId(),
+	           request_message->ClientQueryId(), request_message->LoggableQuery(), duration_ms,
+	           response_message->Type(), error);
 
 	return response_message;
 }

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -124,9 +124,10 @@ static int64_t NowMillis() {
 class QuackSendDataTask : public AsyncTask {
 public:
 	QuackSendDataTask(unique_ptr<QuackClientWrapper> client_wrapper_p, unique_ptr<MemoryStream> payload_p,
-	                  idx_t payload_size_p, string connection_id_p, optional_idx client_query_id_p)
+	                  idx_t payload_size_p, string connection_id_p, optional_idx client_query_id_p,
+	                  shared_ptr<Logger> logger_p)
 	    : client_wrapper(std::move(client_wrapper_p)), payload(std::move(payload_p)), payload_size(payload_size_p),
-	      connection_id(std::move(connection_id_p)), client_query_id(client_query_id_p) {
+	      connection_id(std::move(connection_id_p)), client_query_id(client_query_id_p), logger(std::move(logger_p)) {
 	}
 
 	void Execute() override {
@@ -136,15 +137,16 @@ public:
 		auto response_body = client.PostRaw(nullptr, payload->GetData(), payload_size);
 		auto duration_ms = NowMillis() - start_time;
 
-		MemoryStream read_stream((data_ptr_t)response_body.data(), response_body.size());
-		auto response = QuackMessage::FromMemoryStream(read_stream);
+		auto response = QuackClient::DecodeResponse(response_body);
 
 		string error;
 		if (response->Type() == MessageType::ERROR_RESPONSE) {
 			error = response->Cast<ErrorResponse>().ErrorMessage();
 		}
-		client.LogRequest(MessageType::SEND_DATA_REQUEST, connection_id, client_query_id, string(), duration_ms,
-		                  response->Type(), error);
+		// Log through the context logger captured on the producer thread, so async SEND_DATA logs carry the
+		// query's connection/transaction/query id (the pool thread has no ClientContext).
+		client.LogRequest(Logger::Get(logger), MessageType::SEND_DATA_REQUEST, connection_id, client_query_id, string(),
+		                  duration_ms, response->Type(), error);
 
 		if (response->Type() == MessageType::ERROR_RESPONSE) {
 			response->Cast<ErrorResponse>().Error().Throw();
@@ -160,6 +162,7 @@ private:
 	idx_t payload_size;
 	string connection_id;
 	optional_idx client_query_id;
+	shared_ptr<Logger> logger;
 };
 
 //===--------------------------------------------------------------------===//
@@ -206,24 +209,16 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 		break;
 	}
 
-	// Read client_query_id on this regular thread; the async task must not touch ClientContext.
-	optional_idx client_query_id;
-	if (context.transaction.HasActiveTransaction()) {
-		auto raw_query_id = context.transaction.GetActiveQuery();
-		if (raw_query_id != DConstants::INVALID_INDEX) {
-			client_query_id = raw_query_id;
-			send_msg->SetClientQueryId(raw_query_id);
-		}
-	}
-
+	// Encode on the producer thread: the async task runs off-thread and must not touch ClientContext.
 	auto payload = make_uniq<MemoryStream>();
-	send_msg->ToMemoryStream(*payload);
+	QuackClient::EncodeRequest(context, *send_msg, *payload);
 	auto payload_size = payload->GetPosition();
 
-	auto connection_id = quack_catalog.GetConnectionId();
+	auto connection_id = send_msg->ConnectionId();
+	auto client_query_id = send_msg->ClientQueryId();
 	auto client_wrapper = quack_catalog.GetClientConnection()->GetClient(context);
 	gstate.queue->Register(make_uniq<QuackSendDataTask>(std::move(client_wrapper), std::move(payload), payload_size,
-	                                                    std::move(connection_id), client_query_id),
+	                                                    std::move(connection_id), client_query_id, context.logger),
 	                       payload_size);
 }
 
@@ -238,23 +233,16 @@ static void SendDeadRange(ClientContext &context, QuackInsertGlobalState &gstate
 	                                                  vector<unique_ptr<DataChunkWrapper>>(), gstate.query_uuid);
 	send_msg->SetDeadRange(lo, hi);
 
-	optional_idx client_query_id;
-	if (context.transaction.HasActiveTransaction()) {
-		auto raw_query_id = context.transaction.GetActiveQuery();
-		if (raw_query_id != DConstants::INVALID_INDEX) {
-			client_query_id = raw_query_id;
-			send_msg->SetClientQueryId(raw_query_id);
-		}
-	}
-
+	// Encode on the producer thread: the async task runs off-thread and must not touch ClientContext.
 	auto payload = make_uniq<MemoryStream>();
-	send_msg->ToMemoryStream(*payload);
+	QuackClient::EncodeRequest(context, *send_msg, *payload);
 	auto payload_size = payload->GetPosition();
 
-	auto connection_id = quack_catalog.GetConnectionId();
+	auto connection_id = send_msg->ConnectionId();
+	auto client_query_id = send_msg->ClientQueryId();
 	auto client_wrapper = quack_catalog.GetClientConnection()->GetClient(context);
 	gstate.queue->Register(make_uniq<QuackSendDataTask>(std::move(client_wrapper), std::move(payload), payload_size,
-	                                                    std::move(connection_id), client_query_id),
+	                                                    std::move(connection_id), client_query_id, context.logger),
 	                       payload_size);
 }
 

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -238,7 +238,7 @@ static void SendDeadRange(ClientContext &context, QuackInsertGlobalState &gstate
 	QuackClient::EncodeRequest(context, *send_msg, *payload);
 	auto payload_size = payload->GetPosition();
 
-	auto connection_id = send_msg->ConnectionId();
+	auto connection_id = quack_catalog.GetConnectionId();
 	auto client_query_id = send_msg->ClientQueryId();
 	auto client_wrapper = quack_catalog.GetClientConnection()->GetClient(context);
 	gstate.queue->Register(make_uniq<QuackSendDataTask>(std::move(client_wrapper), std::move(payload), payload_size,

--- a/test/sql/attach_insert_order.test
+++ b/test/sql/attach_insert_order.test
@@ -95,6 +95,16 @@ where message_type = 'SEND_DATA_REQUEST' and server is not null and server != ''
 ----
 true
 
+# Async SEND_DATA POSTs log through the context logger captured on the producer thread, so client-side
+# SEND_DATA logs are CONNECTION-scoped and carry the query's context ids. Assert none is mis-attributed
+# (previously these were DATABASE-scoped with null query_id/transaction_id, emitted via the db logger).
+query I
+select count(*) from duckdb_logs_parsed('Quack')
+where message_type = 'SEND_DATA_REQUEST' and server is not null and server != ''
+  and (scope != 'CONNECTION' or query_id is null or transaction_id is null);
+----
+0
+
 statement ok
 reset quack_send_data_flush_rows;
 


### PR DESCRIPTION
Separate Encoding, Decoding and LogRequest from `RequestInternal` in `QuackClient`. We keep `RequestInternal` as our "sync" flow, but paths that need async machinery (like `SEND_DATA` and in a subsequent PR, `FETCH_DATA`), can decouple serializing from the actual post request. This enables a better decoupling of regular executor threads doing the CPU bound computation and async threads doing only IO.

Moving the logger also cleaned up a bunch of code.