### PR TITLE
Bump quack serialization StorageVersion to v2_0_0

### DIFF
--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -105,7 +105,7 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 void QuackMessage::ToMemoryStream(MemoryStream &write_stream) const {
 	write_stream.Rewind();
 	SerializationOptions options;
-	options.storage_compatibility = StorageCompatibility::FromIndex(StorageVersion::V1_5_0);
+	options.storage_compatibility = StorageCompatibility::FromIndex(StorageVersion::V2_0_0);
 
 	BinarySerializer serializer(write_stream, options);
 


### PR DESCRIPTION
We could consider a process to opt-in to further available StorageVersions, but for now `v2_0_0` > `v1_5_0`