### PR TITLE
fix missing httplogs in async path

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -49,6 +49,10 @@ public:
 	void LogRequest(Logger &logger, MessageType request_type, const string &connection_id, optional_idx client_query_id,
 	                const string &query, int64_t duration_ms, MessageType response_type, const string &error);
 
+	//! Stamp the logger for this client's HTTP transport-log entries. Set at checkout so a pooled client
+	//! (incl. an async send whose pool thread has no ClientContext) logs under the checking-out query.
+	void SetRequestLogger(shared_ptr<Logger> logger);
+
 	static unique_ptr<QuackClient> GetClient(DatabaseInstance &db, const QuackUri &uri);
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
@@ -62,6 +66,8 @@ protected:
 	MemoryStream write_stream;
 	DatabaseInstance &db;
 	QuackUri uri;
+	//! HTTP transport-log logger, stamped at checkout (see SetRequestLogger).
+	shared_ptr<Logger> request_logger;
 
 private:
 	virtual unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
@@ -119,7 +125,7 @@ private:
 	                                         unique_ptr<QuackMessage> request_message) override;
 	//! POST bytes assuming request_mutex is already held.
 	string PostRawLocked(const_data_ptr_t data, idx_t size);
-	//! Lazily initialise http_params (context-aware); assumes request_mutex is held.
+	//! Lazily initialise http_params (context-aware) and attach request_logger; assumes request_mutex is held.
 	void EnsureHttpParams(optional_ptr<ClientContext> context);
 
 private:

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -62,6 +62,10 @@ Logger &QuackClient::GetRequestLogger(optional_ptr<ClientContext> context) {
 	return context ? Logger::Get(*context) : Logger::Get(db);
 }
 
+void QuackClient::SetRequestLogger(shared_ptr<Logger> logger) {
+	request_logger = std::move(logger);
+}
+
 void QuackClient::LogRequest(Logger &logger, MessageType request_type, const string &connection_id,
                              optional_idx client_query_id, const string &query, int64_t duration_ms,
                              MessageType response_type, const string &error) {
@@ -99,15 +103,19 @@ string HttpsQuackClient::PostRawLocked(const_data_ptr_t data, idx_t size) {
 }
 
 void HttpsQuackClient::EnsureHttpParams(optional_ptr<ClientContext> context) {
-	if (http_params) {
-		return;
+	if (!http_params) {
+		auto &http_util = HTTPUtil::Get(db);
+		auto request_url = uri.Http() + "/quack";
+		if (context && context->transaction.HasActiveTransaction()) {
+			http_params = http_util.InitializeParameters(*context, request_url);
+		} else {
+			http_params = http_util.InitializeParameters(db, request_url);
+		}
 	}
-	auto &http_util = HTTPUtil::Get(db);
-	auto request_url = uri.Http() + "/quack";
-	if (context && context->transaction.HasActiveTransaction()) {
-		http_params = http_util.InitializeParameters(*context, request_url);
-	} else {
-		http_params = http_util.InitializeParameters(db, request_url);
+	// http_params is cached across checkouts, so mirror the checkout's logger in each request; the guard
+	// skips the refcount churn when it is unchanged.
+	if (request_logger && http_params->logger != request_logger) {
+		http_params->logger = request_logger;
 	}
 }
 
@@ -216,6 +224,8 @@ unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &c
 		// instantiate a new client
 		result = QuackClient::GetClient(context, uri);
 	}
+	// Stamp the checking-out query's logger so this client's POSTs (incl. off-thread async sends) are logged.
+	result->SetRequestLogger(context.logger);
 	return make_uniq<QuackClientWrapper>(std::move(result), shared_from_this());
 }
 

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -138,6 +138,52 @@ select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.url like '%/qu
 ----
 true
 
+# --- HTTP logging (async insert path) ---
+# The async bulk-INSERT SEND_DATA POSTs must show up in the HTTP transport log, not just the Quack log.
+
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+CALL enable_logging(['HTTP','Quack']);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table rpc.log_t(i bigint);
+
+# UNORDERED (no small dead-range sends) + a small flush so one INSERT makes several async POSTs
+statement ok
+SET preserve_insertion_order=false;
+
+statement ok
+SET quack_send_data_flush_rows=50000;
+
+statement ok
+insert into rpc.log_t select * from range(200000) t(i);
+
+# sanity: the insert actually produced multiple async sends
+query I
+select count(*) > 1 from duckdb_logs_parsed('Quack') where message_type = 'SEND_DATA_REQUEST'
+----
+true
+
+# every SEND_DATA_REQUEST is now visible as a large-body HTTP POST (was ~1-2 of N before the fix)
+query I
+select
+  (select count(*) from duckdb_logs_parsed('Quack') where message_type = 'SEND_DATA_REQUEST')
+  = (select count(*) from duckdb_logs_parsed('HTTP')
+       where request.type = 'POST' and request.request_body_length > 100000)
+----
+true
+
+statement ok
+detach rpc
+
+statement ok
+SET preserve_insertion_order=true;
+
 # clean up
 statement ok
 CALL disable_logging();


### PR DESCRIPTION
This was introduced when splitting sync and async paths! Should be good now