### PR TITLE
Fix internal error when projecting quack_query results that span multiple fetch batches

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -332,9 +332,13 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 				bind_data.completed = true;
 				return;
 			}
-			// set up buffer for scan in next iteration
+			// tag fetched chunks like the initial batch (see QuackScanInitGlobal): direct queries
+			// return full-width chunks that still need projection, the catalog path already projected
+			auto fetched_pushdown_type = bind_data.table_name.empty()
+			                                 ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
+			                                 : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
 			for (auto &chunk : fetch_response->MutableResults()) {
-				local_state.results.emplace(chunk->Chunk(), ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
+				local_state.results.emplace(chunk->Chunk(), fetched_pushdown_type);
 			}
 			local_state.current_batch_index = fetch_response->BatchIndex();
 			continue;

--- a/test/sql/fetch_projection.test
+++ b/test/sql/fetch_projection.test
@@ -1,0 +1,26 @@
+# name: test/sql/fetch_projection.test
+# description: projection over quack_query results that span multiple FETCH batches
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+# 30000 rows x 2 cols => ~15 DataChunks of 2048 => exceeds quack_fetch_batch_chunks (12),
+# forcing at least one FETCH round-trip after the initial PREPARE batch.
+statement ok quack_db:quack_server_con
+create table big as select range as a, range * 2 as b from range(30000);
+
+# Inner query returns 2 columns; the outer aggregate only needs column a, so DuckDB
+# prunes the scan output to width 1. Fetched chunks are still full-width and must be
+# projected locally — previously this raised an INTERNAL error (vector index overrun).
+query III
+select count(*), min(a), max(a) from quack_query({server}, 'SELECT * FROM big', token='asdf')
+----
+30000	0	29999
+
+# Projecting the second column verifies the local projection picks the right column index.
+query III
+select count(*), min(b), max(b) from quack_query({server}, 'SELECT * FROM big', token='asdf')
+----
+30000	0	59998
+
+include test/template/quack_teardown.test_template


### PR DESCRIPTION
**Overview**

Currently on main, queries against `quack_query(...)` throw an internal error when:
- the result is large enough to exceed one fetch batch (`quack_fetch_batch_chunks`, default 12)
AND
- DuckDB prunes the scan output to fewer columns than the inner query returns (e.g. an aggregate over one column of a two-column select)

You get an error like:
```
INTERNAL Error:
Attempted to access index 1 within vector of size 1
```

This PR fixes it by mirroring the `QuackScanInitGlobal` discriminator when tagging fetched chunks:
- `REQUIRES_PUSHDOWN` when `table_name` is empty (direct query)
- `PUSHDOWN_ALREADY_APPLIED` otherwise (catalog path)

**Root cause**

`QuackScan` tags each result chunk with whether projection still needs to be applied locally. For the initial batch, `QuackScanInitGlobal` does this by:
- on catalog/attach path (`table_name` set), rewriting the query with `BuildPushdownQuery`, so the server already projected (`PUSHDOWN_ALREADY_APPLIED`)
- on direct `quack_query('...')`, shipping the caller's SQL verbatim. the chunks come back full-width and need local projection (`REQUIRES_PUSHDOWN`).

The part I changed is the fetch path in `QuackScan`, where `PUSHDOWN_ALREADY_APPLIED` was hardcoded for every fetched chunk. For the direct-query path this made `DataChunk::Reference` wire a full-width chunk into the narrower pruned output, indexing past the end of the output's columns. That's why the first ~12 chunks scan fine and the error only fires once a chunk arrives via a fetch round-trip.

**Testing**
I added `test/sql/fetch_projection.test`, which creates 30000 rows with 2 columns. This forces a fetch round-trip past the 12-chunk batch limit, then aggregates over each column to verify both the width handling and that local projection picks the right column. It fails on main and passes with this change.