### PR TITLE
Queries against materialized views backed by S3/hive Parquet files crashed the extension client side

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -302,22 +302,31 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 
 			auto &response_chunk = chunk.Chunk();
 			if (response_chunk.size() > 0) {
-				if (!chunk.RequiresPushdown()) {
-					output.Reference(response_chunk);
-				} else {
-					for (idx_t i = 0; i < global_state.column_ids.size(); i++) {
-						auto &index = global_state.column_ids[i];
-						if (index.IsVirtualColumn()) {
-							// TODO
-							output.data[i].Reference(Value(output.data[i].GetType()));
-							return;
-						}
-						auto col_idx = index.GetPrimaryIndex();
-						output.data[i].Reference(response_chunk.data[col_idx]);
-					}
-					output.SetCardinality(response_chunk.size());
-				}
-				return;
+		    if (!chunk.RequiresPushdown()) {
+            output.Reference(response_chunk);
+        } else {
+            // Respect projection_ids if DuckDB pruned the columns during pushdown
+            bool has_projection = !global_state.projection_ids.empty();
+            idx_t num_cols = has_projection ? global_state.projection_ids.size() : global_state.column_ids.size();
+
+            for (idx_t i = 0; i < num_cols; i++) {
+                auto &index = has_projection
+                                ? global_state.column_ids[global_state.projection_ids[i]]
+                                : global_state.column_ids[i];
+
+                if (index.IsVirtualColumn()) {
+                    // Safely fill virtual columns (e.g., ROW_ID) with NULLs and continue
+                    output.data[i].SetVectorType(VectorType::CONSTANT_VECTOR);
+                    ConstantVector::SetNull(output.data[i], true);
+                    continue;
+                }
+
+                auto col_idx = index.GetPrimaryIndex();
+                output.data[i].Reference(response_chunk.data[col_idx]);
+            }
+            output.SetCardinality(response_chunk.size());
+        }
+        return;
 			}
 		}
 
@@ -333,10 +342,13 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 				global_state.needs_more_fetch = false;
 				return;
 			}
-			// set up buffer for scan in next iteration
-			for (auto &chunk : fetch_response->MutableResults()) {
-				local_state.results.emplace(chunk->Chunk(), ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
-			}
+            // set up buffer for scan in next iteration
+            for (auto &chunk : fetch_response->MutableResults()) {
+                auto pushdown_type = bind_data.table_name.empty()
+                                        ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
+                                        : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
+                local_state.results.emplace(chunk->Chunk(), pushdown_type);
+            }
 			local_state.current_batch_index = fetch_response->BatchIndex();
 			continue;
 		}


### PR DESCRIPTION
I'm experimenting with quack protocol, I have a view materialized out of parquet files and exposed via quack.

When doing a `select count(*) from remote.myview;`

```
INTERNAL Error:
Vector::Reference used on vector of different type (source VARCHAR referenced BIGINT)

Stack Trace:

/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0xad6cd3) [0x7fb9166d6cd3]
/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0xad6d32) [0x7fb9166d6d32]
/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0xad93a1) [0x7fb9166d93a1]
/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0x9ba839) [0x7fb9165ba839]
/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0x1a747c) [0x7fb915da747c]
/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0x9daff8) [0x7fb9165daff8]
/home/akh/.duckdb/extensions/v1.5.4/linux_amd64/quack.duckdb_extension(+0x4fd228) [0x7fb9160fd228]
/home/akh/Downloads/duckdb_cli-linux-amd64() [0x1b2937f]
/home/akh/Downloads/duckdb_cli-linux-amd64() [0xdf047b]
/home/akh/Downloads/duckdb_cli-linux-amd64() [0xdf866d]
/home/akh/Downloads/duckdb_cli-linux-amd64() [0xdf89c2]
/home/akh/Downloads/duckdb_cli-linux-amd64() [0xdf17b6]
/home/akh/Downloads/duckdb_cli-linux-amd64() [0xdfb026]
/usr/lib/libstdc++.so.6(+0xeb919) [0x7fb934ceb919]
/usr/lib/libc.so.6(+0x981b9) [0x7fb9348981b9]
/usr/lib/libc.so.6(+0x11d21c) [0x7fb93491d21c]

This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see [https://duckdb.org/docs/stable/dev/internal_errors](https://www.google.com/url?sa=E&q=https%3A%2F%2Fduckdb.org%2Fdocs%2Fstable%2Fdev%2Finternal_errors)
```

The same select with a LIMIT 1 works.

The request is passing through a reverse proxy (envoy) but all the sub requests are 200.

I've tasked Gemini and Deepseek to work on the issue.

After recompiling the extension, just on the client side, the problem is gone:

This occurs on the `REQUIRES_PUSHDOWN` code path in `QuackScan` when DuckDB pushes down column projections. Three bugs combine to cause the crash:

### 1. Column projection misalignment

When DuckDB's optimizer prunes or reorders columns via `projection_ids`, the scan loop ignores them and blindly indexes into `column_ids`. A `VARCHAR` column ends up written into a slot DuckDB expects to hold `BIGINT`, triggering the `Vector::Reference` type assertion.

### 2. Virtual column crash

When a virtual column such as `ROW_ID` (used by `COUNT(*)`) is requested, the loop hits a bare `return` statement. This aborts the scan before `SetCardinality` runs, leaving a dangling DataChunk with uninitialized size.

### 3. FETCH chunks skip pushdown

DuckDB streams large results in batches of ~12 chunks. After the `PREPARE` response, subsequent `FETCH` responses are unconditionally flagged `PUSHDOWN_ALREADY_APPLIED`. Chunk 1–12 go through the projection logic correctly, but chunks 13+ bypass it entirely, reproducing the original misalignment crash on every batch boundary.

## Fix

**`src/quack_scan.cpp`** — two changes in `QuackScan`:

1. **RESPONSE_CHUNK handling**: detect whether `projection_ids` is non-empty and use it to route `response_chunk.data[col_idx]` into the correct output slot. Replace the `return` on virtual columns with `continue` and inject a `CONSTANT NULL` so cardinality is always set.

2. **FETCH response loop**: tag each fetched chunk dynamically — `REQUIRES_PUSHDOWN` when `bind_data.table_name` is empty (remote views/macros), otherwise `PUSHDOWN_ALREADY_APPLIED`. This ensures every batch, not just the first, goes through the corrected projection logic.

