### PR TITLE
Fix reset client pooled logger

### DIFF
--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -112,10 +112,14 @@ void HttpsQuackClient::EnsureHttpParams(optional_ptr<ClientContext> context) {
 			http_params = http_util.InitializeParameters(db, request_url);
 		}
 	}
-	// http_params is cached across checkouts, so mirror the checkout's logger in each request; the guard
-	// skips the refcount churn when it is unchanged.
-	if (request_logger && http_params->logger != request_logger) {
-		http_params->logger = request_logger;
+	// http_params is cached across checkouts; re-scope its logger each request so a context-less
+	// teardown on a pooled client never logs under a prior query's scope.
+	if (request_logger) {
+		if (http_params->logger != request_logger) {
+			http_params->logger = request_logger;
+		}
+	} else if (!context) {
+		http_params->logger.reset();
 	}
 }
 
@@ -235,6 +239,8 @@ void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) const 
 		// already exceeded max cache size
 		return;
 	}
+	// A pooled client has no owning query; drop the stamp so later teardown doesn't log under it.
+	client_p->SetRequestLogger(nullptr);
 	cached_clients.push_back(std::move(client_p));
 }
 

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -184,6 +184,44 @@ detach rpc
 statement ok
 SET preserve_insertion_order=true;
 
+# --- HTTP logging (context-less teardown scope) ---
+# A pooled client's DISCONNECT POST is context-less and must not be logged under the
+# connection scope of a query that already ran on that pooled connection.
+
+statement ok
+CALL disable_logging();
+
+statement ok
+CALL enable_logging('HTTP');
+
+statement ok
+attach {server} as rpc_td (token 'asdf')
+
+statement ok
+create table rpc_td.teardown_t(i bigint);
+
+statement ok
+insert into rpc_td.teardown_t values (1);
+
+# sanity: the query's own POSTs are connection-scoped (non-null connection id)
+query I
+select count(*) > 0 from duckdb_logs_parsed('HTTP') where request.type = 'POST' and connection_id is not null
+----
+true
+
+# clear the query's logs so only the detach's DISCONNECT traffic follows
+statement ok
+CALL truncate_duckdb_logs();
+
+statement ok
+detach rpc_td
+
+# the DISCONNECT POST must not carry the finished query's connection id
+query I
+select count(*) = 0 from duckdb_logs_parsed('HTTP') where request.type = 'POST' and connection_id is not null
+----
+true
+
 # clean up
 statement ok
 CALL disable_logging();


### PR DESCRIPTION
If the client logger is not reset correctly, some logging operations with no context may contain incorrect context from a previous query. My bad!