### PR TITLE
Add optional EXTRA_HTTP_HEADERS to the quack secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ FROM remote.hello;
 
 This should show the content of the remote table `hello` on the client side.
 
+The `quack` secret also accepts an optional `EXTRA_HTTP_HEADERS` map. Any headers
+provided there are attached to every HTTP request the client sends to the server,
+which is useful for authenticating through a proxy or load balancer in front of the
+Quack server:
+
+```sql
+CREATE SECRET (
+    TYPE quack,
+    TOKEN 'super_secret',
+    EXTRA_HTTP_HEADERS MAP {'X-Api-Key': 'my-key', 'X-Tenant': 'acme'}
+);
+```
+
 We can also copy data from client to server:
 
 ```sql

--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -95,6 +95,9 @@ private:
 
 private:
 	unique_ptr<HTTPParams> http_params;
+	//! Extra HTTP headers resolved once from the `quack` secret (EXTRA_HTTP_HEADERS),
+	//! injected into every request. Loaded lazily alongside http_params.
+	HTTPHeaders extra_headers;
 };
 
 } // namespace duckdb

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -1,3 +1,5 @@
+#include "duckdb/catalog/catalog_transaction.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
@@ -12,6 +14,28 @@ string GetUriPart(T ele) {
 		throw InvalidInputException("Invalid URI");
 	}
 	return string(ele.first, ele.afterLast - ele.first);
+}
+
+//! Resolve the optional EXTRA_HTTP_HEADERS from the `quack` secret scoped to this URI and add them
+//! to `headers`. Silently does nothing when no matching secret / header map is present.
+static void LoadExtraHttpHeaders(optional_ptr<ClientContext> context, DatabaseInstance &db, const QuackUri &uri,
+                                 HTTPHeaders &headers) {
+	auto &secret_manager = SecretManager::Get(db);
+	auto transaction = context ? CatalogTransaction::GetSystemCatalogTransaction(*context)
+	                           : CatalogTransaction::GetSystemTransaction(db);
+	auto match = secret_manager.LookupSecret(transaction, uri.Uri(), "quack");
+	if (!match.HasMatch()) {
+		return;
+	}
+	const auto &kv = dynamic_cast<const KeyValueSecret &>(*match.secret_entry->secret);
+	Value headers_value;
+	if (!kv.TryGetValue("extra_http_headers", headers_value) || headers_value.IsNull()) {
+		return;
+	}
+	for (const auto &entry : MapValue::GetChildren(headers_value)) {
+		const auto &kv_pair = StructValue::GetChildren(entry);
+		headers.Insert(kv_pair[0].ToString(), kv_pair[1].ToString());
+	}
 }
 
 QuackClient::QuackClient(DatabaseInstance &db_p, const QuackUri &uri_p) : db(db_p), uri(uri_p) {
@@ -39,9 +63,11 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		} else {
 			http_params = http_util.InitializeParameters(db, request_url);
 		}
+		// Resolve EXTRA_HTTP_HEADERS from the quack secret once; reused for every request on this client.
+		LoadExtraHttpHeaders(context, db, uri, extra_headers);
 	}
 
-	HTTPHeaders headers;
+	HTTPHeaders headers = extra_headers;
 
 	// Inject client_query_id from context into the message before sending.
 	// Guard against reading the active query during transaction start itself

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -39,6 +39,9 @@ static unique_ptr<BaseSecret> CreateQuackSecretFromConfig(ClientContext &, Creat
 		auto lower_name = StringUtil::Lower(named_param.first);
 		if (lower_name == "token") {
 			secret->secret_map["token"] = named_param.second.ToString();
+		} else if (lower_name == "extra_http_headers") {
+			// Stored as a MAP(VARCHAR, VARCHAR) Value; injected into every quack HTTP request.
+			secret->secret_map["extra_http_headers"] = named_param.second;
 		} else {
 			throw InvalidInputException("Unknown named parameter for quack secret: %s", lower_name);
 		}
@@ -57,6 +60,7 @@ static void RegisterQuackSecretType(ExtensionLoader &loader) {
 
 	CreateSecretFunction config_fun = {QUACK_SECRET_TYPE, "config", CreateQuackSecretFromConfig};
 	config_fun.named_parameters["token"] = LogicalType::VARCHAR;
+	config_fun.named_parameters["extra_http_headers"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 	loader.RegisterFunction(config_fun);
 }
 

--- a/test/sql/secret_extra_http_headers.test
+++ b/test/sql/secret_extra_http_headers.test
@@ -1,0 +1,65 @@
+# name: test/sql/secret_extra_http_headers.test
+# description: quack secret accepts an optional EXTRA_HTTP_HEADERS map that is injected into quack interactions
+# group: [sql]
+
+require quack
+
+require httpfs
+
+statement ok con1
+call quack_serve('quack:localhost:20111', token='s3kr3t');
+
+sleep 100 millisecond
+
+# --- The secret stores the extra_http_headers map (not redacted) ---
+
+statement ok con2
+create secret quack_hdr (
+    type quack,
+    token 's3kr3t',
+    extra_http_headers MAP {'X-Custom-Header': 'quack-value', 'X-Trace': 'abc123'},
+    scope 'quack:localhost:20111'
+)
+
+query I con2
+select secret_string like '%extra_http_headers%' from duckdb_secrets() where name = 'quack_hdr'
+----
+true
+
+# --- Requests still succeed with the extra headers injected (server ignores unknown headers) ---
+
+statement ok con2
+attach 'quack:localhost:20111' as r_hdr (type quack)
+
+query II con2
+from r_hdr.query('select 1, 2')
+----
+1	2
+
+statement ok con2
+detach r_hdr
+
+statement ok con2
+drop secret quack_hdr
+
+# --- A secret without extra_http_headers keeps working unchanged ---
+
+statement ok con2
+create secret quack_plain (type quack, token 's3kr3t', scope 'quack:localhost:20111')
+
+statement ok con2
+attach 'quack:localhost:20111' as r_plain (type quack)
+
+query II con2
+from r_plain.query('select 3, 4')
+----
+3	4
+
+statement ok con2
+detach r_plain
+
+statement ok con2
+drop secret quack_plain
+
+statement ok con1
+call quack_stop('quack:localhost:20111')


### PR DESCRIPTION
The `quack` secret (TYPE quack) now accepts an optional EXTRA_HTTP_HEADERS map of VARCHAR->VARCHAR. Any headers provided are injected into every HTTP request the quack client sends to the server (connect/prepare/fetch/append/ disconnect all funnel through HttpsQuackClient::RequestInternal), which is useful for authenticating through a proxy or load balancer in front of the Quack server.

The headers are resolved once per client from the URI-scoped secret and reused for all subsequent requests. Adds a SQL test and README docs.

Note: this works explicitly for connection TO a quack endpoint.
An alternative, if you want to cover all traffic, is for example an explicit `HTTP` secret, see for example https://duckdb.org/docs/lts/core_extensions/httpfs/https#authenticating