### PR TITLE
Refactor server to elastic pool of workers

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -76,8 +76,7 @@ private:
 
 class QuackClientConnection : public enable_shared_from_this<QuackClientConnection> {
 public:
-	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
-	                               idx_t max_connections_cached = 1);
+	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p);
 	~QuackClientConnection();
 
 	void CancelQuery(hugeint_t query_uuid);
@@ -98,8 +97,9 @@ private:
 	QuackUri uri;
 	string connection_id;
 	mutable mutex lock;
+	//! All returned clients are cached; the count is naturally bounded by the high-water mark of
+	//! concurrent checkouts (task pools), and idle sockets are reaped by the server's keep-alive.
 	mutable vector<unique_ptr<QuackClient>> cached_clients;
-	idx_t max_connections_cached;
 };
 
 struct QuackClientWrapper {
@@ -130,6 +130,9 @@ private:
 
 private:
 	unique_ptr<HTTPParams> http_params;
+	//! Persistent keep-alive HTTP client: reused across requests so the TCP connection (and its
+	//! warm congestion window) survives between POSTs; replaced by the retry path on dead sockets.
+	unique_ptr<HTTPClient> http_client;
 };
 
 } // namespace duckdb

--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -76,7 +76,8 @@ private:
 
 class QuackClientConnection : public enable_shared_from_this<QuackClientConnection> {
 public:
-	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p);
+	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
+	                               idx_t max_connections_cached = 1);
 	~QuackClientConnection();
 
 	void CancelQuery(hugeint_t query_uuid);
@@ -97,8 +98,9 @@ private:
 	QuackUri uri;
 	string connection_id;
 	mutable mutex lock;
-	//! All returned clients are cached; the count is naturally bounded by the high-water mark of
-	//! concurrent checkouts (task pools), and idle sockets are reaped by the server's keep-alive.
+	//! Bounds cached_clients: each cached client holds a persistent socket that pins a server
+	//! connection slot, so an unbounded cache would let one attach starve the server's budget.
+	idx_t max_connections_cached;
 	mutable vector<unique_ptr<QuackClient>> cached_clients;
 };
 

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
-#include "duckdb/parallel/task_scheduler.hpp"
 
 #include "quack_client.hpp"
 #include "quack_uri.hpp"
@@ -90,7 +89,7 @@ string HttpsQuackClient::PostRawLocked(const_data_ptr_t data, idx_t size) {
 	PostRequestInfo post_request(request_url, headers, *http_params, data, size);
 	unique_ptr<HTTPResponse> response;
 	try {
-		response = http_util.Request(post_request);
+		response = http_util.Request(post_request, http_client);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
 		throw IOException("Failed to send message: %s", error.Message());
@@ -162,9 +161,8 @@ unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const Qua
 	return GetClient(*context.db, uri);
 }
 
-QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
-                                             idx_t max_connections_cached)
-    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)), max_connections_cached(max_connections_cached) {
+QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p)
+    : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)) {
 	if (client_p) {
 		StoreClient(std::move(client_p));
 	}
@@ -209,8 +207,7 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	}
 	// success! we got a connection id
 	auto connection_id = connection_request_response->ConnectionId();
-	idx_t pool_size = MaxValue<idx_t>(1, (idx_t)TaskScheduler::GetScheduler(context).NumberOfAsyncThreads());
-	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id), pool_size);
+	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id));
 }
 
 unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &context) const {
@@ -231,10 +228,6 @@ unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &c
 
 void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) const {
 	lock_guard<mutex> guard(lock);
-	if (cached_clients.size() >= max_connections_cached) {
-		// already exceeded max cache size
-		return;
-	}
 	cached_clients.push_back(std::move(client_p));
 }
 

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -177,6 +177,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Rows a thread buffers before flushing one SEND_DATA_REQUEST (0 = default 204800)",
 	                          LogicalType::UBIGINT, Value::UBIGINT(0));
 
+	config.AddExtensionOption("quack_server_max_connections",
+	                          "Maximum concurrent connections the RPC server accepts; beyond this new "
+	                          "connections are refused",
+	                          LogicalType::UBIGINT, Value::UBIGINT(1024), nullptr, SetScope::GLOBAL);
+	config.AddExtensionOption("quack_server_keep_alive_timeout",
+	                          "Seconds an idle keep-alive connection is kept open by the RPC server",
+	                          LogicalType::UBIGINT, Value::UBIGINT(300), nullptr, SetScope::GLOBAL);
+
 	// Process-wide fallback anchor for whoami().uptime when whoami_started_at isn't set.
 	// Stored as BIGINT epoch-microseconds to stay TZ-invariant regardless of ICU state.
 	config.AddExtensionOption("quack_loaded_at_us", "Epoch microseconds at extension load", LogicalType::BIGINT,

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
 
 #include "quack_server.hpp"
 #include "quack_message.hpp"
@@ -6,7 +8,130 @@
 
 #include "httplib.hpp"
 
+#include <condition_variable>
+#include <deque>
+#include <unordered_set>
+
 namespace duckdb {
+
+//! httplib hands each accepted socket to the task queue as one task spanning the connection's whole
+//! keep-alive lifetime, so a fixed pool deadlocks once idle connections pin every worker. This pool
+//! grows a thread per connection up to `max_threads` and sheds at the cap (clients retry).
+class ElasticThreadPool final : public duckdb_httplib::TaskQueue {
+public:
+	explicit ElasticThreadPool(idx_t max_threads_p) : max_threads(max_threads_p) {
+	}
+
+	~ElasticThreadPool() override {
+		shutdown();
+	}
+
+	bool enqueue(std::function<void()> fn) override {
+		std::unique_lock<std::mutex> guard(lock);
+		JoinFinishedWorkers(guard);
+		// Re-checked after JoinFinishedWorkers: it drops the lock, so shutdown() may have
+		// started meanwhile and a worker spawned now would never be joined.
+		if (shutting_down) {
+			return false;
+		}
+		// A notified worker may not have decremented idle_workers yet, so queued jobs each claim one
+		// idle worker; without this surplus check a burst of accepts can queue a job nobody picks up.
+		if (idle_workers > jobs.size()) {
+			jobs.push_back(std::move(fn));
+			cv.notify_one();
+			return true;
+		}
+		if (live_workers >= max_threads) {
+			return false;
+		}
+		jobs.push_back(std::move(fn));
+		try {
+			workers.emplace_back(&ElasticThreadPool::WorkerLoop, this);
+		} catch (...) {
+			// Thread creation can fail under resource pressure; shed this connection.
+			jobs.pop_back();
+			return false;
+		}
+		live_workers++;
+		return true;
+	}
+
+	void shutdown() override {
+		std::unique_lock<std::mutex> guard(lock);
+		if (!shutting_down) {
+			shutting_down = true;
+			cv.notify_all();
+		}
+		done_cv.wait(guard, [&] { return live_workers == 0; });
+		JoinFinishedWorkers(guard);
+	}
+
+private:
+	void WorkerLoop() {
+		std::unique_lock<std::mutex> guard(lock);
+		for (;;) {
+			idle_workers++;
+			bool has_work = cv.wait_for(guard, std::chrono::milliseconds(IDLE_WORKER_TIMEOUT_MS),
+			                            [&] { return !jobs.empty() || shutting_down; });
+			idle_workers--;
+			if (!jobs.empty()) {
+				auto fn = std::move(jobs.front());
+				jobs.pop_front();
+				guard.unlock();
+				fn();
+				guard.lock();
+				continue;
+			}
+			if (shutting_down || !has_work) {
+				// Idle for the full timeout (or shutting down): exit to shrink the pool.
+				break;
+			}
+		}
+		live_workers--;
+		finished_workers.insert(std::this_thread::get_id());
+		if (shutting_down && live_workers == 0) {
+			done_cv.notify_all();
+		}
+	}
+
+	//! Join threads that have exited (self-reaped or shut down). Caller holds `lock`.
+	void JoinFinishedWorkers(std::unique_lock<std::mutex> &guard) {
+		if (finished_workers.empty()) {
+			return;
+		}
+		std::vector<std::thread> to_join;
+		for (auto it = workers.begin(); it != workers.end();) {
+			if (finished_workers.count(it->get_id())) {
+				finished_workers.erase(it->get_id());
+				to_join.push_back(std::move(*it));
+				it = workers.erase(it);
+			} else {
+				++it;
+			}
+		}
+		// The exited threads may still be between "finished_workers.insert" and returning;
+		// join outside the lock so they can finish their epilogue.
+		guard.unlock();
+		for (auto &thread : to_join) {
+			thread.join();
+		}
+		guard.lock();
+	}
+
+private:
+	static constexpr uint64_t IDLE_WORKER_TIMEOUT_MS = 30000;
+
+	const idx_t max_threads;
+	std::mutex lock;
+	std::condition_variable cv;
+	std::condition_variable done_cv;
+	std::deque<std::function<void()>> jobs;
+	std::vector<std::thread> workers;
+	std::unordered_set<std::thread::id> finished_workers;
+	idx_t live_workers = 0;
+	idx_t idle_workers = 0;
+	bool shutting_down = false;
+};
 
 void HttpQuackServer::StopAccepting() {
 	// Closes the listening socket only. Idempotent. Safe to call from a
@@ -65,16 +190,23 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
     : QuackServer(context_p, uri_p, token_p) {
 	server = make_uniq<duckdb_httplib::Server>();
 
-	// Each keep-alive connection holds a server thread for its lifetime.
-	// We need enough threads to handle all concurrent keep-alive connections
-	// (catalog clients + scan thread clients) simultaneously, otherwise requests
-	// from scan thread clients can deadlock waiting for threads held by the
-	// catalog clients that are in turn waiting for the scan to complete.
-	server->new_task_queue = [] {
-		return new duckdb_httplib::ThreadPool(128);
+	// The elastic pool makes idle cached client connections cheap (one sleeping thread each,
+	// reaped on close) and turns pool exhaustion into load shedding instead of deadlock.
+	auto &db_config = DBConfig::GetConfig(*context_p.db);
+	Value max_connections_val = Value::UBIGINT(1024);
+	db_config.TryGetCurrentSetting("quack_server_max_connections", max_connections_val);
+	auto max_connections = MaxValue<idx_t>(1, max_connections_val.GetValue<idx_t>());
+	Value keep_alive_timeout_val = Value::UBIGINT(300);
+	db_config.TryGetCurrentSetting("quack_server_keep_alive_timeout", keep_alive_timeout_val);
+	auto keep_alive_timeout = MaxValue<idx_t>(1, keep_alive_timeout_val.GetValue<idx_t>());
+
+	server->new_task_queue = [max_connections] {
+		return new ElasticThreadPool(max_connections);
 	};
-	server->set_keep_alive_max_count(128);
-	server->set_keep_alive_timeout(10);
+	// Requests per connection before a forced close; effectively unlimited now that a cached
+	// client connection is expected to live for a whole session.
+	server->set_keep_alive_max_count(1 << 20);
+	server->set_keep_alive_timeout(NumericCast<time_t>(keep_alive_timeout));
 	server->set_tcp_nodelay(true);
 
 	server->Get("/", [=](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {

--- a/test/sql/server_connection_limits.test
+++ b/test/sql/server_connection_limits.test
@@ -1,0 +1,74 @@
+# name: test/sql/server_connection_limits.test
+# description: quack_server_max_connections sheds excess connections cleanly; idle sockets closed by quack_server_keep_alive_timeout self-heal on the client.
+# group: [sql]
+
+require quack
+
+require httpfs
+
+test-env QUACK_SERVER quack:localhost
+
+set ignore_error_messages
+
+# Server with a hard cap of 1 concurrent connection and a 1-second keep-alive, so both
+# limits are exercised quickly. Settings must be in place before quack_serve reads them.
+statement ok quack_db:quack_server_con
+SET quack_server_max_connections=1;
+
+statement ok quack_db:quack_server_con
+SET quack_server_keep_alive_timeout=1;
+
+statement ok quack_db:quack_server_con
+set variable actual_listen_uri = (select listen_uri from quack_serve('{QUACK_SERVER}:0', token='asdf'));
+
+query I quack_db:quack_server_con
+set variable listen_uri = concat('''', getvariable('actual_listen_uri'), '''');
+
+set variable server <variable:quack_server_con:listen_uri>
+
+# Keep the client single-threaded so one cached connection carries the whole session.
+statement ok
+SET threads=1;
+
+# A single client fits in the 1-connection budget: attach, write, read.
+statement ok
+ATTACH {server} AS rpc1 (TYPE quack, TOKEN 'asdf');
+
+statement ok
+CREATE TABLE rpc1.t1 AS SELECT range AS i FROM range(100);
+
+query I
+SELECT count(*) FROM rpc1.t1;
+----
+100
+
+# The cap is taken by rpc1's cached connection: a second attach is shed (socket closed by
+# the server), surfacing as a request error after client retries — not a hang.
+statement error
+ATTACH {server} AS rpc2 (TYPE quack, TOKEN 'asdf');
+----
+Failed to send message
+
+# Detaching releases rpc1's sockets, freeing the connection slot for a new client.
+statement ok
+DETACH rpc1;
+
+statement ok
+ATTACH {server} AS rpc2 (TYPE quack, TOKEN 'asdf');
+
+query I
+SELECT count(*) FROM rpc2.t1;
+----
+100
+
+# Idle past the server keep-alive: the server closes the socket. The client's cached
+# connection is now stale and must self-heal (retry on a fresh socket) transparently.
+sleep 2 seconds
+
+query I
+SELECT count(*) FROM rpc2.t1;
+----
+100
+
+statement ok
+DETACH rpc2;


### PR DESCRIPTION
This PR removes the default pool of 128 worker threads on the server side and replaces it with an elastic pool. Amongst other things, removing this limit allows us to remove the cap on cached connections and avoid deadlocks when the number of concurrent connections reaches 128. Reusing sockets does improve transactional workloads in localhost up to 1.2x so I'm guessing in WAN this will be considerable.

This is a simpler alternative/straight forward fix that avoids re-engineering the server into a fool event loop driven machine.

PS: Don't mind the name of the branch, I was experimenting with event loops and ergo it's called like that but there's no event loop!