### PR TITLE
Fix pushdown type of fetched continuation batches for bind-time results (attached views, quack_query)

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -144,10 +144,11 @@ struct QuackScanLocalState : public LocalTableFunctionState {
 
 struct QuackScanGlobalState : GlobalTableFunctionState {
 	explicit QuackScanGlobalState(vector<ColumnIndex> column_ids_p, vector<idx_t> projection_id_p,
-	                              vector<ChunkResult> results_p, bool needs_more_fetch_p, hugeint_t result_uuid_p)
+	                              vector<ChunkResult> results_p, bool needs_more_fetch_p, hugeint_t result_uuid_p,
+	                              ChunkResultPushdownType fetch_pushdown_type_p)
 	    : max_threads(needs_more_fetch_p ? MAX_THREADS : 1), column_ids(std::move(column_ids_p)),
 	      projection_ids(std::move(projection_id_p)), needs_more_fetch(needs_more_fetch_p), result_uuid(result_uuid_p),
-	      results(std::move(results_p)) {
+	      fetch_pushdown_type(fetch_pushdown_type_p), results(std::move(results_p)) {
 	}
 	idx_t MaxThreads() const override {
 		return max_threads;
@@ -157,6 +158,12 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
 	hugeint_t result_uuid;
+	//! How chunks fetched AFTER the initial batch must be treated. When the scan was
+	//! executed via a server-side pushdown query (catalog table scan), fetched chunks
+	//! already have the projection applied. When the scan consumes a bind-time result
+	//! (quack_query / quack_query_by_name, incl. ATTACH'd views), fetched chunks are
+	//! full-width continuations and still require client-side pushdown.
+	ChunkResultPushdownType fetch_pushdown_type;
 
 	vector<ChunkResult> TryGetResults() {
 		lock_guard<mutex> guard(lock);
@@ -247,6 +254,8 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	vector<ChunkResult> results;
 	bool needs_more_fetch = bind_data.needs_more_fetch;
 	hugeint_t result_uuid;
+	auto fetch_pushdown_type = bind_data.table_name.empty() ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
+	                                                        : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
 	if (!bind_data.table_name.empty()) {
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
@@ -271,7 +280,7 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	}
 	// we only multithread if there is more to fetch
 	return make_uniq<QuackScanGlobalState>(input.column_indexes, input.projection_ids, std::move(results),
-	                                       needs_more_fetch, result_uuid);
+	                                       needs_more_fetch, result_uuid, fetch_pushdown_type);
 }
 
 unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
@@ -335,7 +344,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 			}
 			// set up buffer for scan in next iteration
 			for (auto &chunk : fetch_response->MutableResults()) {
-				local_state.results.emplace(chunk->Chunk(), ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
+				local_state.results.emplace(chunk->Chunk(), global_state.fetch_pushdown_type);
 			}
 			local_state.current_batch_index = fetch_response->BatchIndex();
 			continue;

--- a/test/sql/attach_view_fetch_projection.test
+++ b/test/sql/attach_view_fetch_projection.test
@@ -1,8 +1,9 @@
-# name: test/sql/attach_view_fetch_projection.test_slow
+# name: test/sql/attach_view_fetch_projection.test
 # description: projected scan of an attached view whose result spans multiple fetch batches.
 #              Regression test: continuation batches of a bind-time result were tagged
 #              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
-#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N").
+#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N",
+#              or a Vector::Reference type mismatch depending on the view's schema).
 # group: [sql]
 
 require quack
@@ -11,6 +12,10 @@ require httpfs
 
 set ignore_error_messages __none__
 
+# force tiny fetch batches so even a small view spans many FETCH responses
+statement ok
+set global quack_fetch_batch_chunks=1;
+
 foreach server 'quack:localhost'
 
 statement ok con1
@@ -18,7 +23,7 @@ call quack_serve({server}, token='asdf');
 
 # 3-column view so a projected scan is narrower than the wire chunks
 statement ok
-create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(10_000_000) t(i);
+create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
 
 statement ok
 attach {server} as rpc (token 'asdf')
@@ -28,13 +33,13 @@ attach {server} as rpc (token 'asdf')
 query II
 select count(*), sum(i) from rpc.big_view
 ----
-10000000	49999995000000
+100000	4999950000
 
 # a projected multi-batch quack_query takes the same path
 query II
 select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
 ----
-10000000	49999995000000
+100000	4999950000
 
 statement ok con2
 detach rpc;

--- a/test/sql/attach_view_fetch_projection.test_slow
+++ b/test/sql/attach_view_fetch_projection.test_slow
@@ -1,0 +1,45 @@
+# name: test/sql/attach_view_fetch_projection.test_slow
+# description: projected scan of an attached view whose result spans multiple fetch batches.
+#              Regression test: continuation batches of a bind-time result were tagged
+#              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
+#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N").
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# 3-column view so a projected scan is narrower than the wire chunks
+statement ok
+create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(10_000_000) t(i);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# view scans go through quack_query_by_name (bind-time result, client-side pushdown);
+# before the fix, fetch batch 2+ crashed here
+query II
+select count(*), sum(i) from rpc.big_view
+----
+10000000	49999995000000
+
+# a projected multi-batch quack_query takes the same path
+query II
+select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
+----
+10000000	49999995000000
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop


### PR DESCRIPTION
## Problem

Scanning an ATTACH'd remote **view** (or any projected `quack_query` / `quack_query_by_name` result) fails with an internal error when the result spans more than one fetch batch and the local plan projects a subset of columns:

```
INTERNAL Error: Attempted to access index 1 within vector of size 1
```
(stack: `QuackScan` → `DataChunk::Reference`)

Minimal repro (also the new test): a 3-column view over `range(10_000_000)`, attached, then `SELECT count(*), sum(i) FROM rpc.big_view`. Small views work — the failure only appears once the result no longer fits the first prepare batch, so in practice it looks data-dependent (a view that worked yesterday crashes today after its underlying tables grow).

## Cause

`QuackScan` has two chunk modes (`ChunkResultPushdownType`):

- **Catalog table scans** build a server-side pushdown query in `QuackScanInitGlobal` (`bind_data.table_name` non-empty) → response chunks are already projection-width → `PUSHDOWN_ALREADY_APPLIED`, consumed via `output.Reference(response_chunk)`.
- **Bind-time results** (`quack_query`, `quack_query_by_name` — which is also how attached views are scanned, per `QuackViewCatalogEntry::CreateViewSQL`) are full-width → `REQUIRES_PUSHDOWN`, consumed by mapping `column_ids` primary indexes into the response chunk.

The fetch loop in `QuackScan`, however, tags **every continuation batch** as `PUSHDOWN_ALREADY_APPLIED` unconditionally. In the bind-time-result mode, batch 2+ is a full-width continuation of the bind-time result, so `output.Reference(full_width_chunk)` runs against a projection-narrow output chunk and throws — the reported index always equals the projected width. (When the projected width happens to equal the source width but the column order is permuted, the `Reference` would instead succeed silently with mis-ordered columns.)

## Fix

`QuackScanInitGlobal` records which mode the scan is in (`fetch_pushdown_type`: `PUSHDOWN_ALREADY_APPLIED` for the server-side pushdown path, `REQUIRES_PUSHDOWN` for bind-time results), and the fetch loop tags continuation chunks with that instead of the hardcoded value.

## Test

`test/sql/attach_view_fetch_projection.test` — projected aggregates over a 3-column, 100k-row attached view, plus the same through `quack_query`. It sets `quack_fetch_batch_chunks=1` so even a small view spans many FETCH batches, which keeps it fast enough for the default CI test run. Fails with the internal error when built from the pre-fix source (`INTERNAL Error: Attempted to access index 1 within vector of size 1`); passes with this change. `attach_views.test`, `attach.test`, and `attach_fetch_large.test_slow` still pass.

Fixes #199 — same root cause, different flavor: there the mis-tagged full-width continuation chunk dies at column 0 on the type check (`Vector::Reference used on vector of different type (source VARCHAR referenced BIGINT)`) before reaching the bounds error; the reported "works with LIMIT 1" matches (the result fits the first prepare batch, so no continuation fetch happens).
