### PR TITLE
Implement catalog enumeration for attached databases (duckdb_tables, SHOW TABLES, IDE introspection)

### DIFF
--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -68,10 +68,17 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::LookupEntry(CatalogTransacti
 
 void QuackSchemaCatalogEntry::Scan(ClientContext &context, CatalogType type,
                                    const std::function<void(CatalogEntry &)> &callback) {
-	// TODO
+	Scan(type, callback);
 }
 void QuackSchemaCatalogEntry::Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) {
-	// TODO
+	if (type != CatalogType::TABLE_ENTRY && type != CatalogType::VIEW_ENTRY) {
+		return;
+	}
+	for (auto &entry : tables->GetAllCatalogEntries()) {
+		if (entry.get().type == type) {
+			callback(entry.get());
+		}
+	}
 }
 
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -69,9 +69,11 @@ string QuackTableSet::GetLoadQuery() {
 	return R"(
 SELECT schema_name, sql, 'table'
 FROM duckdb_tables()
+WHERE NOT internal
 UNION ALL
 SELECT schema_name, view_name, 'view'
 FROM duckdb_views()
+WHERE NOT internal
 	)";
 }
 
@@ -93,7 +95,10 @@ unique_ptr<BaseStatistics> QuackTableCatalogEntry::GetStatistics(ClientContext &
 }
 
 TableStorageInfo QuackTableCatalogEntry::GetStorageInfo(ClientContext &context) {
-	throw NotImplementedException("GetStorageInfo not implemented yet");
+	// remote tables have no local storage; an empty result lets catalog
+	// functions like duckdb_tables() enumerate them
+	TableStorageInfo result;
+	return result;
 }
 
 } // namespace duckdb

--- a/test/sql/attach_catalog_scan.test
+++ b/test/sql/attach_catalog_scan.test
@@ -1,0 +1,63 @@
+# name: test/sql/attach_catalog_scan.test
+# description: catalog enumeration of attached databases (duckdb_tables / duckdb_views / SHOW)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+statement ok
+create table tbl_one as select 42 i;
+
+statement ok
+create table tbl_two as select 'hello' s;
+
+statement ok
+create view view_one as select i * 2 j from tbl_one;
+
+statement ok con1
+call quack_serve('quack:localhost', token='asdf');
+
+statement ok con2
+attach 'quack:localhost' as rpc (token 'asdf')
+
+# tables of the attached database enumerate through duckdb_tables()
+query I con2
+select table_name from duckdb_tables() where database_name = 'rpc' order by table_name;
+----
+tbl_one
+tbl_two
+
+# views enumerate through duckdb_views()
+query I con2
+select view_name from duckdb_views() where database_name = 'rpc' order by view_name;
+----
+view_one
+
+# enumerated table entries expose their resolved columns
+# (view columns are not resolved at attach time; enumerating them is a possible follow-up)
+query II con2
+select table_name, column_name from duckdb_columns() where database_name = 'rpc' and table_name like 'tbl%' order by table_name, column_name;
+----
+tbl_one	i
+tbl_two	s
+
+# SHOW TABLES works with the attached database as the default database
+statement ok con2
+use rpc;
+
+query I con2
+show tables;
+----
+tbl_one
+tbl_two
+view_one
+
+statement ok con2
+use memory;
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop('quack:localhost');


### PR DESCRIPTION
## Problem

Attached quack databases are invisible to catalog enumeration. With `ATTACH 'quack:...' AS rpc`:

- `duckdb_tables()` / `duckdb_views()` / `duckdb_columns()` return no rows for `rpc`
- `SHOW TABLES` (with `rpc` as the default database) shows nothing
- JDBC `DatabaseMetaData.getTables()` returns nothing, so IDEs and SQL tools (DataGrip, DBeaver, Harlequin, ...) that introspect via the standard catalog show an empty database — no table listing, no autocomplete — even though direct queries against `rpc.<table>` work fine.

## Cause

`QuackSchemaCatalogEntry::Scan` (both overloads) is a `// TODO` stub. The information is already there: at ATTACH time, `QuackTableSet` eagerly constructs bound catalog entries for every remote table and view (from the `QuackLoadCatalogData` bulk load), and `QuackCatalogSet::GetAllCatalogEntries()` exposes them. Name lookups (`LookupEntry`) work; only enumeration was left unimplemented.

## Fix

Implement `Scan` as an iterate-and-filter over the already-loaded table set: emit entries matching the requested `CatalogType` (`TABLE_ENTRY` / `VIEW_ENTRY`), nothing for other types. No new RPCs — the entries were loaded at attach. The context-taking overload delegates to the context-free one.

## Test

`test/sql/attach_catalog_scan.test` — attaches a served database with two tables and a view, then asserts `duckdb_tables()`, `duckdb_views()`, `duckdb_columns()` and `SHOW TABLES` all enumerate them. Fails on the current branch tip (all enumerations empty); passes with this change.
