### PR TITLE
Deduplicate quack scan output column names

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/query_result.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
@@ -51,6 +52,10 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
+	// the remote query may produce duplicate column names (e.g. SELECT 1 AS x, 2 AS x) - a table
+	// function binding requires unique names, so rename the repeats (x, x_1, ...). Columns are
+	// referenced positionally everywhere below, so this is purely the name we expose to the binder.
+	QueryResult::DeduplicateColumns(names);
 
 	bind_data->results = std::move(bind_response->MutableResults());
 	bind_data->needs_more_fetch = bind_response->NeedsMoreFetch();
@@ -97,6 +102,7 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
+	QueryResult::DeduplicateColumns(names);
 
 	// new stuff
 	bind_data->results = std::move(bind_response->MutableResults());

--- a/test/sql/rpc_duplicate_columns.test
+++ b/test/sql/rpc_duplicate_columns.test
@@ -1,0 +1,74 @@
+# name: test/sql/rpc_duplicate_columns.test
+# description: a remote query with duplicate output column names binds (names are deduplicated)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+call quack_serve('quack:localhost', token='asdf');
+
+statement ok con2
+create secret (type quack, token 'asdf')
+
+# Duplicate names are legal in the remote query - the second one is renamed to x_1.
+query II con2
+SELECT * FROM quack_query('quack:localhost', 'SELECT 1 AS x, 2 AS x');
+----
+1	2
+
+query I con2
+SELECT x FROM quack_query('quack:localhost', 'SELECT 1 AS x, 2 AS x');
+----
+1
+
+query I con2
+SELECT x_1 FROM quack_query('quack:localhost', 'SELECT 1 AS x, 2 AS x');
+----
+2
+
+# Three-way duplicate, interleaved with a distinct column: x, y, x_1, x_2.
+query IIII con2
+SELECT * FROM quack_query('quack:localhost', 'SELECT 1 AS x, 2 AS y, 3 AS x, 4 AS x');
+----
+1	2	3	4
+
+query II con2
+SELECT x_2, y FROM quack_query('quack:localhost', 'SELECT 1 AS x, 2 AS y, 3 AS x, 4 AS x');
+----
+4	2
+
+# Duplicates that come from unaliased expressions on the server side.
+query II con2
+SELECT * FROM quack_query('quack:localhost', 'SELECT 42, 42');
+----
+42	42
+
+# Same via the catalog path: quack_query_by_name.
+statement ok con2
+attach 'quack:localhost' as q (type quack);
+
+query II con2
+SELECT * FROM quack_query_by_name('q', 'SELECT 1 AS x, 2 AS x');
+----
+1	2
+
+query II con2
+SELECT x_1, x FROM quack_query_by_name('q', 'SELECT 1 AS x, 2 AS x');
+----
+2	1
+
+# The catalog `query` table macro wraps quack_query_by_name.
+query II con2
+FROM q.query('SELECT 1 AS x, 2 AS x');
+----
+1	2
+
+statement ok con2
+detach q;
+
+statement ok con1
+call quack_stop('quack:localhost');


### PR DESCRIPTION
A remote query is free to produce duplicate column names (SELECT 1 AS x, 2 AS x), but a table function binding requires them to be unique: duckdb's Binding::Initialize throws 'table "quack_query" has duplicate column name'. Both quack scan binds passed the server's names through verbatim, so any such query failed to bind.

Rename repeats in the bind (x, x_1, ...) via QueryResult::DeduplicateColumns, as the arrow scan does. Nothing maps back: quack never sends column names to the server - projection pushdown emits positional #N refs and the scan references result columns by index - so this only affects the names exposed to the binder.

Currently:
```sql
CALL quack_serve('quack:localhost', token:='1234');
SELECT * FROM quack_query('quack:localhost', 'SELECT 1 AS x, 2 AS x');
```
fails like:
```
Binder Error:
table "quack_query" has duplicate column name "x"
```
Failure happens client side, basically this goes local duckdb -> quack protocol -> computed server side -> quack protocol -> fails re-entering client side.

This is not great, since query has been executed (so possibly with side-effects) but then fails on re-entering client side.

After this PR:
```
┌───────┬───────┐
│   x   │  x_1  │
│ int32 │ int32 │
├───────┼───────┤
│     1 │     2 │
└───────┴───────┘
```
that behave according to the precedent of:
```sql
FROM (SELECT 1 AS x, 2 AS x);
```

Given this expand what's processed, and changes nothing for already de-duplicated queries, this is in my view an improvement.

Discovered while stress testing `CONNECT`, but found `USE quack` had the same limitation.