### PR TITLE
Quack: surface actual error types (instead of generic `Invalid`) AND allow invalidated servers to communicate this back to clients

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -29,12 +29,22 @@ public:
 		if (response_message->Type() != TARGET::TYPE) {
 			if (response_message->Type() == MessageType::ERROR_RESPONSE) {
 				// if we get an error throw it immediately
+				NoteError(response_message->Cast<ErrorResponse>());
 				response_message->Cast<ErrorResponse>().Error().Throw();
 			}
 			throw IOException("Expected %s message, got %s instead", MessageTypeToString(TARGET::TYPE),
 			                  MessageTypeToString(response_message->Type()));
 		}
 		return unique_ptr_cast<QuackMessage, TARGET>(std::move(response_message));
+	}
+
+	//! Invalidate the owning connection if the error says the server's database died. Call before rethrowing.
+	void NoteError(const ErrorResponse &error_response);
+
+	//! The connection this client is checked out from - set by QuackClientWrapper. Null for the initial connect
+	//! and for a one-shot quack_query.
+	void SetOwnerConnection(optional_ptr<const QuackClientConnection> owner_connection_p) {
+		owner_connection = owner_connection_p;
 	}
 
 	//! POST already-serialized request bytes and return the raw response body, throwing on transport failure.
@@ -92,6 +102,8 @@ protected:
 	QuackUri uri;
 	//! HTTP transport-log logger, stamped at checkout (see SetRequestLogger).
 	shared_ptr<Logger> request_logger;
+	//! See SetOwnerConnection
+	optional_ptr<const QuackClientConnection> owner_connection;
 
 private:
 	virtual unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
@@ -117,10 +129,19 @@ public:
 		return heartbeat_timeout_seconds;
 	}
 
-	//! Get a client (either a cached one, or open a new one if required)
+	//! Get a client (either a cached one, or open a new one if required).
+	//! Throws once the server has told us its database is gone - see MarkServerInvalidated.
 	unique_ptr<QuackClientWrapper> GetClient(ClientContext &context) const;
 	//! Return a client back to the cache
 	void StoreClient(unique_ptr<QuackClient> client_p) const;
+
+	//! The server's database is invalidated, so this connection is a dead end - fail fast on it. Reconnecting
+	//! would be worse than useless: an invalidated server cannot run its authentication query either, so it
+	//! rejects every reconnect with a misleading "Authentication failed".
+	void MarkServerInvalidated() const;
+	bool ServerInvalidated() const {
+		return server_invalidated;
+	}
 
 private:
 	friend class QuackClient;
@@ -135,6 +156,7 @@ private:
 	//! Lease timeout accepted by the server during the connection handshake.
 	idx_t heartbeat_timeout_seconds;
 	mutable mutex lock;
+	mutable atomic<bool> server_invalidated {false};
 	//! Bounds cached_clients: each cached client holds a persistent socket that pins a server
 	//! connection slot, so an unbounded cache would let one attach starve the server's budget.
 	idx_t max_connections_cached;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -597,6 +597,21 @@ private:
 	hugeint_t query_uuid {0, 0};
 };
 
+//! Keys quack adds to an error's extra info, so a caller can act on the facts instead of reading English out
+//! of the message. They belong to the ErrorData rather than to the message ON PURPOSE: a quack server can
+//! itself be the client of another quack server, and there the error stops being a message - it is thrown,
+//! caught, and re-raised as that server's own query error, through DuckDB code that has never heard of quack.
+//! An ErrorData's extra info survives that hop; a field of ErrorResponse would not.
+namespace QuackErrorInfo {
+//! The type the SERVER raised, when it was too severe to rethrow as-is (see ErrorResponse::FromWire). It has
+//! to survive relaying: when a server passes on an error it got from ANOTHER server, this still names the
+//! type that originally went wrong.
+constexpr const char *ORIGINAL_EXCEPTION_TYPE = "original_exception_type";
+} // namespace QuackErrorInfo
+
+//! An error raised while handling a request. The exception type and the extra info travel along with the
+//! message, so the client rethrows the exception the server actually raised (a Catalog Error stays a Catalog
+//! Error) instead of a bare InvalidInputException.
 class ErrorResponse : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::ERROR_RESPONSE;
@@ -614,6 +629,24 @@ public:
 	const string &ErrorMessage() const {
 		return error.Message();
 	}
+	//! The exception type in its wire form (e.g. "Catalog"), empty if this response holds no error
+	string ExceptionTypeName() const;
+	//! The extra info minus the entries that only mean something in the process that raised the error
+	unordered_map<string, string> TransferableExtraInfo() const;
+
+	//! Whether the SENDER's database is now invalidated, i.e. this connection is a dead end and the receiver
+	//! should stop using it. It is deliberately a bare flag and not the sender's identity: a server behind a
+	//! proxy does not know the address it is reachable at (it may believe it is "quack:localhost"), while the
+	//! receiver always knows which server it dialed. Whoever holds the connection names it.
+	bool MustInvalidate() const {
+		return must_invalidate;
+	}
+	void SetMustInvalidate(bool must_invalidate_p) {
+		must_invalidate = must_invalidate_p;
+	}
+	//! Rebuild an error response from the wire fields - the inverse of Serialize
+	static unique_ptr<ErrorResponse> FromWire(const string &message, const string &exception_type,
+	                                          const unordered_map<string, string> &extra_info, bool must_invalidate);
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ErrorResponse> Deserialize(Deserializer &deserializer);
@@ -624,6 +657,8 @@ protected:
 
 private:
 	ErrorData error;
+	//! Set by the server when its OWN database died with this error - see MustInvalidate()
+	bool must_invalidate = false;
 };
 
 class CancelRequestMessage : public QuackMessage {

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -597,21 +597,17 @@ private:
 	hugeint_t query_uuid {0, 0};
 };
 
-//! Keys quack adds to an error's extra info, so a caller can act on the facts instead of reading English out
-//! of the message. They belong to the ErrorData rather than to the message ON PURPOSE: a quack server can
-//! itself be the client of another quack server, and there the error stops being a message - it is thrown,
-//! caught, and re-raised as that server's own query error, through DuckDB code that has never heard of quack.
-//! An ErrorData's extra info survives that hop; a field of ErrorResponse would not.
+//! Keys quack adds to an error's extra info. They live in the ErrorData, not in ErrorResponse, so that they
+//! survive relaying: a quack server can be the client of another one, and there the error is caught and
+//! re-raised through DuckDB code that has never heard of quack. Extra info makes that hop, message fields do
+//! not.
 namespace QuackErrorInfo {
-//! The type the SERVER raised, when it was too severe to rethrow as-is (see ErrorResponse::FromWire). It has
-//! to survive relaying: when a server passes on an error it got from ANOTHER server, this still names the
-//! type that originally went wrong.
+//! The type the SERVER raised, when it was too severe to rethrow as-is (see ErrorResponse::FromWire)
 constexpr const char *ORIGINAL_EXCEPTION_TYPE = "original_exception_type";
 } // namespace QuackErrorInfo
 
-//! An error raised while handling a request. The exception type and the extra info travel along with the
-//! message, so the client rethrows the exception the server actually raised (a Catalog Error stays a Catalog
-//! Error) instead of a bare InvalidInputException.
+//! An error raised while handling a request. Type and extra info travel with the message, so the client
+//! rethrows the exception the server raised (a Catalog Error stays a Catalog Error).
 class ErrorResponse : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::ERROR_RESPONSE;
@@ -634,10 +630,9 @@ public:
 	//! The extra info minus the entries that only mean something in the process that raised the error
 	unordered_map<string, string> TransferableExtraInfo() const;
 
-	//! Whether the SENDER's database is now invalidated, i.e. this connection is a dead end and the receiver
-	//! should stop using it. It is deliberately a bare flag and not the sender's identity: a server behind a
-	//! proxy does not know the address it is reachable at (it may believe it is "quack:localhost"), while the
-	//! receiver always knows which server it dialed. Whoever holds the connection names it.
+	//! Whether the SENDER's database is now invalidated, i.e. the receiver should stop using this connection.
+	//! A bare flag rather than the sender's identity: a server behind a proxy does not know the address it is
+	//! reachable at, while the receiver always knows which server it dialed.
 	bool MustInvalidate() const {
 		return must_invalidate;
 	}

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -32,9 +32,27 @@
         "name": "message",
         "type": "string",
         "serialize_property": "error.RawMessage()"
+      },
+      {
+        "id": 2,
+        "name": "exception_type",
+        "type": "string",
+        "serialize_property": "ExceptionTypeName()"
+      },
+      {
+        "id": 3,
+        "name": "extra_info",
+        "type": "unordered_map<string, string>",
+        "serialize_property": "TransferableExtraInfo()"
+      },
+      {
+        "id": 4,
+        "name": "must_invalidate",
+        "type": "bool"
       }
     ],
-    "constructor": ["message"]
+    "constructor": ["message", "exception_type", "extra_info", "must_invalidate"],
+    "constructor_method": "ErrorResponse::FromWire"
   },
   {
     "class": "PrepareRequestMessage",

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -165,7 +165,9 @@ public:
 	}
 
 protected:
+	//! Handle one request, turning any exception raised along the way into an ErrorResponse
 	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);
+	unique_ptr<QuackMessage> DispatchMessage(MemoryStream &read_stream);
 	//! Drops caches idle past quack_result_ttl
 	void SweepExpiredCaches(DatabaseInstance &db);
 	//! Give `connection` its expiry-queue slot when its cache is created; caller must hold connection.lock.

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -334,8 +334,24 @@ unique_ptr<QuackClient> QuackClientConnection::TakeClient(optional_ptr<ClientCon
 }
 
 unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &context) const {
+	if (server_invalidated) {
+		throw InvalidInputException(
+		    "The Quack server at %s invalidated its database, so this attached database is gone with it. The "
+		    "server has to be restarted; DETACH and ATTACH again to use it afterwards.",
+		    uri.Uri());
+	}
 	auto result = TakeClient(context);
 	return make_uniq<QuackClientWrapper>(std::move(result), shared_from_this());
+}
+
+void QuackClient::NoteError(const ErrorResponse &error_response) {
+	if (error_response.MustInvalidate() && owner_connection) {
+		owner_connection->MarkServerInvalidated();
+	}
+}
+
+void QuackClientConnection::MarkServerInvalidated() const {
+	server_invalidated = true;
 }
 
 void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) const {
@@ -353,9 +369,13 @@ void QuackClientConnection::StoreClient(unique_ptr<QuackClient> client_p) const 
 QuackClientWrapper::QuackClientWrapper(unique_ptr<QuackClient> client_p,
                                        shared_ptr<const QuackClientConnection> client_connection_p)
     : client(std::move(client_p)), client_connection(std::move(client_connection_p)) {
+	// while checked out, the client knows which attachment it serves, so an error that kills the server can
+	// mark that attachment dead (see QuackClient::NoteError)
+	client->SetOwnerConnection(client_connection.get());
 }
 
 QuackClientWrapper::~QuackClientWrapper() {
+	client->SetOwnerConnection(nullptr);
 	client_connection->StoreClient(std::move(client));
 }
 

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -1,7 +1,9 @@
 #include "duckdb/catalog/catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #include "quack_message.hpp"
 
@@ -179,6 +181,86 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 	deserializer.End();
 	// a chunk-carrying message continues with its raw blob, from right after the message
 	result->DecodeBlob(deserializer);
+	return result;
+}
+
+//! Extra info that must not cross the wire, because it describes the process that raised the error:
+//! - exception_type / exception_message are reserved by the JSON error encoding (ExceptionToJSONMap asserts
+//!   on them), and a peer that sent them would overwrite the very type and message we decoded
+//! - position is an offset into the SERVER's SQL - the client would point a caret into its own statement
+//!   (query errors have theirs folded into the message by the server already)
+//! - a stack trace holds frames of the server process: useless to the client, and it would hand out the
+//!   layout of the server binary to anyone who can trigger an error
+static bool IsTransferableErrorInfo(const string &key) {
+	static const char *const NON_TRANSFERABLE[] = {"exception_type", "exception_message", "position", "stack_trace",
+	                                               "stack_trace_pointers"};
+	for (auto &non_transferable : NON_TRANSFERABLE) {
+		if (key == non_transferable) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static unordered_map<string, string> TransferableErrorInfo(const unordered_map<string, string> &extra_info) {
+	unordered_map<string, string> result;
+	for (auto &entry : extra_info) {
+		if (IsTransferableErrorInfo(entry.first)) {
+			result.insert(entry);
+		}
+	}
+	return result;
+}
+
+//! DuckDB invalidates its whole DatabaseInstance when it sees one of these (client_context.cpp): they say
+//! the process that raised them is no longer trustworthy. That verdict is about the SERVER, so rethrowing
+//! one verbatim would let a broken server poison THIS database - keep the message, drop the severity.
+static bool InvalidatesDatabase(ExceptionType type) {
+	return type == ExceptionType::INTERNAL || Exception::InvalidatesDatabase(type);
+}
+
+string ErrorResponse::ExceptionTypeName() const {
+	if (!error.HasError()) {
+		return string();
+	}
+	return Exception::ExceptionTypeToString(error.Type());
+}
+
+unordered_map<string, string> ErrorResponse::TransferableExtraInfo() const {
+	return TransferableErrorInfo(error.ExtraInfo());
+}
+
+unique_ptr<ErrorResponse> ErrorResponse::FromWire(const string &message, const string &exception_type,
+                                                  const unordered_map<string, string> &extra_info,
+                                                  bool must_invalidate) {
+	auto type = Exception::StringToExceptionType(exception_type);
+	if (type == ExceptionType::INVALID) {
+		// the peer named an exception type this DuckDB does not know (it may run a different version), or sent
+		// no type at all - fall back to the type quack has always thrown for remote errors
+		type = ExceptionType::INVALID_INPUT;
+	}
+	// the peer controls this map, so filter it here too and not just on the way out
+	auto received_info = TransferableErrorInfo(extra_info);
+
+	auto raw_message = message;
+	if (InvalidatesDatabase(type)) {
+		// The server condemned ITS database. Say so in the message for a human, and keep the type it raised in
+		// the extra info for a caller that wants to branch on it - but throw a type that does not make DuckDB
+		// condemn OUR database along with it. (`must_invalidate` carries the actionable half of this.)
+		received_info[QuackErrorInfo::ORIGINAL_EXCEPTION_TYPE] = Exception::ExceptionTypeToString(type);
+		raw_message =
+		    StringUtil::Format("%s Error on the Quack server: %s", Exception::ExceptionTypeToString(type), raw_message);
+		type = ExceptionType::INVALID_INPUT;
+	}
+
+	auto result = unique_ptr<ErrorResponse>(new ErrorResponse());
+	result->must_invalidate = must_invalidate;
+	if (received_info.empty()) {
+		result->error = ErrorData(type, raw_message);
+	} else {
+		// ErrorData has no setter for its extra info: its JSON constructor is the only way to restore it
+		result->error = ErrorData(StringUtil::ExceptionToJSONMap(type, raw_message, received_info));
+	}
 	return result;
 }
 

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -185,12 +185,11 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 }
 
 //! Extra info that must not cross the wire, because it describes the process that raised the error:
-//! - exception_type / exception_message are reserved by the JSON error encoding (ExceptionToJSONMap asserts
-//!   on them), and a peer that sent them would overwrite the very type and message we decoded
+//! - exception_type / exception_message are reserved by ExceptionToJSONMap (it asserts on them), and a peer
+//!   sending them would overwrite the type and message we decoded
 //! - position is an offset into the SERVER's SQL - the client would point a caret into its own statement
-//!   (query errors have theirs folded into the message by the server already)
-//! - a stack trace holds frames of the server process: useless to the client, and it would hand out the
-//!   layout of the server binary to anyone who can trigger an error
+//! - a stack trace holds frames of the server process, and would hand out the layout of the server binary to
+//!   anyone who can trigger an error
 static bool IsTransferableErrorInfo(const string &key) {
 	static const char *const NON_TRANSFERABLE[] = {"exception_type", "exception_message", "position", "stack_trace",
 	                                               "stack_trace_pointers"};
@@ -212,9 +211,8 @@ static unordered_map<string, string> TransferableErrorInfo(const unordered_map<s
 	return result;
 }
 
-//! DuckDB invalidates its whole DatabaseInstance when it sees one of these (client_context.cpp): they say
-//! the process that raised them is no longer trustworthy. That verdict is about the SERVER, so rethrowing
-//! one verbatim would let a broken server poison THIS database - keep the message, drop the severity.
+//! DuckDB invalidates the whole DatabaseInstance when it sees one of these (client_context.cpp). That verdict
+//! is about the SERVER, so rethrowing one verbatim would let a broken server poison THIS database.
 static bool InvalidatesDatabase(ExceptionType type) {
 	return type == ExceptionType::INTERNAL || Exception::InvalidatesDatabase(type);
 }
@@ -235,8 +233,7 @@ unique_ptr<ErrorResponse> ErrorResponse::FromWire(const string &message, const s
                                                   bool must_invalidate) {
 	auto type = Exception::StringToExceptionType(exception_type);
 	if (type == ExceptionType::INVALID) {
-		// the peer named an exception type this DuckDB does not know (it may run a different version), or sent
-		// no type at all - fall back to the type quack has always thrown for remote errors
+		// the peer sent no type, or one this DuckDB does not know (it may run a different version)
 		type = ExceptionType::INVALID_INPUT;
 	}
 	// the peer controls this map, so filter it here too and not just on the way out
@@ -244,9 +241,7 @@ unique_ptr<ErrorResponse> ErrorResponse::FromWire(const string &message, const s
 
 	auto raw_message = message;
 	if (InvalidatesDatabase(type)) {
-		// The server condemned ITS database. Say so in the message for a human, and keep the type it raised in
-		// the extra info for a caller that wants to branch on it - but throw a type that does not make DuckDB
-		// condemn OUR database along with it. (`must_invalidate` carries the actionable half of this.)
+		// downgrade to a type that does not invalidate OUR database, keeping the original one in the extra info
 		received_info[QuackErrorInfo::ORIGINAL_EXCEPTION_TYPE] = Exception::ExceptionTypeToString(type);
 		raw_message =
 		    StringUtil::Format("%s Error on the Quack server: %s", Exception::ExceptionTypeToString(type), raw_message);
@@ -258,7 +253,7 @@ unique_ptr<ErrorResponse> ErrorResponse::FromWire(const string &message, const s
 	if (received_info.empty()) {
 		result->error = ErrorData(type, raw_message);
 	} else {
-		// ErrorData has no setter for its extra info: its JSON constructor is the only way to restore it
+		// ErrorData has no setter for its extra info: the JSON constructor is the only way to restore it
 		result->error = ErrorData(StringUtil::ExceptionToJSONMap(type, raw_message, received_info));
 	}
 	return result;

--- a/src/quack_send_data.cpp
+++ b/src/quack_send_data.cpp
@@ -52,6 +52,8 @@ public:
 		                  duration_ms, response->Type(), error);
 
 		if (response->Type() == MessageType::ERROR_RESPONSE) {
+			// this path decodes the response itself instead of going through Request(), so note the error here too
+			client.NoteError(response->Cast<ErrorResponse>());
 			response->Cast<ErrorResponse>().Error().Throw();
 		}
 		if (response->Type() != SendDataResponseMessage::TYPE) {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -499,16 +499,16 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	try {
 		response = DispatchMessage(read_stream);
 	} catch (std::exception &ex) {
-		// The message could not even be decoded (an exception raised while HANDLING one is caught below, where
-		// it can still be logged). Letting it escape to httplib would make it an HTTP 500, which the client can
-		// only report as a transport failure ("Failed to send message").
+		// Letting this escape to httplib would make it an HTTP 500, which the client can only report as a
+		// transport failure ("Failed to send message"). Exceptions from HANDLING a message are caught below,
+		// where they can still be logged; this catches the ones from decoding it.
 		response = make_uniq<ErrorResponse>(ErrorData(ex));
 	} catch (...) {
 		response = make_uniq<ErrorResponse>("Unknown error while handling request");
 	}
 	if (response->Type() == MessageType::ERROR_RESPONSE) {
-		// Tell the client whether we are still usable at all. Ask the database itself rather than guessing from
-		// the exception type - it is the one that decides it has been invalidated.
+		// tell the client whether we are still usable - ask the database rather than guess from the exception
+		// type, it is the one that decides it has been invalidated
 		auto db = db_ptr.lock();
 		response->Cast<ErrorResponse>().SetMustInvalidate(!db || ValidChecker::IsInvalidated(*db));
 	}
@@ -520,6 +520,13 @@ unique_ptr<QuackMessage> QuackServer::DispatchMessage(MemoryStream &read_stream)
 	auto db = db_ptr.lock();
 	if (!db) {
 		return make_uniq<ErrorResponse>("Database was closed");
+	}
+	if (ValidChecker::IsInvalidated(*db)) {
+		// bail out before touching the database: the authentication query cannot run either, so a client
+		// reconnecting to an invalidated server would otherwise be told its token was rejected
+		return make_uniq<ErrorResponse>("The server database has been invalidated and the server must be "
+		                                "restarted before it can be used again. Original error: \"%s\"",
+		                                ValidChecker::Get(*db).InvalidatedMessage());
 	}
 	auto &logger = Logger::Get(*db);
 	bool should_log = logger.ShouldLog(QuackLogType::NAME, QuackLogType::LEVEL);
@@ -562,8 +569,8 @@ unique_ptr<QuackMessage> QuackServer::DispatchMessage(MemoryStream &read_stream)
 		}
 	}
 
-	// process the message - an exception raised while handling it becomes the response, so that it reaches the
-	// client with the type and message it was raised with (and still shows up in the log below)
+	// an exception raised while handling the message becomes the response, so it reaches the client with the
+	// type it was raised with (and still shows up in the log below)
 	unique_ptr<QuackMessage> response;
 	try {
 		response = HandleMessageInternal(*db, *received_message, connection);

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/valid_checker.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/temporary_file_manager.hpp"
@@ -493,8 +494,29 @@ bool MessageRequiresConnection(MessageType type) {
 	}
 }
 
-// main switcheroo happens here
 unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
+	unique_ptr<QuackMessage> response;
+	try {
+		response = DispatchMessage(read_stream);
+	} catch (std::exception &ex) {
+		// The message could not even be decoded (an exception raised while HANDLING one is caught below, where
+		// it can still be logged). Letting it escape to httplib would make it an HTTP 500, which the client can
+		// only report as a transport failure ("Failed to send message").
+		response = make_uniq<ErrorResponse>(ErrorData(ex));
+	} catch (...) {
+		response = make_uniq<ErrorResponse>("Unknown error while handling request");
+	}
+	if (response->Type() == MessageType::ERROR_RESPONSE) {
+		// Tell the client whether we are still usable at all. Ask the database itself rather than guessing from
+		// the exception type - it is the one that decides it has been invalidated.
+		auto db = db_ptr.lock();
+		response->Cast<ErrorResponse>().SetMustInvalidate(!db || ValidChecker::IsInvalidated(*db));
+	}
+	return response;
+}
+
+// main switcheroo happens here
+unique_ptr<QuackMessage> QuackServer::DispatchMessage(MemoryStream &read_stream) {
 	auto db = db_ptr.lock();
 	if (!db) {
 		return make_uniq<ErrorResponse>("Database was closed");
@@ -540,8 +562,14 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 		}
 	}
 
-	// process the message
-	auto response = HandleMessageInternal(*db, *received_message, connection);
+	// process the message - an exception raised while handling it becomes the response, so that it reaches the
+	// client with the type and message it was raised with (and still shows up in the log below)
+	unique_ptr<QuackMessage> response;
+	try {
+		response = HandleMessageInternal(*db, *received_message, connection);
+	} catch (std::exception &ex) {
+		response = make_uniq<ErrorResponse>(ErrorData(ex));
+	}
 
 	if (should_log) {
 		auto duration_ms = QuackNowMillis() - start_time;

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -77,11 +77,18 @@ unique_ptr<DisconnectMessage> DisconnectMessage::Deserialize(Deserializer &deser
 
 void ErrorResponse::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "message", error.RawMessage());
+	serializer.WritePropertyWithDefault<string>(2, "exception_type", ExceptionTypeName());
+	serializer.WritePropertyWithDefault<unordered_map<string, string>>(3, "extra_info", TransferableExtraInfo());
+	serializer.WritePropertyWithDefault<bool>(4, "must_invalidate", must_invalidate);
 }
 
 unique_ptr<ErrorResponse> ErrorResponse::Deserialize(Deserializer &deserializer) {
 	auto message = deserializer.ReadPropertyWithDefault<string>(1, "message");
-	auto result = duckdb::unique_ptr<ErrorResponse>(new ErrorResponse(std::move(message)));
+	auto exception_type = deserializer.ReadPropertyWithDefault<string>(2, "exception_type");
+	auto extra_info = deserializer.ReadPropertyWithDefault<unordered_map<string, string>>(3, "extra_info");
+	auto must_invalidate = deserializer.ReadPropertyWithDefault<bool>(4, "must_invalidate");
+	auto result =
+	    ErrorResponse::FromWire(std::move(message), std::move(exception_type), std::move(extra_info), must_invalidate);
 	return result;
 }
 

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -57,10 +57,12 @@ SELECT s FROM rpc.t2 ORDER BY s
 a
 b
 
+# the table is gone on the server, but our catalog cache still has it: the error comes back from the
+# server, carrying the type it was raised with there
 statement error
 SELECT i FROM rpc.t1
 ----
-Invalid Input Error: Table with name t1 does not exist
+Catalog Error: Table with name t1 does not exist
 
 statement ok
 CALL quack_clear_cache()

--- a/test/sql/error_types.test
+++ b/test/sql/error_types.test
@@ -1,0 +1,81 @@
+# name: test/sql/error_types.test
+# description: errors raised by the server are rethrown by the client with their original exception type
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok
+create secret (type quack, token 'asdf')
+
+# a catalog error stays a catalog error - it used to arrive as "Invalid Input Error"
+statement error
+from quack_query({server}, 'select * from no_such_table')
+----
+Catalog Error: Table with name no_such_table does not exist!
+
+statement error
+from quack_query({server}, 'selexxxct 42')
+----
+Parser Error: syntax error at or near
+
+statement error
+from quack_query({server}, 'select ''abc''::int')
+----
+Conversion Error: Could not convert string 'abc' to INT32
+
+statement error
+from quack_query({server}, 'select no_such_column from range(10)')
+----
+Binder Error: Referenced column "no_such_column" not found
+
+# the error is raised while streaming the result (in a FETCH, not in the PREPARE): the batch is 12 chunks,
+# so the failing row is well past the first response
+statement error
+from quack_query({server}, 'select case when i < 30000 then i::varchar else ''abc'' end::int from range(60000) t(i)')
+----
+Conversion Error: Could not convert string 'abc' to INT32
+
+# errors raised by quack itself (not by a query) keep throwing as InvalidInputException
+statement error
+from quack_query({server}, 'select 42', token='wrong-token')
+----
+Invalid Input Error: Authentication failed
+
+# over an attached database: an insert rejected by the server surfaces as a constraint error, not as
+# an invalid input error (this one comes back on the SEND_DATA path)
+statement ok
+attach {server} as rpc (type quack)
+
+statement ok
+create table rpc.checked (i integer check (i < 30000))
+
+statement error
+insert into rpc.checked select i from range(60000) t(i)
+----
+Constraint Error: CHECK constraint failed
+
+statement ok
+detach rpc
+
+# A FATAL error says the process that raised it is no longer trustworthy: DuckDB reacts to one by
+# invalidating its whole database. That verdict is about the SERVER, so we keep the message but throw a type
+# that does not condemn the CLIENT's database along with it. Arm the server to fail its next checkpoint:
+statement ok
+from quack_query({server}, 'attach ''{TEST_DIR}/fatal.db'' as f; create table f.t as select 42 i')
+
+statement ok
+from quack_query({server}, 'pragma debug_checkpoint_abort=''before_header''')
+
+# the abort trips on whichever write reaches the header first (the insert's own flush, or the checkpoint), so
+# assert only what is invariant: whatever the server raised, it arrives as a FATAL that happened THERE
+statement error
+from quack_query({server}, 'insert into f.t values (43); checkpoint f;')
+----
+Invalid Input Error: FATAL Error on the Quack server:
+
+# the FATAL invalidated the SERVER's database. Ours is untouched and stays fully usable - rethrowing the
+# FatalException verbatim would have condemned this database along with the server's.
+query I
+select 42
+----
+42

--- a/test/sql/error_types.test
+++ b/test/sql/error_types.test
@@ -54,28 +54,47 @@ insert into rpc.checked select i from range(60000) t(i)
 ----
 Constraint Error: CHECK constraint failed
 
-statement ok
-detach rpc
-
-# A FATAL error says the process that raised it is no longer trustworthy: DuckDB reacts to one by
-# invalidating its whole database. That verdict is about the SERVER, so we keep the message but throw a type
-# that does not condemn the CLIENT's database along with it. Arm the server to fail its next checkpoint:
+# A failed checkpoint on an ATTACHED database is scoped to that database: DuckDB invalidates only it and
+# raises an IOException (it invalidates the whole instance, with a FatalException, only for the initial
+# database - see SingleFileStorageManager::CheckpointDatabase). Arm the server to fail its next checkpoint:
 statement ok
 from quack_query({server}, 'attach ''{TEST_DIR}/fatal.db'' as f; create table f.t as select 42 i')
 
 statement ok
 from quack_query({server}, 'pragma debug_checkpoint_abort=''before_header''')
 
-# the abort trips on whichever write reaches the header first (the insert's own flush, or the checkpoint), so
-# assert only what is invariant: whatever the server raised, it arrives as a FATAL that happened THERE
-statement error
-from quack_query({server}, 'insert into f.t values (43); checkpoint f;')
-----
-Invalid Input Error: FATAL Error on the Quack server:
+# raise the WAL threshold first, so the insert cannot autocheckpoint on its own: the explicit CHECKPOINT is
+# then the only thing that can trip the abort, and the error arrives unwrapped rather than nested inside the
+# "COMMIT succeeded but the autocheckpoint failed" message.
+statement ok
+from quack_query({server}, 'set wal_autocheckpoint=''1TB''')
 
-# the FATAL invalidated the SERVER's database. Ours is untouched and stays fully usable - rethrowing the
-# FatalException verbatim would have condemned this database along with the server's.
+statement ok
+from quack_query({server}, 'insert into f.t values (43)')
+
+# the type survives the wire: an IO Error stays an IO Error, and names the database it was scoped to
+statement error
+from quack_query({server}, 'checkpoint f')
+----
+IO Error: Checkpoint failed for database "f". The database has been invalidated.
+
+# our own database is untouched and stays fully usable
 query I
 select 42
 ----
 42
+
+# and so is the SERVER's own database - only the attached "f" died, so rpc still answers
+query I
+select count(*) from rpc.checked
+----
+0
+
+statement ok
+detach rpc
+
+# NOTE: this test no longer covers the whole-server-invalidation path (the must_invalidate flag on
+# ErrorResponse, and the client-side "this attached database is gone with it" fallback). Reaching it needs a
+# FATAL on the server's INITIAL database, which the test harness cannot arrange: quack_serve runs on the same
+# in-memory DuckDB instance as the client, because sqllogictest's named connections ("quack_db:foo") are all
+# connections to the one runner database, not separate instances. That behaviour is currently untested.


### PR DESCRIPTION
This started looking to improve compatibility of `CONNECT` statement, and I bumped against the fact queries that would error server side (for N reasons, like `Catalog Errors`, constraints, Invalid Input, IOExceptions) would all surface as Invalid Input Exception, basically loosing information on the wire.

Idea here is keeping information, allowing more faith-full error messages to users.

Then I bumped against a corner case: `FatalException` would invalidate server AND client. That's not great, so for that and Internal error case I still opted for generic like message (but carrying around metadata).
Next: I realized that `FatalException` or in any case server being invalidated must be communicated back to client directly, since otherwise any other reconnection attempt would fail even at executing auth / authz queries.

Now added a boolean on ErrorMessage, so client can be informed and act on server in invalid state (example, earlier failures).