### PR TITLE
Preserve source catalogs in remote scans and appends

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -301,10 +301,11 @@ class AppendRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::APPEND_REQUEST;
 
-	explicit AppendRequestMessage(string connection_id_p, string schema_name_p, string table_name_p,
-	                              unique_ptr<DataChunkWrapper> append_chunk_p)
-	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)),
-	      table_name(std::move(table_name_p)), append_chunk(std::move(append_chunk_p)) {
+	explicit AppendRequestMessage(string connection_id_p, string catalog_name_p, string schema_name_p,
+	                              string table_name_p, unique_ptr<DataChunkWrapper> append_chunk_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), catalog_name(std::move(catalog_name_p)),
+	      schema_name(std::move(schema_name_p)), table_name(std::move(table_name_p)),
+	      append_chunk(std::move(append_chunk_p)) {
 	}
 
 	void Serialize(Serializer &serializer) const override;
@@ -312,6 +313,9 @@ public:
 
 	DataChunk &AppendChunk() const {
 		return append_chunk->Chunk();
+	}
+	const string &CatalogName() const {
+		return catalog_name;
 	}
 	const string &SchemaName() const {
 		return schema_name;
@@ -325,6 +329,7 @@ protected:
 	}
 
 private:
+	string catalog_name;
 	string schema_name;
 	string table_name;
 	unique_ptr<DataChunkWrapper> append_chunk;

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -112,6 +112,11 @@
         "id": 3,
         "name": "append_chunk",
         "type": "unique_ptr<DataChunkWrapper>"
+      },
+      {
+        "id": 4,
+        "name": "catalog_name",
+        "type": "string"
       }
     ]
   },
@@ -181,4 +186,3 @@
     ]
   }
 ]
-

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -10,18 +10,23 @@ struct QuackScanBindData : FunctionData {
 		auto &other = other_p.Cast<QuackScanBindData>();
 		return other.client_connection->ConnectionId() == client_connection->ConnectionId() &&
 		       other.client_connection->ServerURI() == client_connection->ServerURI() &&
+		       other.catalog_name == catalog_name && other.schema_name == schema_name &&
 		       other.table_name == table_name && other.column_names == column_names &&
 		       other.column_types == column_types;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackScanBindData>();
 		result->client_connection = client_connection;
+		result->catalog_name = catalog_name;
+		result->schema_name = schema_name;
 		result->table_name = table_name;
 		result->column_names = column_names;
 		result->column_types = column_types;
 		return std::move(result);
 	}
 
+	string catalog_name;
+	string schema_name;
 	string table_name;
 	vector<string> column_names;
 	vector<LogicalType> column_types;

--- a/src/include/storage/quack_schema.hpp
+++ b/src/include/storage/quack_schema.hpp
@@ -31,7 +31,7 @@ class QuackSchemaCatalogEntry : public SchemaCatalogEntry {
 public:
 	QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p);
 	QuackSchemaCatalogEntry(ClientContext &context, Catalog &catalog_p, CreateSchemaInfo &info_p,
-	                        const QuackLoadCatalogData &load_data);
+	                        const QuackLoadCatalogData &load_data, string source_catalog_p);
 	~QuackSchemaCatalogEntry() override;
 
 	void Scan(ClientContext &context, CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
@@ -57,12 +57,17 @@ public:
 	void DropEntry(ClientContext &context, DropInfo &info) override;
 	void Alter(CatalogTransaction transaction, AlterInfo &info) override;
 
+	const string &SourceCatalogName() const {
+		return source_catalog;
+	}
+
 private:
 	optional_ptr<CatalogEntry> TryLoadBuiltInFunction(const string &entry_name);
 	optional_ptr<CatalogEntry> LoadBuiltInFunction(DefaultTableMacro macro);
 
 private:
 	unique_ptr<QuackTableSet> tables;
+	string source_catalog;
 
 private:
 	mutex default_function_lock;

--- a/src/include/storage/quack_view.hpp
+++ b/src/include/storage/quack_view.hpp
@@ -22,7 +22,8 @@ public:
 	//! Generate SQL for querying a view from quack
 	//! This SQL will always be "FROM {catalog}.query('FROM {view_name}');"
 	//! Ensuring the view is executed remotely
-	static string CreateViewSQL(const string &catalog_name, const string &schema_name, const string &view_name);
+	static string CreateViewSQL(const string &quack_catalog_name, const string &source_catalog_name,
+	                            const string &schema_name, const string &view_name);
 };
 
 } // namespace duckdb

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -213,7 +213,8 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 	// 		query = "SELECT " + StringUtil::Join(selected_columns, ", ") + " ";
 	// 	}
 	// }
-	query += StringUtil::Format("FROM %s", SQLIdentifier(bind_data.table_name));
+	query += StringUtil::Format("FROM %s.%s.%s", SQLIdentifier(bind_data.catalog_name),
+	                            SQLIdentifier(bind_data.schema_name), SQLIdentifier(bind_data.table_name));
 	//
 	// // Filters: build WHERE clause from pushable filters
 	// if (input.filters) {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -398,9 +398,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 
 		// we never execute this query, but throw it at the authorization function so it can check if this user gets to
 		// insert into this table
-		auto dummy_insert_query =
-		    StringUtil::Format("INSERT INTO %s.%s VALUES (NULL)", SQLIdentifier(append_request_message.SchemaName()),
-		                       SQLIdentifier(append_request_message.TableName()));
+		auto dummy_insert_query = StringUtil::Format(
+		    "INSERT INTO %s.%s.%s VALUES (NULL)", SQLIdentifier(append_request_message.CatalogName()),
+		    SQLIdentifier(append_request_message.SchemaName()), SQLIdentifier(append_request_message.TableName()));
 
 		// TODO do not do this if there is no fun set
 		{
@@ -415,11 +415,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 
 		std::unique_lock<std::mutex> lock(connection.lock);
 		auto &context = *connection.duckdb_connection->context;
-		auto table_info = context.TableInfo(append_request_message.SchemaName(), append_request_message.TableName());
+		auto table_info = context.TableInfo(append_request_message.CatalogName(), append_request_message.SchemaName(),
+		                                    append_request_message.TableName());
 		if (!table_info) {
-			return make_uniq<ErrorResponse>("Table %s.%s does not exist",
-			                                SQLIdentifier(append_request_message.SchemaName()),
-			                                SQLIdentifier(append_request_message.TableName()));
+			return make_uniq<ErrorResponse>(
+			    "Table %s.%s.%s does not exist", SQLIdentifier(append_request_message.CatalogName()),
+			    SQLIdentifier(append_request_message.SchemaName()), SQLIdentifier(append_request_message.TableName()));
 		}
 		try {
 			ColumnDataCollection collection(Allocator::Get(context), append_request_message.AppendChunk().GetTypes());

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -13,6 +13,7 @@ void AppendRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "schema_name", schema_name);
 	serializer.WritePropertyWithDefault<string>(2, "table_name", table_name);
 	serializer.WritePropertyWithDefault<unique_ptr<DataChunkWrapper>>(3, "append_chunk", append_chunk);
+	serializer.WritePropertyWithDefault<string>(4, "catalog_name", catalog_name);
 }
 
 unique_ptr<AppendRequestMessage> AppendRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -20,6 +21,7 @@ unique_ptr<AppendRequestMessage> AppendRequestMessage::Deserialize(Deserializer 
 	deserializer.ReadPropertyWithDefault<string>(1, "schema_name", result->schema_name);
 	deserializer.ReadPropertyWithDefault<string>(2, "table_name", result->table_name);
 	deserializer.ReadPropertyWithDefault<unique_ptr<DataChunkWrapper>>(3, "append_chunk", result->append_chunk);
+	deserializer.ReadPropertyWithDefault<string>(4, "catalog_name", result->catalog_name);
 	return result;
 }
 
@@ -133,8 +135,7 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(3, "needs_more_fetch");
 	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results");
 	auto result_uuid = deserializer.ReadProperty<hugeint_t>(5, "result_uuid");
-	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(
-	    std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
+	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
 	return result;
 }
 

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -56,8 +56,10 @@ SinkResultType QuackInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 	append_chunk->Initialize(context.client, chunk.GetTypes());
 	append_chunk->Reference(chunk);
 	auto chunk_wrapper = make_uniq<DataChunkWrapper>(*append_chunk);
-	auto append_message = make_uniq<AppendRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name, tbl.name,
-	                                                      std::move(chunk_wrapper));
+	auto &quack_schema = tbl.schema.Cast<QuackSchemaCatalogEntry>();
+	auto append_message =
+	    make_uniq<AppendRequestMessage>(quack_catalog.GetConnectionId(), quack_schema.SourceCatalogName(),
+	                                    tbl.schema.name, tbl.name, std::move(chunk_wrapper));
 
 	auto client_connection = quack_catalog.GetClientConnection();
 	auto client_wrapper = client_connection->GetClient(context.client);

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -23,7 +23,7 @@ void QuackSchemaSet::Reload(ClientContext &context, QuackCatalog &catalog, const
 		info.catalog = row.GetValue(0).GetValue<string>();
 		info.schema = row.GetValue(1).GetValue<string>();
 		// TODO this will fail if there are two schemas with the same name in different catalogs :/
-		auto schema = make_uniq<QuackSchemaCatalogEntry>(context, catalog, info, load_data);
+		auto schema = make_uniq<QuackSchemaCatalogEntry>(context, catalog, info, load_data, info.catalog);
 		CreateEntry(std::move(schema), OnCreateConflict::REPLACE_ON_CONFLICT);
 	}
 }
@@ -38,13 +38,13 @@ ORDER BY ALL
 }
 
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p)
-    : SchemaCatalogEntry(catalog_p, info_p) {
+    : SchemaCatalogEntry(catalog_p, info_p), source_catalog(info_p.catalog) {
 	tables = make_uniq<QuackTableSet>(*this);
 }
 
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(ClientContext &context, Catalog &catalog_p, CreateSchemaInfo &info_p,
-                                                 const QuackLoadCatalogData &load_data)
-    : SchemaCatalogEntry(catalog_p, info_p) {
+                                                 const QuackLoadCatalogData &load_data, string source_catalog_p)
+    : SchemaCatalogEntry(catalog_p, info_p), source_catalog(std::move(source_catalog_p)) {
 	tables = make_uniq<QuackTableSet>(context, *this, load_data);
 }
 
@@ -86,7 +86,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateFunction(CatalogTransa
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransaction transaction,
                                                                 BoundCreateTableInfo &info) {
 	auto create_table_info = info.Base().Copy();
-	create_table_info->catalog = GetInfo()->catalog;
+	create_table_info->catalog = source_catalog;
 	create_table_info->schema = GetInfo()->schema;
 
 	auto &quack_transaction = QuackTransaction::Get(transaction);
@@ -97,7 +97,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransacti
 
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
 	auto create_view_info = info.Copy();
-	create_view_info->catalog = GetInfo()->catalog;
+	create_view_info->catalog = source_catalog;
 	create_view_info->schema = GetInfo()->schema;
 
 	// create the view verbatim in the serer
@@ -105,7 +105,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransactio
 	quack_transaction.Query(create_view_info->ToString());
 
 	// locally, override the query with a remote procedure call to ensure the view is evaluated remotely
-	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName(), name, info.view_name);
+	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName(), source_catalog, name, info.view_name);
 	info.query = CreateViewInfo::ParseSelect(info.sql);
 
 	auto quack_entry = make_uniq<QuackViewCatalogEntry>(catalog, *this, info);
@@ -138,7 +138,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateType(CatalogTransactio
 
 void QuackSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) {
 	auto drop_info = info_p.Copy();
-	drop_info->catalog = GetInfo()->catalog;
+	drop_info->catalog = source_catalog;
 	drop_info->schema = name;
 	switch (drop_info->type) {
 	case CatalogType::TABLE_ENTRY:

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -25,16 +25,17 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
                              const QuackLoadCatalogData &load_data)
     : QuackCatalogSet(parent.ParentCatalog().Cast<QuackCatalog>()), schema(parent) {
 	for (auto &row : load_data.tables->Rows()) {
-		auto schema_name = row.GetValue(0).GetValue<string>();
-		if (schema_name != parent.name) {
+		auto catalog_name = row.GetValue(0).GetValue<string>();
+		auto schema_name = row.GetValue(1).GetValue<string>();
+		if (catalog_name != parent.SourceCatalogName() || schema_name != parent.name) {
 			// does not belong to this schema
 			continue;
 		}
 		// parse the SQL to get the table definition
-		auto type = row.GetValue(2).GetValue<string>();
+		auto type = row.GetValue(3).GetValue<string>();
 		unique_ptr<CatalogEntry> entry;
 		if (type == "table") {
-			auto sql = row.GetValue(1).GetValue<string>();
+			auto sql = row.GetValue(2).GetValue<string>();
 			auto info = ParseCreateTable(sql);
 			if (info->type != CatalogType::TABLE_ENTRY) {
 				throw InternalException("Expected a CREATE TABLE");
@@ -45,12 +46,12 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());
 			entry = std::move(table);
 		} else {
-			auto view_name = row.GetValue(1).GetValue<string>();
+			auto view_name = row.GetValue(2).GetValue<string>();
 			// bind a remote procedure call to the view on the server side
 			// we don't actually care what the view contains server-side, we just treat it like an opaque object we can
 			// query
 			CreateViewInfo info(schema, view_name);
-			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName(), schema.name, view_name);
+			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName(), catalog_name, schema.name, view_name);
 			info.query = CreateViewInfo::ParseSelect(info.sql);
 
 			// bind to resolve the types
@@ -67,10 +68,10 @@ QuackTableSet::QuackTableSet(QuackSchemaCatalogEntry &parent)
 
 string QuackTableSet::GetLoadQuery() {
 	return R"(
-SELECT schema_name, sql, 'table'
+SELECT database_name, schema_name, sql, 'table'
 FROM duckdb_tables()
 UNION ALL
-SELECT schema_name, view_name, 'view'
+SELECT database_name, schema_name, view_name, 'view'
 FROM duckdb_views()
 	)";
 }
@@ -79,6 +80,8 @@ TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, un
 	auto &quack_catalog = catalog.Cast<QuackCatalog>();
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = quack_catalog.GetClientConnection();
+	bind_data->catalog_name = schema.Cast<QuackSchemaCatalogEntry>().SourceCatalogName();
+	bind_data->schema_name = schema.name;
 	bind_data->table_name = name;
 	for (auto &col : GetColumns().Physical()) {
 		bind_data->column_names.push_back(col.Name());

--- a/src/storage/quack_view.cpp
+++ b/src/storage/quack_view.cpp
@@ -7,11 +7,12 @@ QuackViewCatalogEntry::QuackViewCatalogEntry(Catalog &catalog_p, SchemaCatalogEn
     : ViewCatalogEntry(catalog_p, schema_p, info_p) {
 }
 
-string QuackViewCatalogEntry::CreateViewSQL(const string &catalog_name, const string &schema_name,
-                                            const string &view_name) {
+string QuackViewCatalogEntry::CreateViewSQL(const string &quack_catalog_name, const string &source_catalog_name,
+                                            const string &schema_name, const string &view_name) {
 	//! This SQL will always be "FROM quack_query({catalog}, 'FROM {view_name}');"
-	auto remote_sql = StringUtil::Format("FROM %s.%s", SQLIdentifier(schema_name), SQLIdentifier(view_name));
-	return StringUtil::Format("FROM quack_query_by_name(%s, %s)", SQLString(catalog_name), SQLString(remote_sql));
+	auto remote_sql = StringUtil::Format("FROM %s.%s.%s", SQLIdentifier(source_catalog_name),
+	                                     SQLIdentifier(schema_name), SQLIdentifier(view_name));
+	return StringUtil::Format("FROM quack_query_by_name(%s, %s)", SQLString(quack_catalog_name), SQLString(remote_sql));
 }
 
 } // namespace duckdb

--- a/test/sql/attach_source_catalog.test
+++ b/test/sql/attach_source_catalog.test
@@ -1,0 +1,62 @@
+# name: test/sql/attach_source_catalog.test
+# description: preserve source catalogue and schema for attached remote objects
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+ATTACH ':memory:' AS ducklake
+
+statement ok con1
+CREATE SCHEMA ducklake.atlas
+
+statement ok con1
+CREATE TABLE ducklake.atlas.documents(id INTEGER, title VARCHAR)
+
+statement ok con1
+INSERT INTO ducklake.atlas.documents VALUES (1, 'first')
+
+statement ok con1
+CREATE VIEW ducklake.atlas.document_titles AS SELECT id, upper(title) AS title FROM ducklake.atlas.documents
+
+foreach server 'quack:localhost'
+
+statement ok con1
+CALL quack_serve({server}, token='asdf')
+
+statement ok con2
+CREATE SECRET (TYPE quack, TOKEN 'asdf')
+
+statement ok con2
+ATTACH {server} AS remote
+
+query II con2
+SELECT id, title FROM remote.atlas.documents ORDER BY id
+----
+1	first
+
+query II con2
+SELECT id, title FROM remote.atlas.document_titles ORDER BY id
+----
+1	FIRST
+
+statement ok con2
+INSERT INTO remote.atlas.documents VALUES (2, 'second')
+
+query II con1
+SELECT id, title FROM ducklake.atlas.documents ORDER BY id
+----
+1	first
+2	second
+
+statement ok con2
+DETACH remote
+
+statement ok con1
+CALL quack_stop({server})
+
+endloop


### PR DESCRIPTION
## What changed

- Preserve the server-side source catalogue on loaded Quack schema entries.
- Discover tables/views by both source catalogue and schema instead of schema alone.
- Generate fully qualified `catalog.schema.table` scan SQL.
- Carry the source catalogue through append RPCs and use three-part `TableInfo` lookup server-side.
- Qualify remote view scans with the source catalogue as well.

## Why

When the Quack server exposes a table from an attached catalogue, the client catalogue discovers its schema but loses the originating catalogue when it later scans or appends. A client reference such as `remote.atlas.documents` therefore becomes an unqualified server query against `documents` and fails even though the actual source is `ducklake.atlas.documents`.

This blocks clients that keep DuckLake attached only in the stateful Quack server process.

## Validation

- Added `attach_source_catalog.test`, covering table reads, view reads, and inserts against a non-primary attached catalogue.
- `attach_source_catalog.test`: 19 assertions passed.
- Existing `attach.test`: 33 assertions passed.
- Existing `attach_views.test`: 13 assertions passed.
- DuckDB 1.5.4 release build passed.
- clang-format 11.0.1 check passed.
