### PR TITLE
Bind typed parameters on remote queries

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -119,13 +119,20 @@ class PrepareRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::PREPARE_REQUEST;
 
-	PrepareRequestMessage(string connection_id_p, string sql_query_p)
-	    : QuackMessage(TYPE, std::move(connection_id_p)), sql_query(std::move(sql_query_p)) {
+	PrepareRequestMessage(string connection_id_p, string sql_query_p, vector<Value> parameters_p = {})
+	    : QuackMessage(TYPE, std::move(connection_id_p)), sql_query(std::move(sql_query_p)),
+	      parameters(std::move(parameters_p)) {
 	}
 
 public:
 	const string &Query() const {
 		return sql_query;
+	}
+	vector<Value> &Parameters() {
+		return parameters;
+	}
+	const vector<Value> &Parameters() const {
+		return parameters;
 	}
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<PrepareRequestMessage> Deserialize(Deserializer &deserializer);
@@ -136,6 +143,7 @@ protected:
 
 private:
 	string sql_query;
+	vector<Value> parameters;
 };
 
 class PrepareResponseMessage : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -43,6 +43,11 @@
         "id": 1,
         "name": "sql_query",
         "type": "string"
+      },
+      {
+        "id": 2,
+        "name": "parameters",
+        "type": "vector<Value>"
       }
     ]
   },
@@ -181,4 +186,3 @@
     ]
   }
 ]
-

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -23,6 +23,10 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	}
 
 	auto query = input.inputs[1].GetValue<string>();
+	vector<Value> parameters;
+	for (idx_t i = 2; i < input.inputs.size(); i++) {
+		parameters.push_back(input.inputs[i]);
+	}
 	auto initial_uri = QuackUri(input.inputs[0].GetValue<string>());
 
 	// no ssl on local by default
@@ -47,7 +51,7 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 	auto &client = client_wrapper->GetClient();
 
 	auto bind_response = client.Request<PrepareResponseMessage>(
-	    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(), query));
+	    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(), query, std::move(parameters)));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -88,12 +92,17 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 	// TODO some of this stuff below is duplicated af
 
 	auto query = input.inputs[1].GetValue<string>();
+	vector<Value> parameters;
+	for (idx_t i = 2; i < input.inputs.size(); i++) {
+		parameters.push_back(input.inputs[i]);
+	}
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = catalog.GetClientConnection();
 	auto client_wrapper = bind_data->client_connection->GetClient(context);
 	auto &client = client_wrapper->GetClient();
 	auto bind_response = client.Request<PrepareResponseMessage>(
-	    context, make_uniq<PrepareRequestMessage>(bind_data->client_connection->ConnectionId(), query));
+	    context,
+	    make_uniq<PrepareRequestMessage>(bind_data->client_connection->ConnectionId(), query, std::move(parameters)));
 
 	return_types = bind_response->Types();
 	names = bind_response->Names();
@@ -375,6 +384,7 @@ TableFunction QuackScanFunction::GetFunction() {
 	                         QuackScanInitGlobal, QuackScanInitLocal);
 	fun.named_parameters["disable_ssl"] = LogicalType::BOOLEAN;
 	fun.named_parameters["token"] = LogicalType::VARCHAR;
+	fun.varargs = LogicalType::ANY;
 
 	fun.projection_pushdown = true;
 	fun.get_partition_data = QuackScanGetPartitionData;
@@ -389,6 +399,7 @@ TableFunction QuackScanFunction::GetFunction() {
 TableFunction QuackScanByNameFunction::GetFunction() {
 	auto fun = TableFunction("quack_query_by_name", {LogicalType::VARCHAR, LogicalType::VARCHAR}, QuackScan,
 	                         QuackScanBindCatalogName, QuackScanInitGlobal, QuackScanInitLocal);
+	fun.varargs = LogicalType::ANY;
 	fun.projection_pushdown = true;
 	fun.get_partition_data = QuackScanGetPartitionData;
 	fun.to_string = QuackScanToString;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -315,7 +315,18 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		connection.query_started_at = Timestamp::GetCurrentTimestamp();
 
 		{
-			auto query_result = connection.duckdb_connection->SendQuery(effective_sql);
+			unique_ptr<QueryResult> query_result;
+			if (prepare_request_message.Parameters().empty()) {
+				query_result = connection.duckdb_connection->SendQuery(effective_sql);
+			} else {
+				auto pending = connection.duckdb_connection->PendingQuery(
+				    effective_sql, prepare_request_message.Parameters(), QueryResultOutputType::ALLOW_STREAMING);
+				if (pending->HasError()) {
+					query_result = make_uniq<MaterializedQueryResult>(pending->GetErrorObject());
+				} else {
+					query_result = pending->Execute();
+				}
+			}
 			if (query_result->HasError()) {
 				// TODO; instead of cancelled, add an ERROR state
 				connection.query_state = QuackQueryState::CANCELLED;

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -111,11 +111,13 @@ MessageHeader MessageHeader::Deserialize(Deserializer &deserializer) {
 
 void PrepareRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "sql_query", sql_query);
+	serializer.WritePropertyWithDefault<vector<Value>>(2, "parameters", parameters);
 }
 
 unique_ptr<PrepareRequestMessage> PrepareRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<PrepareRequestMessage>(new PrepareRequestMessage());
 	deserializer.ReadPropertyWithDefault<string>(1, "sql_query", result->sql_query);
+	deserializer.ReadPropertyWithDefault<vector<Value>>(2, "parameters", result->parameters);
 	return result;
 }
 
@@ -133,8 +135,7 @@ unique_ptr<PrepareResponseMessage> PrepareResponseMessage::Deserialize(Deseriali
 	auto needs_more_fetch = deserializer.ReadPropertyWithDefault<bool>(3, "needs_more_fetch");
 	auto results = deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(4, "results");
 	auto result_uuid = deserializer.ReadProperty<hugeint_t>(5, "result_uuid");
-	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(
-	    std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
+	auto result = duckdb::unique_ptr<PrepareResponseMessage>(new PrepareResponseMessage(std::move(result_types), std::move(result_names), std::move(results), needs_more_fetch, result_uuid));
 	return result;
 }
 

--- a/test/sql/bound_parameters.test
+++ b/test/sql/bound_parameters.test
@@ -1,0 +1,40 @@
+# name: test/sql/bound_parameters.test
+# description: bind typed values on the server without rendering SQL literals
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+foreach server 'quack:localhost'
+
+statement ok con1
+CALL quack_serve({server}, token='asdf')
+
+statement ok con2
+ATTACH {server} AS remote (TOKEN 'asdf')
+
+query ITT con2
+FROM quack_query_by_name('remote', 'SELECT ?::INTEGER, ?::UUID, ?::VARCHAR', 42, UUID '12345678-1234-5678-1234-567812345678', 'Robert''); DROP TABLE students;--')
+----
+42	12345678-1234-5678-1234-567812345678	Robert'); DROP TABLE students;--
+
+query TI con2
+FROM quack_query_by_name('remote', 'SELECT ?::DATE, ?::BOOLEAN', DATE '2026-07-12', true)
+----
+2026-07-12	true
+
+query IT con2
+FROM quack_query_by_name('remote', 'SELECT ? IS NULL, ?::INTEGER[]', NULL, [1, 2, 3])
+----
+true	[1, 2, 3]
+
+statement ok con2
+DETACH remote
+
+statement ok con1
+CALL quack_stop({server})
+
+endloop


### PR DESCRIPTION
## What changed

- Add positional typed values to `PrepareRequestMessage`.
- Bind those values with DuckDB's prepared/pending-query API on the server.
- Make `quack_query` and `quack_query_by_name` accept variadic typed parameters after the SQL argument.
- Preserve streaming query results after parameter binding.

Example:

```sql
FROM quack_query_by_name(
    'remote',
    'SELECT * FROM ducklake.atlas.documents WHERE id = ? AND created_at >= ?',
    UUID '12345678-1234-5678-1234-567812345678',
    TIMESTAMPTZ '2026-07-12 00:00:00+00'
);
```

## Why

Today callers of the ad-hoc remote query path must render values into the SQL string. Binding only the complete SQL string into the local `remote.query(?)` call does not bind values on the server. That makes DB-API-style adapters lossy and forces every caller to maintain its own literal encoder.

The protocol should carry SQL and values separately so the server remains the syntax/type authority.

## Compatibility

The new serialized field uses a new property id and defaults to an empty vector. Existing calls without parameters keep the current `SendQuery` path. Authorization continues to receive the placeholder SQL rather than rendered application values.

## Validation

- Added `bound_parameters.test` covering integer, UUID, injection-shaped VARCHAR, DATE, BOOLEAN, NULL, and LIST values.
- `bound_parameters.test`: 11 assertions passed.
- Existing `rpc.test`: 30 assertions passed.
- DuckDB 1.5.4 release build passed.
- clang-format 11.0.1 check passed.
