### PR TITLE
Drain the catalog-load query across fetch batches

### DIFF
--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -66,7 +66,6 @@ const QuackUri &QuackCatalog::GetServerUri() {
 }
 
 unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(ClientContext &context, const string &query) {
-	// FIXME this will break with many results!
 	auto chunk_collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator());
 	// get a client to query
 	auto client_wrapper = client_connection->GetClient(context);
@@ -76,6 +75,23 @@ unique_ptr<ColumnDataCollection> QuackCatalog::ExecuteCommandInternal(ClientCont
 	chunk_collection->Initialize(response->Types());
 	for (auto &chunk : response->MutableResults()) {
 		chunk_collection->Append(chunk->Chunk());
+	}
+	// The PREPARE response only carries the first batch (at most quack_fetch_batch_chunks chunks).
+	// These commands load the catalog, so anything left behind is not a truncated result set - it
+	// is a schema, table or view that silently ceases to exist. Drain the rest.
+	auto result_uuid = response->ResultUUID();
+	auto needs_more_fetch = response->NeedsMoreFetch();
+	while (needs_more_fetch) {
+		auto fetch_response = client.Request<FetchResponseMessage>(
+		    context, make_uniq<FetchRequestMessage>(GetConnectionId(), result_uuid));
+		if (fetch_response->MutableResults().empty()) {
+			// an empty FETCH is how the server says the result is exhausted (cf. QuackScan)
+			needs_more_fetch = false;
+			break;
+		}
+		for (auto &chunk : fetch_response->MutableResults()) {
+			chunk_collection->Append(chunk->Chunk());
+		}
 	}
 	return chunk_collection;
 }

--- a/test/sql/attach_catalog_multi_batch.test
+++ b/test/sql/attach_catalog_multi_batch.test
@@ -1,0 +1,52 @@
+# name: test/sql/attach_catalog_multi_batch.test
+# description: the catalog-load query must be drained across fetch batches.
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+# one chunk per fetch batch: the catalog listing no longer fits in the PREPARE response
+statement ok
+set global quack_fetch_batch_chunks=1;
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# a table AND a view: >= 2 chunks out of the UNION ALL, so the listing spans batches
+statement ok
+create table t1 as select i, i * 2 as j from range(10) t(i);
+
+statement ok
+create view v1 as select i, i * 2 as j from range(10) t(i);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# before the fix: "Catalog Error: Table with name v1 does not exist!" - the view was dropped
+# from the catalog because its row arrived in the second chunk
+query II
+select count(*), sum(i) from rpc.v1
+----
+10	45
+
+query II
+select count(*), sum(i) from rpc.t1
+----
+10	45
+
+# binding rpc.v1 / rpc.t1 above IS the catalog lookup that used to fail: an entry dropped from
+# the load never becomes a CatalogEntry, so the scan cannot even be bound. (duckdb_tables() and
+# duckdb_views() do not list entries of an attached quack catalog, so they cannot check this.)
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop


### PR DESCRIPTION
QuackCatalog::ExecuteCommandInternal appended only the chunks carried by the PREPARE response and never issued a FETCH, so anything past the first batch was dropped. Its own comment said so: "FIXME this will break with many results!". For these queries the dropped rows are not a truncated result set - they are catalog entries, so a schema, table or view silently ceases to exist, with no error at all.

Reachable today: the table-load query is duckdb_tables() UNION ALL duckdb_views(), whose two branches emit separate chunks, so a database holding both a table and a view already spans two chunks and loses the view at quack_fetch_batch_chunks=1. At the default batch size it takes a large catalog to reach, but lowering that setting - a documented knob - silently deletes part of the catalog.

Fetch until the server reports the result exhausted, the same way QuackScan does.