### PR TITLE
Fix pushdown with pruned columns via tag predicate

### DIFF
--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -158,11 +158,12 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
 	hugeint_t result_uuid;
-	//! How chunks fetched AFTER the initial batch must be treated. When the scan was
-	//! executed via a server-side pushdown query (catalog table scan), fetched chunks
-	//! already have the projection applied. When the scan consumes a bind-time result
-	//! (quack_query / quack_query_by_name, incl. ATTACH'd views), fetched chunks are
-	//! full-width continuations and still require client-side pushdown.
+	//! How EVERY chunk of this scan must be treated - the initial batch and all fetched
+	//! continuation batches alike. PUSHDOWN_ALREADY_APPLIED only when the server-side query
+	//! actually carried the projection, i.e. when BuildPushdownQuery emitted a SELECT list.
+	//! Bind-time results (quack_query / quack_query_by_name, incl. ATTACH'd views) arrive
+	//! full-width and are projected client-side, as does a catalog scan whose pushdown query
+	//! degraded to a full-width "FROM <table>".
 	ChunkResultPushdownType fetch_pushdown_type;
 
 	vector<ChunkResult> TryGetResults() {
@@ -254,11 +255,17 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	vector<ChunkResult> results;
 	bool needs_more_fetch = bind_data.needs_more_fetch;
 	hugeint_t result_uuid;
-	auto fetch_pushdown_type = bind_data.table_name.empty() ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
-	                                                        : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
+	// Derive the pushdown tag ONCE, from the only thing that decides it: whether the query we
+	// send to the server carries the projection. BuildPushdownQuery only emits a SELECT list
+	// when column_indexes is non-empty - with an empty one it degrades to a full-width
+	// "FROM <table>", which still needs client-side pushdown like any bind-time result.
+	auto fetch_pushdown_type = ChunkResultPushdownType::REQUIRES_PUSHDOWN;
 	if (!bind_data.table_name.empty()) {
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
+		if (!input.column_indexes.empty()) {
+			fetch_pushdown_type = ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
+		}
 		auto &client_connection = *bind_data.client_connection;
 		auto client_wrapper = client_connection.GetClient(context);
 		auto &client = client_wrapper->GetClient();
@@ -268,13 +275,13 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 		// fetch the result
 		for (auto &chunk_ref : response_message->MutableResults()) {
 			auto &chunk = chunk_ref->Chunk();
-			results.emplace_back(chunk, ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
+			results.emplace_back(chunk, fetch_pushdown_type);
 		}
 		result_uuid = response_message->ResultUUID();
 	} else {
 		for (auto &chunk_ref : bind_data.results) {
 			auto &chunk = chunk_ref->Chunk();
-			results.emplace_back(chunk, ChunkResultPushdownType::REQUIRES_PUSHDOWN);
+			results.emplace_back(chunk, fetch_pushdown_type);
 		}
 		result_uuid = bind_data.result_uuid;
 	}

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -158,12 +158,8 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
 	hugeint_t result_uuid;
-	//! How EVERY chunk of this scan must be treated - the initial batch and all fetched
-	//! continuation batches alike. PUSHDOWN_ALREADY_APPLIED only when the server-side query
-	//! actually carried the projection, i.e. when BuildPushdownQuery emitted a SELECT list.
-	//! Bind-time results (quack_query / quack_query_by_name, incl. ATTACH'd views) arrive
-	//! full-width and are projected client-side, as does a catalog scan whose pushdown query
-	//! degraded to a full-width "FROM <table>".
+	//! How every chunk of this scan must be treated, initial batch and fetched continuations
+	//! alike. Derived in QuackScanInitGlobal.
 	ChunkResultPushdownType fetch_pushdown_type;
 
 	vector<ChunkResult> TryGetResults() {
@@ -255,10 +251,9 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	vector<ChunkResult> results;
 	bool needs_more_fetch = bind_data.needs_more_fetch;
 	hugeint_t result_uuid;
-	// Derive the pushdown tag ONCE, from the only thing that decides it: whether the query we
-	// send to the server carries the projection. BuildPushdownQuery only emits a SELECT list
-	// when column_indexes is non-empty - with an empty one it degrades to a full-width
-	// "FROM <table>", which still needs client-side pushdown like any bind-time result.
+	// The chunks are already projected only if the query we send carries the projection, which is
+	// exactly when BuildPushdownQuery emits a SELECT list - it degrades to a full-width
+	// "FROM <table>" on an empty column_indexes.
 	auto fetch_pushdown_type = ChunkResultPushdownType::REQUIRES_PUSHDOWN;
 	if (!bind_data.table_name.empty()) {
 		// apply pushdown to the query

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -144,10 +144,11 @@ struct QuackScanLocalState : public LocalTableFunctionState {
 
 struct QuackScanGlobalState : GlobalTableFunctionState {
 	explicit QuackScanGlobalState(vector<ColumnIndex> column_ids_p, vector<idx_t> projection_id_p,
-	                              vector<ChunkResult> results_p, bool needs_more_fetch_p, hugeint_t result_uuid_p)
+	                              vector<ChunkResult> results_p, bool needs_more_fetch_p, hugeint_t result_uuid_p,
+	                              ChunkResultPushdownType fetch_pushdown_type_p)
 	    : max_threads(needs_more_fetch_p ? MAX_THREADS : 1), column_ids(std::move(column_ids_p)),
 	      projection_ids(std::move(projection_id_p)), needs_more_fetch(needs_more_fetch_p), result_uuid(result_uuid_p),
-	      results(std::move(results_p)) {
+	      fetch_pushdown_type(fetch_pushdown_type_p), results(std::move(results_p)) {
 	}
 	idx_t MaxThreads() const override {
 		return max_threads;
@@ -157,6 +158,12 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
 	hugeint_t result_uuid;
+	//! How chunks fetched AFTER the initial batch must be treated. When the scan was
+	//! executed via a server-side pushdown query (catalog table scan), fetched chunks
+	//! already have the projection applied. When the scan consumes a bind-time result
+	//! (quack_query / quack_query_by_name, incl. ATTACH'd views), fetched chunks are
+	//! full-width continuations and still require client-side pushdown.
+	ChunkResultPushdownType fetch_pushdown_type;
 
 	vector<ChunkResult> TryGetResults() {
 		lock_guard<mutex> guard(lock);
@@ -247,6 +254,8 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	vector<ChunkResult> results;
 	bool needs_more_fetch = bind_data.needs_more_fetch;
 	hugeint_t result_uuid;
+	auto fetch_pushdown_type = bind_data.table_name.empty() ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
+	                                                        : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
 	if (!bind_data.table_name.empty()) {
 		// apply pushdown to the query
 		auto query = BuildPushdownQuery(bind_data, input);
@@ -271,7 +280,7 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 	}
 	// we only multithread if there is more to fetch
 	return make_uniq<QuackScanGlobalState>(input.column_indexes, input.projection_ids, std::move(results),
-	                                       needs_more_fetch, result_uuid);
+	                                       needs_more_fetch, result_uuid, fetch_pushdown_type);
 }
 
 unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
@@ -335,7 +344,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 			}
 			// set up buffer for scan in next iteration
 			for (auto &chunk : fetch_response->MutableResults()) {
-				local_state.results.emplace(chunk->Chunk(), ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED);
+				local_state.results.emplace(chunk->Chunk(), global_state.fetch_pushdown_type);
 			}
 			local_state.current_batch_index = fetch_response->BatchIndex();
 			continue;

--- a/test/sql/attach_table_fetch_projection.test
+++ b/test/sql/attach_table_fetch_projection.test
@@ -1,0 +1,62 @@
+# name: test/sql/attach_table_fetch_projection.test
+# description: projected scan of an attached TABLE whose result spans multiple fetch batches.
+#              This is the catalog path: the projection is applied server-side by
+#              BuildPushdownQuery, so every chunk arrives already narrowed and is tagged
+#              PUSHDOWN_ALREADY_APPLIED. Coverage, not a red/green regression guard - this path
+#              is correct before and after the pushdown-tag change. It exists because that tag
+#              holds only while BuildPushdownQuery actually emits a SELECT list, and nothing
+#              else in the suite scans a real table across more than one fetch batch.
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+# force tiny fetch batches so even a small table spans many FETCH responses
+statement ok
+set global quack_fetch_batch_chunks=1;
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# NOTE: deliberately no view in this database. With a small fetch batch, a catalog holding both
+# a table and a view loses the view entirely (QuackCatalog::ExecuteCommandInternal reads only the
+# PREPARE batch of the catalog-load query and never FETCHes the rest - see its own FIXME). That
+# is a separate, pre-existing bug; keep it out of this test so a failure here means THIS bug.
+statement ok
+create table big_tbl as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# no columns needed by the query: the planner still binds one column, so the pushdown query
+# keeps a SELECT list and the chunks really are already projected
+query I
+select count(*) from rpc.big_tbl
+----
+100000
+
+# narrowing projection: output is narrower than the table
+query II
+select count(*), sum(i) from rpc.big_tbl
+----
+100000	4999950000
+
+# equal-width PERMUTATION: the silent failure mode. A mis-tagged chunk would not raise here -
+# DataChunk::Reference succeeds and the columns simply come back swapped.
+query IIII
+select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_tbl)
+----
+0	199998	0	99999
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop

--- a/test/sql/attach_table_fetch_projection.test
+++ b/test/sql/attach_table_fetch_projection.test
@@ -1,11 +1,5 @@
 # name: test/sql/attach_table_fetch_projection.test
-# description: projected scan of an attached TABLE whose result spans multiple fetch batches.
-#              This is the catalog path: the projection is applied server-side by
-#              BuildPushdownQuery, so every chunk arrives already narrowed and is tagged
-#              PUSHDOWN_ALREADY_APPLIED. Coverage, not a red/green regression guard - this path
-#              is correct before and after the pushdown-tag change. It exists because that tag
-#              holds only while BuildPushdownQuery actually emits a SELECT list, and nothing
-#              else in the suite scans a real table across more than one fetch batch.
+# description: server-side projected scan of an attached TABLE across multiple fetch batches
 # group: [sql]
 
 require quack

--- a/test/sql/attach_view_fetch_projection.test
+++ b/test/sql/attach_view_fetch_projection.test
@@ -1,8 +1,9 @@
-# name: test/sql/attach_view_fetch_projection.test_slow
+# name: test/sql/attach_view_fetch_projection.test
 # description: projected scan of an attached view whose result spans multiple fetch batches.
 #              Regression test: continuation batches of a bind-time result were tagged
 #              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
-#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N").
+#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N",
+#              or a Vector::Reference type mismatch depending on the view's schema).
 # group: [sql]
 
 require quack
@@ -11,6 +12,10 @@ require httpfs
 
 set ignore_error_messages __none__
 
+# force tiny fetch batches so even a small view spans many FETCH responses
+statement ok
+set global quack_fetch_batch_chunks=1;
+
 foreach server 'quack:localhost'
 
 statement ok con1
@@ -18,7 +23,7 @@ call quack_serve({server}, token='asdf');
 
 # 3-column view so a projected scan is narrower than the wire chunks
 statement ok
-create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(10_000_000) t(i);
+create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
 
 statement ok
 attach {server} as rpc (token 'asdf')
@@ -28,13 +33,13 @@ attach {server} as rpc (token 'asdf')
 query II
 select count(*), sum(i) from rpc.big_view
 ----
-10000000	49999995000000
+100000	4999950000
 
 # a projected multi-batch quack_query takes the same path
 query II
 select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
 ----
-10000000	49999995000000
+100000	4999950000
 
 statement ok con2
 detach rpc;

--- a/test/sql/attach_view_fetch_projection.test
+++ b/test/sql/attach_view_fetch_projection.test
@@ -1,9 +1,11 @@
 # name: test/sql/attach_view_fetch_projection.test
-# description: projected scan of an attached view whose result spans multiple fetch batches.
+# description: projected scan of an attached view whose result spans multiple fetch batches,
+#              reached the way a user reaches it: by sheer result size, at the default batch size.
 #              Regression test: continuation batches of a bind-time result were tagged
 #              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
-#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N",
-#              or a Vector::Reference type mismatch depending on the view's schema).
+#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N").
+#              See attach_view_fetch_projection_batch_chunks.test for the same path forced
+#              directly via quack_fetch_batch_chunks, plus the permuted-projection case.
 # group: [sql]
 
 require quack
@@ -12,10 +14,6 @@ require httpfs
 
 set ignore_error_messages __none__
 
-# force tiny fetch batches so even a small view spans many FETCH responses
-statement ok
-set global quack_fetch_batch_chunks=1;
-
 foreach server 'quack:localhost'
 
 statement ok con1
@@ -23,7 +21,7 @@ call quack_serve({server}, token='asdf');
 
 # 3-column view so a projected scan is narrower than the wire chunks
 statement ok
-create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
+create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(10_000_000) t(i);
 
 statement ok
 attach {server} as rpc (token 'asdf')
@@ -33,21 +31,13 @@ attach {server} as rpc (token 'asdf')
 query II
 select count(*), sum(i) from rpc.big_view
 ----
-100000	4999950000
+10000000	49999995000000
 
 # a projected multi-batch quack_query takes the same path
 query II
 select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
 ----
-100000	4999950000
-
-# An equal-width PERMUTATION of the columns is the silent failure mode: DataChunk::Reference
-# succeeds (no bounds error, no type error), so continuation batches come back with their
-# columns swapped and the query returns plausible but WRONG numbers instead of raising.
-query IIII
-select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_view)
-----
-0	199998	0	99999
+10000000	49999995000000
 
 statement ok con2
 detach rpc;

--- a/test/sql/attach_view_fetch_projection.test
+++ b/test/sql/attach_view_fetch_projection.test
@@ -25,10 +25,6 @@ call quack_serve({server}, token='asdf');
 statement ok
 create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
 
-# same shape as a real table: exercises the catalog path (server-side pushdown), see below
-statement ok
-create table big_tbl as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
-
 statement ok
 attach {server} as rpc (token 'asdf')
 
@@ -50,29 +46,6 @@ select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf'
 # columns swapped and the query returns plausible but WRONG numbers instead of raising.
 query IIII
 select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_view)
-----
-0	199998	0	99999
-
-# The catalog path (ATTACH'd real TABLE) projects server-side via BuildPushdownQuery, so it is
-# tagged PUSHDOWN_ALREADY_APPLIED. Coverage, not a regression guard - this path is correct both
-# before and after. It exists because the tag is only true while BuildPushdownQuery emits a
-# SELECT list, and nothing else in the suite scans a real table across multiple fetch batches.
-
-# no columns needed: the planner still binds one column, so the pushdown query stays projected
-query I
-select count(*) from rpc.big_tbl
-----
-100000
-
-# narrowing projection
-query II
-select count(*), sum(i) from rpc.big_tbl
-----
-100000	4999950000
-
-# permuted projection over the catalog path
-query IIII
-select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_tbl)
 ----
 0	199998	0	99999
 

--- a/test/sql/attach_view_fetch_projection.test
+++ b/test/sql/attach_view_fetch_projection.test
@@ -25,6 +25,10 @@ call quack_serve({server}, token='asdf');
 statement ok
 create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
 
+# same shape as a real table: exercises the catalog path (server-side pushdown), see below
+statement ok
+create table big_tbl as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
+
 statement ok
 attach {server} as rpc (token 'asdf')
 
@@ -40,6 +44,37 @@ query II
 select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
 ----
 100000	4999950000
+
+# An equal-width PERMUTATION of the columns is the silent failure mode: DataChunk::Reference
+# succeeds (no bounds error, no type error), so continuation batches come back with their
+# columns swapped and the query returns plausible but WRONG numbers instead of raising.
+query IIII
+select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_view)
+----
+0	199998	0	99999
+
+# The catalog path (ATTACH'd real TABLE) projects server-side via BuildPushdownQuery, so it is
+# tagged PUSHDOWN_ALREADY_APPLIED. Coverage, not a regression guard - this path is correct both
+# before and after. It exists because the tag is only true while BuildPushdownQuery emits a
+# SELECT list, and nothing else in the suite scans a real table across multiple fetch batches.
+
+# no columns needed: the planner still binds one column, so the pushdown query stays projected
+query I
+select count(*) from rpc.big_tbl
+----
+100000
+
+# narrowing projection
+query II
+select count(*), sum(i) from rpc.big_tbl
+----
+100000	4999950000
+
+# permuted projection over the catalog path
+query IIII
+select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_tbl)
+----
+0	199998	0	99999
 
 statement ok con2
 detach rpc;

--- a/test/sql/attach_view_fetch_projection.test
+++ b/test/sql/attach_view_fetch_projection.test
@@ -1,11 +1,5 @@
 # name: test/sql/attach_view_fetch_projection.test
-# description: projected scan of an attached view whose result spans multiple fetch batches,
-#              reached the way a user reaches it: by sheer result size, at the default batch size.
-#              Regression test: continuation batches of a bind-time result were tagged
-#              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
-#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N").
-#              See attach_view_fetch_projection_batch_chunks.test for the same path forced
-#              directly via quack_fetch_batch_chunks, plus the permuted-projection case.
+# description: projected scan of an attached view spanning multiple fetch batches, by result size
 # group: [sql]
 
 require quack

--- a/test/sql/attach_view_fetch_projection.test_slow
+++ b/test/sql/attach_view_fetch_projection.test_slow
@@ -1,0 +1,45 @@
+# name: test/sql/attach_view_fetch_projection.test_slow
+# description: projected scan of an attached view whose result spans multiple fetch batches.
+#              Regression test: continuation batches of a bind-time result were tagged
+#              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
+#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N").
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# 3-column view so a projected scan is narrower than the wire chunks
+statement ok
+create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(10_000_000) t(i);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# view scans go through quack_query_by_name (bind-time result, client-side pushdown);
+# before the fix, fetch batch 2+ crashed here
+query II
+select count(*), sum(i) from rpc.big_view
+----
+10000000	49999995000000
+
+# a projected multi-batch quack_query takes the same path
+query II
+select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
+----
+10000000	49999995000000
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop

--- a/test/sql/attach_view_fetch_projection_batch_chunks.test
+++ b/test/sql/attach_view_fetch_projection_batch_chunks.test
@@ -1,12 +1,5 @@
 # name: test/sql/attach_view_fetch_projection_batch_chunks.test
-# description: projected scan of an attached view whose result spans multiple fetch batches,
-#              forced directly by shrinking the FETCH batch to a single chunk rather than by
-#              growing the result - same code path as attach_view_fetch_projection.test, but
-#              targeted at the mechanism instead of reaching it through data volume.
-#              Regression test: continuation batches of a bind-time result were tagged
-#              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
-#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N",
-#              or a Vector::Reference type mismatch depending on the view's schema).
+# description: projected scan of an attached view spanning multiple fetch batches, by batch size
 # group: [sql]
 
 require quack

--- a/test/sql/attach_view_fetch_projection_batch_chunks.test
+++ b/test/sql/attach_view_fetch_projection_batch_chunks.test
@@ -1,0 +1,61 @@
+# name: test/sql/attach_view_fetch_projection_batch_chunks.test
+# description: projected scan of an attached view whose result spans multiple fetch batches,
+#              forced directly by shrinking the FETCH batch to a single chunk rather than by
+#              growing the result - same code path as attach_view_fetch_projection.test, but
+#              targeted at the mechanism instead of reaching it through data volume.
+#              Regression test: continuation batches of a bind-time result were tagged
+#              PUSHDOWN_ALREADY_APPLIED and referenced full-width into the projected output
+#              chunk ("INTERNAL Error: Attempted to access index N within vector of size N",
+#              or a Vector::Reference type mismatch depending on the view's schema).
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+# force tiny fetch batches so even a small view spans many FETCH responses
+statement ok
+set global quack_fetch_batch_chunks=1;
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# 3-column view so a projected scan is narrower than the wire chunks
+statement ok
+create view big_view as select i, i * 2 as j, 'payload_' || i as k from range(100_000) t(i);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# view scans go through quack_query_by_name (bind-time result, client-side pushdown);
+# before the fix, fetch batch 2+ crashed here
+query II
+select count(*), sum(i) from rpc.big_view
+----
+100000	4999950000
+
+# a projected multi-batch quack_query takes the same path
+query II
+select count(*), sum(i) from quack_query({server}, 'from big_view', token='asdf')
+----
+100000	4999950000
+
+# An equal-width PERMUTATION of the columns is the silent failure mode: DataChunk::Reference
+# succeeds (no bounds error, no type error), so continuation batches come back with their
+# columns swapped and the query returns plausible but WRONG numbers instead of raising.
+query IIII
+select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_view)
+----
+0	199998	0	99999
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop

--- a/test/sql/attach_view_fetch_projection_batch_chunks.test
+++ b/test/sql/attach_view_fetch_projection_batch_chunks.test
@@ -52,6 +52,17 @@ select min(j), max(j), min(i), max(i) from (select j, i from rpc.big_view)
 ----
 0	199998	0	99999
 
+# A projection that is narrower AND mixes types raises a different error than the width-1 case
+# above: DataChunk::Reference iterates over the SOURCE width, so output slot 1 - the VARCHAR k -
+# is handed the source's j, a BIGINT. This is the shape users actually reported (#199):
+#   INTERNAL Error: Vector::Reference used on vector of different type
+#                   (source VARCHAR referenced BIGINT)
+# The width-1 projections above cannot produce it; they run off the end of the output instead.
+query II
+select count(*), max(k) from (select i, k from rpc.big_view)
+----
+100000	payload_99999
+
 statement ok con2
 detach rpc;
 


### PR DESCRIPTION
Solves a bug that was solved by three independent PRs:
* https://github.com/duckdb/duckdb-quack/pull/209
* https://github.com/duckdb/duckdb-quack/pull/199
* https://github.com/duckdb/duckdb-quack/pull/197 (vs `main`)
and fixes https://github.com/duckdb/duckdb-quack/issues/146

When multiple roundtrips are required for fetching a result AND some columns are pruned client side from the output, the bug would surface either as:
```
INTERNAL Error:
Attempted to access index 1 within vector of size 1
```
or
```
INTERNAL Error:
Vector::Reference used on vector of different type (source VARCHAR referenced BIGINT)
```

All three PRs already solved the problem in the strict sense, here though it generalize the solution and make the invariant clear also in code-paths there are at the moment unreachable, but could if code expands re-surface the same issue.

Infrastructure from https://github.com/duckdb/duckdb-quack/pull/209 (this PR is on top of tht), adding extended testing, and moving a pre-existing `.test_slow` to `.test` given it's regularly sub 1 second.