### PR TITLE
Quack compression or make quack faster over WAN!

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   quack_active_connections.cpp
   quack_clear_cache.cpp
   quack_client.cpp
+  quack_compression.cpp
   quack_data_stream.cpp
   quack_extension.cpp
   quack_fetch_ahead.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   quack_client.cpp
   quack_data_stream.cpp
   quack_extension.cpp
+  quack_fetch_ahead.cpp
   quack_http_server.cpp
   quack_log.cpp
   quack_message.cpp

--- a/src/include/quack_compression.hpp
+++ b/src/include/quack_compression.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class DatabaseInstance;
+
+enum class QuackCodec : uint8_t { NONE = 0, ZSTD = 2 };
+
+//! Sender-side settings; receivers auto-detect from the frame header.
+struct QuackCompressionConfig {
+	QuackCodec codec = QuackCodec::NONE;
+	int64_t zstd_level = 3;
+	idx_t min_size = 4096;
+
+	static QuackCompressionConfig FromContext(ClientContext &context);
+	//! Parse 'none', 'zstd' or 'zstd-<1..22>'; throws on anything else.
+	void ParseSpec(const string &spec);
+};
+
+//! Frame for compressed HTTP bodies: magic (2) + codec (1) + uncompressed size (8) + codec stream.
+//! Raw bodies always have 0x00 as their second byte (BinarySerializer field id), so no collision.
+struct QuackCompression {
+	static constexpr uint8_t MAGIC0 = 0xDB;
+	static constexpr uint8_t MAGIC1 = 0xC2;
+	static constexpr idx_t FRAME_HEADER_SIZE = 11;
+	static constexpr idx_t MAX_DECOMPRESSED_SIZE = idx_t(1) << 32;
+
+	//! Returns false (out untouched) when codec is NONE, size < min_size, or compression doesn't shrink.
+	static bool Compress(const QuackCompressionConfig &config, const_data_ptr_t data, idx_t size, MemoryStream &out);
+	static bool IsCompressedFrame(const_data_ptr_t data, idx_t size);
+	//! Throws IOException on unknown codec, corrupt frame or cap violation.
+	static AllocatedData Decompress(const_data_ptr_t data, idx_t size, idx_t &uncompressed_size);
+};
+
+} // namespace duckdb

--- a/src/include/quack_data_stream.hpp
+++ b/src/include/quack_data_stream.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/parallel/async_result.hpp"
 
 #include <condition_variable>
 #include <deque>
@@ -83,6 +84,20 @@ private:
 	//! Dead batch ranges [lo, hi) reported by the client for filtered/pruned gaps the sink never crossed.
 	//! The drain skips the cursor over a covering range instead of waiting for data that never comes.
 	std::map<idx_t, idx_t> dead_ranges DUCKDB_GUARDED_BY(lock);
+};
+
+//! Async task that parks a blocked scan until the stream has data (or ends); shared by
+//! scan_data_from_quack_client and the client-side fetch read-ahead.
+class QuackWaitForChunkTask : public AsyncTask {
+public:
+	explicit QuackWaitForChunkTask(shared_ptr<QuackDataStream> stream_p) : stream(std::move(stream_p)) {
+	}
+	void Execute() override {
+		stream->WaitForData();
+	}
+
+private:
+	shared_ptr<QuackDataStream> stream;
 };
 
 //! Process-global registry: maps stream id → QuackDataStream so the scan function can find it.

--- a/src/include/quack_fetch_ahead.hpp
+++ b/src/include/quack_fetch_ahead.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/serializer/async_task_queue.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+
+#include "quack_client.hpp"
+#include "quack_data_stream.hpp"
+
+namespace duckdb {
+
+//! Client-side FETCH read-ahead: keeps up to `depth` FETCH requests in flight on the ASYNC pool so
+//! scan threads consume decoded batches from a buffer instead of blocking on the wire. Mirrors the
+//! async SEND_DATA path. Top-up is consumer-driven only: tasks never register new tasks.
+class QuackFetchAhead {
+	friend class QuackFetchDataTask;
+
+public:
+	QuackFetchAhead(ClientContext &context, QuackClientConnection &connection, hugeint_t query_uuid, idx_t depth_p);
+	~QuackFetchAhead();
+
+public:
+	//! Resolve the read-ahead depth from the quack_fetch_read_ahead setting (0 = async thread count).
+	static idx_t GetReadAheadDepth(ClientContext &context);
+
+	QuackDataStream &Buffer() {
+		return *buffer;
+	}
+	shared_ptr<QuackDataStream> BufferPtr() {
+		return buffer;
+	}
+
+	//! Register fetch tasks until in-flight + buffered batches reach `depth`.
+	void TopUp();
+	//! Account one popped batch and refill the pipeline. Called by scan threads after a successful pop.
+	void BatchConsumed();
+	//! Stop topping up and drain all in-flight fetches; errors were already surfaced through the buffer.
+	void StopAndDrain();
+
+private:
+	//! Return a checked-out client to the idle stack.
+	void ReturnClient(unique_ptr<QuackClientWrapper> client);
+	//! Task epilogue: recycle the client, settle counters, finish the buffer after the last fetch.
+	void FinishTask(unique_ptr<QuackClientWrapper> client, bool pushed_batch);
+
+private:
+	unique_ptr<ManagedAsyncTaskQueue> queue;
+	shared_ptr<QuackDataStream> buffer;
+	//! The FETCH request bytes, encoded once; identical for every fetch of the query.
+	unique_ptr<MemoryStream> payload;
+	idx_t payload_size = 0;
+	string connection_id;
+	optional_idx client_query_id;
+	//! Context logger captured on the creating thread; pool threads have no ClientContext.
+	shared_ptr<Logger> logger;
+	idx_t depth;
+
+	mutex client_lock;
+	vector<unique_ptr<QuackClientWrapper>> idle_clients;
+
+	//! In-flight fetches + buffered batches not yet popped; bounded by depth.
+	atomic<idx_t> outstanding {0};
+	atomic<idx_t> in_flight {0};
+	atomic<bool> stop {false};
+	//! Set on the first empty FETCH response; no further fetches are issued.
+	atomic<bool> no_more_fetches {false};
+};
+
+} // namespace duckdb

--- a/src/include/quack_log.hpp
+++ b/src/include/quack_log.hpp
@@ -1,9 +1,16 @@
 #pragma once
 
+#include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/logging/log_type.hpp"
 #include "quack_message.hpp"
 
 namespace duckdb {
+
+//! Wall-clock epoch millis, same clock domain as core's HTTP request logs (HTTPLogType), so Quack
+//! and HTTP durations for the same request stay comparable.
+inline int64_t QuackNowMillis() {
+	return Timestamp::GetEpochMs(Timestamp::GetCurrentTimestamp());
+}
 
 class QuackLogType : public LogType {
 public:

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
+#include "quack_compression.hpp"
 #include "quack_uri.hpp"
 
 #include "httplib.hpp" // TODO forward declare
@@ -25,6 +26,7 @@ class PreparedStatement;
 class EncryptionState;
 class QuackDataStream;
 class ErrorData;
+enum class MessageType : uint8_t;
 
 enum class QuackQueryState : uint8_t { IDLE, ACTIVE, FINISHED, CANCELLED, QUACK_ERROR };
 
@@ -136,9 +138,11 @@ public:
 	}
 
 protected:
-	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);
+	//! `send_compression` is filled from the connection's session: response compression is per-connection.
+	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream, QuackCompressionConfig &send_compression);
 	unique_ptr<QuackMessage> HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
-	                                               optional_ptr<QuackConnection> connection);
+	                                               optional_ptr<QuackConnection> connection,
+	                                               QuackCompressionConfig &send_compression);
 
 protected:
 	std::vector<std::thread> listen_threads;

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -21,7 +21,7 @@ class QuackClientConnection;
 class QuackCatalog : public Catalog {
 public:
 	explicit QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p, ClientContext &context,
-	                      const string &token);
+	                      const string &token, const string &compression_spec);
 	~QuackCatalog() override;
 
 public:
@@ -78,6 +78,11 @@ public:
 
 	shared_ptr<QuackClientConnection> GetClientConnection();
 
+	//! ATTACH `compression` option; empty when not given (settings apply).
+	const string &AttachCompression() const {
+		return attach_compression;
+	}
+
 	void Refresh(ClientContext &context);
 
 private:
@@ -88,6 +93,7 @@ private:
 private:
 	shared_ptr<QuackClientConnection> client_connection;
 	unique_ptr<QuackSchemaSet> schemas;
+	string attach_compression;
 };
 
 } // namespace duckdb

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -6,15 +6,8 @@
 #include "quack_client.hpp"
 #include "quack_uri.hpp"
 
-#include <chrono>
 
 namespace duckdb {
-
-static int64_t NowMillis() {
-	return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-	    .time_since_epoch()
-	    .count();
-}
 
 template <class T>
 string GetUriPart(T ele) {
@@ -136,11 +129,11 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 	lock_guard<mutex> guard(request_mutex);
 	EnsureHttpParams(context);
 
-	int64_t start_time = NowMillis();
+	auto start_time = QuackNowMillis();
 	EncodeRequest(context, *request_message, write_stream);
 	auto response_body = PostRawLocked(write_stream.GetData(), write_stream.GetPosition());
 	auto response_message = DecodeResponse(response_body);
-	int64_t duration_ms = NowMillis() - start_time;
+	auto duration_ms = QuackNowMillis() - start_time;
 
 	string error;
 	if (response_message->Type() == MessageType::ERROR_RESPONSE) {

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -6,7 +6,6 @@
 #include "quack_client.hpp"
 #include "quack_uri.hpp"
 
-
 namespace duckdb {
 
 template <class T>

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/parallel/task_scheduler.hpp"
 
 #include "quack_client.hpp"
+#include "quack_compression.hpp"
 #include "quack_uri.hpp"
 
 namespace duckdb {
@@ -46,7 +47,16 @@ void QuackClient::EncodeRequest(optional_ptr<ClientContext> context, QuackMessag
 }
 
 unique_ptr<QuackMessage> QuackClient::DecodeResponse(const string &response_body) {
-	MemoryStream read_stream((data_ptr_t)response_body.data(), response_body.size());
+	auto data = const_data_ptr_cast(response_body.data());
+	idx_t size = response_body.size();
+	if (QuackCompression::IsCompressedFrame(data, size)) {
+		// DataChunk::Deserialize copies the data, so the scratch buffer may die on return
+		idx_t raw_size;
+		auto raw = QuackCompression::Decompress(data, size, raw_size);
+		MemoryStream read_stream(raw.get(), raw_size);
+		return QuackMessage::FromMemoryStream(read_stream);
+	}
+	MemoryStream read_stream((data_ptr_t)response_body.data(), size);
 	return QuackMessage::FromMemoryStream(read_stream);
 }
 

--- a/src/quack_compression.cpp
+++ b/src/quack_compression.cpp
@@ -1,0 +1,117 @@
+#include "quack_compression.hpp"
+
+#include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
+
+// duckdb's vendored zstd, already compiled into core
+#include "zstd.h"
+
+namespace duckdb {
+
+void QuackCompressionConfig::ParseSpec(const string &spec) {
+	auto lower = StringUtil::Lower(spec);
+	if (lower == "none") {
+		codec = QuackCodec::NONE;
+		return;
+	}
+	if (lower == "zstd") {
+		codec = QuackCodec::ZSTD;
+		zstd_level = 3;
+		return;
+	}
+	if (StringUtil::StartsWith(lower, "zstd-")) {
+		int64_t level;
+		if (TryCast::Operation(string_t(lower.substr(5)), level) && level >= 1 && level <= 22) {
+			codec = QuackCodec::ZSTD;
+			zstd_level = level;
+			return;
+		}
+	}
+	throw InvalidInputException(
+	    "Unknown quack_compression '%s', expected 'none', 'zstd' or 'zstd-<level>' with level between 1 and 22", spec);
+}
+
+template <class OP>
+static QuackCompressionConfig ReadConfig(OP &&try_get_setting) {
+	QuackCompressionConfig result;
+	Value val;
+	if (try_get_setting("quack_compression", val) && !val.IsNull()) {
+		result.ParseSpec(StringValue::Get(val));
+	}
+	if (try_get_setting("quack_compression_min_size", val) && !val.IsNull()) {
+		result.min_size = val.GetValue<idx_t>();
+	}
+	return result;
+}
+
+QuackCompressionConfig QuackCompressionConfig::FromContext(ClientContext &context) {
+	return ReadConfig([&](const string &name, Value &val) { return context.TryGetCurrentSetting(name, val); });
+}
+
+bool QuackCompression::Compress(const QuackCompressionConfig &config, const_data_ptr_t data, idx_t size,
+                                MemoryStream &out) {
+	if (config.codec != QuackCodec::ZSTD || size < config.min_size || size == 0) {
+		return false;
+	}
+
+	idx_t bound = duckdb_zstd::ZSTD_compressBound(size);
+	auto scratch = Allocator::DefaultAllocator().Allocate(bound);
+	auto ret = duckdb_zstd::ZSTD_compress(scratch.get(), bound, data, size, NumericCast<int>(config.zstd_level));
+	if (duckdb_zstd::ZSTD_isError(ret)) {
+		throw IOException("quack compression failed: %s", duckdb_zstd::ZSTD_getErrorName(ret));
+	}
+	idx_t compressed_size = ret;
+
+	if (compressed_size + FRAME_HEADER_SIZE >= size) {
+		// not worth it, send raw
+		return false;
+	}
+
+	uint8_t frame_header[FRAME_HEADER_SIZE];
+	frame_header[0] = MAGIC0;
+	frame_header[1] = MAGIC1;
+	frame_header[2] = static_cast<uint8_t>(config.codec);
+	uint64_t uncompressed_size = size;
+	memcpy(frame_header + 3, &uncompressed_size, sizeof(uint64_t));
+	out.WriteData(frame_header, FRAME_HEADER_SIZE);
+	out.WriteData(scratch.get(), compressed_size);
+	return true;
+}
+
+bool QuackCompression::IsCompressedFrame(const_data_ptr_t data, idx_t size) {
+	return size > FRAME_HEADER_SIZE && data[0] == MAGIC0 && data[1] == MAGIC1;
+}
+
+AllocatedData QuackCompression::Decompress(const_data_ptr_t data, idx_t size, idx_t &uncompressed_size) {
+	D_ASSERT(IsCompressedFrame(data, size));
+	auto codec = static_cast<QuackCodec>(data[2]);
+	if (codec != QuackCodec::ZSTD) {
+		throw IOException("quack decompression failed: unknown codec %d", int(data[2]));
+	}
+	uint64_t declared_size;
+	memcpy(&declared_size, data + 3, sizeof(uint64_t));
+	if (declared_size == 0 || declared_size > MAX_DECOMPRESSED_SIZE) {
+		throw IOException("quack decompression failed: declared size %llu out of bounds", declared_size);
+	}
+	auto body = data + FRAME_HEADER_SIZE;
+	auto body_size = size - FRAME_HEADER_SIZE;
+
+	auto result = Allocator::DefaultAllocator().Allocate(declared_size);
+	auto content_size = duckdb_zstd::ZSTD_getFrameContentSize(body, body_size);
+	if (content_size != declared_size) {
+		throw IOException("quack decompression failed: frame content size does not match declared size");
+	}
+	auto ret = duckdb_zstd::ZSTD_decompress(result.get(), declared_size, body, body_size);
+	if (duckdb_zstd::ZSTD_isError(ret)) {
+		throw IOException("quack decompression failed: %s", duckdb_zstd::ZSTD_getErrorName(ret));
+	}
+	if (ret != declared_size) {
+		throw IOException("quack decompression failed: decompressed size does not match declared size");
+	}
+	uncompressed_size = declared_size;
+	return result;
+}
+
+} // namespace duckdb

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -15,6 +15,7 @@
 #include "include/storage/quack_catalog.hpp"
 #include "quack_active_connections.hpp"
 #include "quack_clear_cache.hpp"
+#include "quack_compression.hpp"
 #include "quack_extension.hpp"
 #include "quack_log.hpp"
 #include "quack_scan.hpp"
@@ -119,6 +120,12 @@ static TableFunction GetQuackIdentifyFunction() {
 	return fun;
 }
 
+static void ValidateQuackCompression(ClientContext &, SetScope, Value &parameter) {
+	if (!parameter.IsNull()) {
+		QuackCompressionConfig().ParseSpec(StringValue::Get(parameter));
+	}
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
 	loader.SetDescription("The DuckDB 'Quack' Client/Server Protocol");
 
@@ -182,6 +189,16 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_send_data_flush_rows",
 	                          "Rows a thread buffers before flushing one SEND_DATA_REQUEST (0 = default 204800)",
 	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+
+	config.AddExtensionOption("quack_compression",
+	                          "Codec for bulk RPC payloads this node sends: 'none', 'zstd' or 'zstd-<level>' with "
+	                          "level 1-22 (bare 'zstd' = level 3); receivers auto-detect. On a server, responses "
+	                          "honor each connection's session value (settable by the client via the query "
+	                          "passthrough), falling back to the server's global",
+	                          LogicalType::VARCHAR, Value("none"), ValidateQuackCompression);
+	config.AddExtensionOption("quack_compression_min_size",
+	                          "Minimum encoded payload size in bytes before compression is attempted",
+	                          LogicalType::UBIGINT, Value::UBIGINT(4096));
 
 	config.AddExtensionOption("quack_server_max_connections",
 	                          "Maximum concurrent connections the RPC server accepts; beyond this new "

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -170,8 +170,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_authorization_function", "Name of a callback function for authorization",
 	                          LogicalType::VARCHAR, Value("quack_nop_authorization"), nullptr, SetScope::GLOBAL);
 
-	config.AddExtensionOption("quack_fetch_batch_chunks", "Maximum number of DataChunks returned per FETCH response",
-	                          LogicalType::UBIGINT, Value::UBIGINT(12));
+	config.AddExtensionOption("quack_fetch_batch_rows",
+	                          "Rows accumulated per FETCH response batch; whole DataChunks are added until the "
+	                          "cap is reached, so sparse (filtered) chunks don't shrink the response",
+	                          LogicalType::UBIGINT, Value::UBIGINT(24576));
+
+	config.AddExtensionOption("quack_fetch_read_ahead",
+	                          "FETCH requests kept in flight ahead of the scan (0 = number of async threads)",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0));
 
 	config.AddExtensionOption("quack_send_data_flush_rows",
 	                          "Rows a thread buffers before flushing one SEND_DATA_REQUEST (0 = default 204800)",

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -171,8 +171,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::VARCHAR, Value("quack_nop_authorization"), nullptr, SetScope::GLOBAL);
 
 	config.AddExtensionOption("quack_fetch_batch_rows",
-	                          "Rows accumulated per FETCH response batch; whole DataChunks are added until the "
-	                          "cap is reached, so sparse (filtered) chunks don't shrink the response",
+	                          "Rows accumulated per FETCH response batch (whole DataChunks, so the last chunk "
+	                          "may overshoot the cap)",
 	                          LogicalType::UBIGINT, Value::UBIGINT(24576));
 
 	config.AddExtensionOption("quack_fetch_read_ahead",

--- a/src/quack_fetch_ahead.cpp
+++ b/src/quack_fetch_ahead.cpp
@@ -5,7 +5,6 @@
 
 namespace duckdb {
 
-
 //===--------------------------------------------------------------------===//
 // Async fetch task
 //===--------------------------------------------------------------------===//
@@ -61,8 +60,8 @@ private:
 
 		auto &fetch_response = response->Cast<FetchResponseMessage>();
 		auto &wrappers = fetch_response.MutableResults();
-		// Recycle the client BEFORE publishing: the consumer's TopUp fires as soon as the batch is
-		// visible, and it must find an idle client or the pipeline stalls (fatal at depth 1).
+		// Recycle the client before publishing: a consumer TopUp triggered by this batch must
+		// find an idle client.
 		fetch_ahead.ReturnClient(std::move(client_wrapper));
 		bool pushed = false;
 		if (wrappers.empty()) {
@@ -81,8 +80,7 @@ private:
 				owned->Reference(wrapper->Chunk());
 				chunks.push_back(std::move(owned));
 			}
-			// Ordered delivery: fetches complete out of order, but scan threads must observe
-			// monotonically increasing batch indices (order-preserving plans enforce this).
+			// deliver in index order: scan threads must observe monotonically increasing batch indices
 			fetch_ahead.buffer->PushOrdered(std::move(chunks), batch_index.GetIndex(), 0, true, optional_idx());
 			pushed = true;
 		}

--- a/src/quack_fetch_ahead.cpp
+++ b/src/quack_fetch_ahead.cpp
@@ -1,0 +1,204 @@
+#include "quack_fetch_ahead.hpp"
+
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+namespace duckdb {
+
+
+//===--------------------------------------------------------------------===//
+// Async fetch task
+//===--------------------------------------------------------------------===//
+// Performs the blocking FETCH POST + response decode on an ASYNC-pool thread and publishes the
+// decoded batch into the read-ahead buffer under the server-assigned batch index.
+// TODO: there's read ahead logic implemented in core for multi file reader, a common abstraction
+// could be nice.
+class QuackFetchDataTask : public AsyncTask {
+public:
+	QuackFetchDataTask(QuackFetchAhead &fetch_ahead_p, unique_ptr<QuackClientWrapper> client_wrapper_p)
+	    : fetch_ahead(fetch_ahead_p), client_wrapper(std::move(client_wrapper_p)) {
+	}
+
+	void Execute() override {
+		// Surface errors through the buffer first so blocked scan threads wake and rethrow them,
+		// then let the queue capture them as well.
+		try {
+			ExecuteInternal();
+		} catch (std::exception &ex) {
+			fetch_ahead.buffer->SetError(ErrorData(ex));
+			fetch_ahead.FinishTask(std::move(client_wrapper), false);
+			throw;
+		} catch (...) {
+			fetch_ahead.buffer->SetError(ErrorData("Unknown error in quack fetch task"));
+			fetch_ahead.FinishTask(std::move(client_wrapper), false);
+			throw;
+		}
+	}
+
+private:
+	void ExecuteInternal() {
+		auto &client = client_wrapper->GetClient();
+		auto start_time = QuackNowMillis();
+		// context=nullptr: called off the execution thread, must not touch ClientContext.
+		auto response_body = client.PostRaw(nullptr, fetch_ahead.payload->GetData(), fetch_ahead.payload_size);
+		auto duration_ms = QuackNowMillis() - start_time;
+
+		auto response = QuackClient::DecodeResponse(response_body);
+
+		string error;
+		if (response->Type() == MessageType::ERROR_RESPONSE) {
+			error = response->Cast<ErrorResponse>().ErrorMessage();
+		}
+		client.LogRequest(Logger::Get(fetch_ahead.logger), MessageType::FETCH_REQUEST, fetch_ahead.connection_id,
+		                  fetch_ahead.client_query_id, string(), duration_ms, response->Type(), error);
+
+		if (response->Type() == MessageType::ERROR_RESPONSE) {
+			response->Cast<ErrorResponse>().Error().Throw();
+		}
+		if (response->Type() != FetchResponseMessage::TYPE) {
+			throw IOException("Expected fetch_response, got %s instead", MessageTypeToString(response->Type()));
+		}
+
+		auto &fetch_response = response->Cast<FetchResponseMessage>();
+		auto &wrappers = fetch_response.MutableResults();
+		// Recycle the client BEFORE publishing: the consumer's TopUp fires as soon as the batch is
+		// visible, and it must find an idle client or the pipeline stalls (fatal at depth 1).
+		fetch_ahead.ReturnClient(std::move(client_wrapper));
+		bool pushed = false;
+		if (wrappers.empty()) {
+			fetch_ahead.no_more_fetches = true;
+		} else {
+			auto batch_index = fetch_response.BatchIndex();
+			if (!batch_index.IsValid()) {
+				throw IOException("fetch_response with data is missing its batch index");
+			}
+			// Convert to owned chunks (buffers are shared, Reference is cheap) so decode stays here.
+			vector<unique_ptr<DataChunk>> chunks;
+			chunks.reserve(wrappers.size());
+			for (auto &wrapper : wrappers) {
+				auto owned = make_uniq<DataChunk>();
+				owned->InitializeEmpty(wrapper->Chunk().GetTypes());
+				owned->Reference(wrapper->Chunk());
+				chunks.push_back(std::move(owned));
+			}
+			// Ordered delivery: fetches complete out of order, but scan threads must observe
+			// monotonically increasing batch indices (order-preserving plans enforce this).
+			fetch_ahead.buffer->PushOrdered(std::move(chunks), batch_index.GetIndex(), 0, true, optional_idx());
+			pushed = true;
+		}
+		fetch_ahead.FinishTask(nullptr, pushed);
+	}
+
+private:
+	QuackFetchAhead &fetch_ahead;
+	unique_ptr<QuackClientWrapper> client_wrapper;
+};
+
+//===--------------------------------------------------------------------===//
+// QuackFetchAhead
+//===--------------------------------------------------------------------===//
+idx_t QuackFetchAhead::GetReadAheadDepth(ClientContext &context) {
+	Value val;
+	idx_t depth = 0;
+	if (context.TryGetCurrentSetting("quack_fetch_read_ahead", val) && !val.IsNull()) {
+		depth = val.GetValue<uint64_t>();
+	}
+	if (depth == 0) {
+		depth = MaxValue<idx_t>(1, (idx_t)TaskScheduler::GetScheduler(context).NumberOfAsyncThreads());
+	}
+	return depth;
+}
+
+QuackFetchAhead::QuackFetchAhead(ClientContext &context, QuackClientConnection &connection, hugeint_t query_uuid,
+                                 idx_t depth_p)
+    : depth(MaxValue<idx_t>(depth_p, 1)) {
+	queue = make_uniq<ManagedAsyncTaskQueue>(context, depth);
+	if (!queue->IsAsync()) {
+		// Register runs the POST inline on the scan thread; deeper pipelining is impossible.
+		depth = 1;
+	}
+	// Ordered stream: server-assigned FETCH batch indices are dense starting at 1 (the PREPARE
+	// batch is 0), so seed the delivery cursor there and release batches in index order.
+	buffer = make_shared_ptr<QuackDataStream>(vector<LogicalType>(), true);
+	buffer->SetWatermarkAndDrain(optional_idx(1));
+
+	FetchRequestMessage fetch_msg(connection.ConnectionId(), query_uuid);
+	payload = make_uniq<MemoryStream>();
+	QuackClient::EncodeRequest(context, fetch_msg, *payload);
+	payload_size = payload->GetPosition();
+	connection_id = fetch_msg.ConnectionId();
+	client_query_id = fetch_msg.ClientQueryId();
+	logger = context.logger;
+
+	for (idx_t i = 0; i < depth; i++) {
+		idle_clients.push_back(connection.GetClient(context));
+	}
+	TopUp();
+}
+
+QuackFetchAhead::~QuackFetchAhead() {
+	StopAndDrain();
+}
+
+void QuackFetchAhead::TopUp() {
+	while (!stop && !no_more_fetches) {
+		auto current = outstanding.load();
+		if (current >= depth) {
+			break;
+		}
+		if (!outstanding.compare_exchange_weak(current, current + 1)) {
+			continue;
+		}
+		unique_ptr<QuackClientWrapper> client;
+		{
+			lock_guard<mutex> guard(client_lock);
+			if (idle_clients.empty()) {
+				--outstanding;
+				break;
+			}
+			client = std::move(idle_clients.back());
+			idle_clients.pop_back();
+		}
+		++in_flight;
+		queue->Register(make_uniq<QuackFetchDataTask>(*this, std::move(client)), payload_size);
+	}
+}
+
+void QuackFetchAhead::BatchConsumed() {
+	--outstanding;
+	TopUp();
+}
+
+void QuackFetchAhead::ReturnClient(unique_ptr<QuackClientWrapper> client) {
+	lock_guard<mutex> guard(client_lock);
+	idle_clients.push_back(std::move(client));
+}
+
+void QuackFetchAhead::FinishTask(unique_ptr<QuackClientWrapper> client, bool pushed_batch) {
+	if (client) {
+		ReturnClient(std::move(client));
+	}
+	if (!pushed_batch) {
+		// Nothing entered the buffer for this fetch; release its pipeline slot.
+		--outstanding;
+	}
+	if (--in_flight == 0 && no_more_fetches) {
+		buffer->Finish();
+	}
+}
+
+void QuackFetchAhead::StopAndDrain() {
+	stop = true;
+	if (queue) {
+		try {
+			queue->Close();
+		} catch (...) {
+			// Fetch errors were already surfaced through the buffer; the scan rethrows them.
+		}
+		queue.reset();
+	}
+	lock_guard<mutex> guard(client_lock);
+	idle_clients.clear();
+}
+
+} // namespace duckdb

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -230,8 +230,29 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 			stream.WriteData((data_ptr_t)data, data_length);
 			return true;
 		});
-		auto response = HandleMessage(stream);
+		unique_ptr<QuackMessage> response;
+		QuackCompressionConfig send_compression;
+		if (QuackCompression::IsCompressedFrame(stream.GetData(), stream.GetPosition())) {
+			try {
+				idx_t raw_size;
+				auto raw = QuackCompression::Decompress(stream.GetData(), stream.GetPosition(), raw_size);
+				MemoryStream raw_stream(raw.get(), raw_size);
+				response = HandleMessage(raw_stream, send_compression);
+			} catch (std::exception &ex) {
+				response = make_uniq<ErrorResponse>(ErrorData(ex));
+			}
+		} else {
+			response = HandleMessage(stream, send_compression);
+		}
 		response->ToMemoryStream(stream);
+		auto response_type = response->Type();
+		if (response_type == MessageType::FETCH_RESPONSE || response_type == MessageType::PREPARE_RESPONSE) {
+			MemoryStream compressed;
+			if (QuackCompression::Compress(send_compression, stream.GetData(), stream.GetPosition(), compressed)) {
+				res.set_content((const char *)compressed.GetData(), compressed.GetPosition(), "application/vnd.duckdb");
+				return;
+			}
+		}
 		res.set_content((const char *)stream.GetData(), stream.GetPosition(), "application/vnd.duckdb");
 	});
 

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/enums/task_scheduler_type.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_helper.hpp"
@@ -7,6 +8,7 @@
 
 #include "quack_scan.hpp"
 #include "quack_client.hpp"
+#include "quack_fetch_ahead.hpp"
 #include "include/storage/quack_catalog.hpp"
 #include "storage/quack_transaction.hpp"
 
@@ -130,7 +132,6 @@ struct QuackScanLocalState : public LocalTableFunctionState {
 	~QuackScanLocalState() override {
 	}
 
-	unique_ptr<QuackClientWrapper> client_wrapper;
 	//! batch_index of the batch that `fetched_results` currently holds chunks from (server-assigned).
 	//! Surfaced to DuckDB via get_partition_data so downstream order-preserving operators
 	//! (CTAS, COPY TO, INSERT SELECT) can run the scan in parallel without losing order.
@@ -155,6 +156,8 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
 	hugeint_t query_uuid;
+	//! FETCH read-ahead pipeline; set when needs_more_fetch (see QuackScanInitGlobal).
+	shared_ptr<QuackFetchAhead> fetch_ahead;
 
 	vector<ChunkResult> TryGetResults() {
 		lock_guard<mutex> guard(lock);
@@ -268,8 +271,14 @@ unique_ptr<GlobalTableFunctionState> QuackScanInitGlobal(ClientContext &context,
 		query_uuid = bind_data.query_uuid;
 	}
 	// we only multithread if there is more to fetch
-	return make_uniq<QuackScanGlobalState>(input.column_indexes, input.projection_ids, std::move(results),
-	                                       needs_more_fetch, query_uuid);
+	auto global_state = make_uniq<QuackScanGlobalState>(input.column_indexes, input.projection_ids, std::move(results),
+	                                                    needs_more_fetch, query_uuid);
+	if (needs_more_fetch) {
+		// start pipelining FETCH requests on the ASYNC pool before the first scan call
+		global_state->fetch_ahead = make_shared_ptr<QuackFetchAhead>(context, *bind_data.client_connection, query_uuid,
+		                                                             QuackFetchAhead::GetReadAheadDepth(context));
+	}
+	return std::move(global_state);
 }
 
 unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
@@ -278,8 +287,6 @@ unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context
 	auto &global_state = global_state_p->Cast<QuackScanGlobalState>();
 	auto local_state = make_uniq<QuackScanLocalState>();
 
-	// re-use initial client from bind if possible
-	local_state->client_wrapper = bind_data.client_connection->GetClient(context.client);
 	auto results = global_state.TryGetResults();
 	for (auto &chunk : results) {
 		local_state->results.push(std::move(chunk));
@@ -319,29 +326,53 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 			}
 		}
 
-		// if that did not work, we request more results
-		if (local_state.results.empty() && global_state.needs_more_fetch) {
-			auto &client = local_state.client_wrapper->GetClient();
-			auto fetch_response = client.Request<FetchResponseMessage>(
-			    context,
-			    make_uniq<FetchRequestMessage>(bind_data.client_connection->ConnectionId(), global_state.query_uuid));
-
-			if (fetch_response->MutableResults().empty()) {
+		// if that did not work, we consume the next prefetched batch from the read-ahead buffer
+		if (local_state.results.empty() && global_state.needs_more_fetch && global_state.fetch_ahead) {
+			auto &fetch_ahead = *global_state.fetch_ahead;
+			idx_t batch_index;
+			vector<unique_ptr<DataChunk>> chunks;
+			switch (fetch_ahead.Buffer().TryPopBatch(batch_index, chunks)) {
+			case QuackDataStream::PopBatchStatus::BATCH: {
+				fetch_ahead.BatchConsumed();
+				// tag fetched chunks like the initial batch (see QuackScanInitGlobal): direct queries
+				// return full-width chunks that still need projection, the catalog path already projected
+				auto fetched_pushdown_type = bind_data.table_name.empty()
+				                                 ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
+				                                 : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
+				for (auto &chunk : chunks) {
+					local_state.results.emplace(*chunk, fetched_pushdown_type);
+				}
+				local_state.current_batch_index = batch_index;
+				continue;
+			}
+			case QuackDataStream::PopBatchStatus::FINISHED:
 				// server is done, we are done
 				global_state.needs_more_fetch = false;
 				bind_data.completed = true;
 				return;
+			case QuackDataStream::PopBatchStatus::ERRORED:
+				fetch_ahead.Buffer().GetError().Throw();
+				return;
+			case QuackDataStream::PopBatchStatus::EMPTY: {
+				// Self-healing: if a free pipeline slot and an idle client exist (e.g. a slot was
+				// released after this thread's last TopUp), refill before parking.
+				fetch_ahead.TopUp();
+				vector<unique_ptr<AsyncTask>> tasks;
+				tasks.push_back(make_uniq<QuackWaitForChunkTask>(fetch_ahead.BufferPtr()));
+				AsyncResult async_result(std::move(tasks), TaskSchedulerType::ASYNC);
+				if (input.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR) {
+					// yield BLOCKED; the wait task reschedules this scan once a batch is ready
+					input.async_result = std::move(async_result);
+					return;
+				}
+				// Synchronous fallback (async_threads=0): run the wait inline, then retry.
+				async_result.ExecuteTasksSynchronously();
+				if (context.IsInterrupted()) {
+					throw InterruptException();
+				}
+				continue;
 			}
-			// tag fetched chunks like the initial batch (see QuackScanInitGlobal): direct queries
-			// return full-width chunks that still need projection, the catalog path already projected
-			auto fetched_pushdown_type = bind_data.table_name.empty()
-			                                 ? ChunkResultPushdownType::REQUIRES_PUSHDOWN
-			                                 : ChunkResultPushdownType::PUSHDOWN_ALREADY_APPLIED;
-			for (auto &chunk : fetch_response->MutableResults()) {
-				local_state.results.emplace(chunk->Chunk(), fetched_pushdown_type);
 			}
-			local_state.current_batch_index = fetch_response->BatchIndex();
-			continue;
 		}
 		// we did not have anything cached and then request to the server did not yield anything - we are done
 		bind_data.completed = true;

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -354,8 +354,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 				fetch_ahead.Buffer().GetError().Throw();
 				return;
 			case QuackDataStream::PopBatchStatus::EMPTY: {
-				// Self-healing: if a free pipeline slot and an idle client exist (e.g. a slot was
-				// released after this thread's last TopUp), refill before parking.
+				// refill any free pipeline slots before parking
 				fetch_ahead.TopUp();
 				vector<unique_ptr<AsyncTask>> tasks;
 				tasks.push_back(make_uniq<QuackWaitForChunkTask>(fetch_ahead.BufferPtr()));

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -8,6 +8,7 @@
 
 #include "quack_scan.hpp"
 #include "quack_client.hpp"
+#include "quack_compression.hpp"
 #include "quack_fetch_ahead.hpp"
 #include "include/storage/quack_catalog.hpp"
 #include "storage/quack_transaction.hpp"
@@ -48,6 +49,19 @@ static unique_ptr<FunctionData> QuackScanBind(ClientContext &context, TableFunct
 
 	auto client_wrapper = client_connection.GetClient(context);
 	auto &client = client_wrapper->GetClient();
+
+	// quack_query has its own server connection, so the compression parameter can be scoped to it.
+	auto compression_entry = input.named_parameters.find("compression");
+	if (compression_entry != input.named_parameters.end()) {
+		if (compression_entry->second.IsNull()) {
+			throw InvalidInputException("compression cannot be null");
+		}
+		auto spec = compression_entry->second.GetValue<string>();
+		QuackCompressionConfig().ParseSpec(spec);
+		client.Request<PrepareResponseMessage>(
+		    context, make_uniq<PrepareRequestMessage>(client_connection.ConnectionId(),
+		                                              StringUtil::Format("SET quack_compression='%s'", spec), 0));
+	}
 
 	bind_data->query_uuid = UUID::GenerateRandomUUID();
 	auto bind_response = client.Request<PrepareResponseMessage>(
@@ -417,6 +431,8 @@ TableFunction QuackScanFunction::GetFunction() {
 	                         QuackScanInitGlobal, QuackScanInitLocal);
 	fun.named_parameters["disable_ssl"] = LogicalType::BOOLEAN;
 	fun.named_parameters["token"] = LogicalType::VARCHAR;
+	// no compression parameter: it rides the attach's shared connection, where the ATTACH option governs
+	fun.named_parameters["compression"] = LogicalType::VARCHAR;
 
 	fun.projection_pushdown = true;
 	fun.get_partition_data = QuackScanGetPartitionData;

--- a/src/quack_scan_from_client.cpp
+++ b/src/quack_scan_from_client.cpp
@@ -12,18 +12,6 @@
 
 namespace duckdb {
 
-class QuackWaitForChunkTask : public AsyncTask {
-public:
-	explicit QuackWaitForChunkTask(shared_ptr<QuackDataStream> stream_p) : stream(std::move(stream_p)) {
-	}
-	void Execute() override {
-		stream->WaitForData();
-	}
-
-private:
-	shared_ptr<QuackDataStream> stream;
-};
-
 struct QuackScanFromClientBindData : public FunctionData {
 	string stream_id;
 	shared_ptr<QuackDataStream> stream;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -347,8 +347,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 			error = response->Cast<ErrorResponse>().ErrorMessage();
 		}
 		auto msg = QuackLogType::ConstructLogMessage(header.type, header.connection_id, header.client_query_id,
-		                                             ExtractQuery(*received_message), "", duration_ms,
-		                                             response->Type(), error);
+		                                             ExtractQuery(*received_message), "", duration_ms, response->Type(),
+		                                             error);
 		logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 	}
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -309,9 +309,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 
 	int64_t start_time = 0;
 	if (should_log) {
-		start_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-		                 .time_since_epoch()
-		                 .count();
+		start_time = QuackNowMillis();
 	}
 
 	// start deserializing the message
@@ -343,15 +341,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	auto response = HandleMessageInternal(*db, *received_message, connection);
 
 	if (should_log) {
-		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-		                       .time_since_epoch()
-		                       .count();
+		auto duration_ms = QuackNowMillis() - start_time;
 		string error;
 		if (response->Type() == MessageType::ERROR_RESPONSE) {
 			error = response->Cast<ErrorResponse>().ErrorMessage();
 		}
 		auto msg = QuackLogType::ConstructLogMessage(header.type, header.connection_id, header.client_query_id,
-		                                             ExtractQuery(*received_message), "", end_time - start_time,
+		                                             ExtractQuery(*received_message), "", duration_ms,
 		                                             response->Type(), error);
 		logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 	}
@@ -359,11 +355,14 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	return response;
 }
 
+// Accumulate whole chunks until `max_rows` is reached (row-based like the send path, so sparse
+// filtered chunks don't shrink the batch). Resets query_result once the cursor is exhausted.
 static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, unique_ptr<QueryResult> &query_result,
-                                                        idx_t max_chunks) {
+                                                        idx_t max_rows) {
 	vector<unique_ptr<DataChunkWrapper>> results;
 
-	while (results.size() < max_chunks) {
+	idx_t rows = 0;
+	while (rows < max_rows) {
 		auto result_chunk = query_result->Fetch();
 		// error case
 		if (!result_chunk && query_result->HasError()) {
@@ -375,6 +374,7 @@ static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, un
 			query_result.reset();
 			break;
 		}
+		rows += result_chunk->size();
 		results.push_back(make_uniq<DataChunkWrapper>(*result_chunk));
 	}
 	return results;
@@ -460,14 +460,14 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		connection.next_batch_index = 1;
 		connection.query_uuid = prepare_request_message.QueryUUID();
 
-		Value max_chunks_val;
-		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);
-		auto max_chunks_per_batch = max_chunks_val.GetValue<uint64_t>();
+		Value max_rows_val;
+		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_rows", max_rows_val);
+		auto max_rows_per_batch = max_rows_val.GetValue<uint64_t>();
 
 		auto names = connection.duckdb_query_result->names;
 		auto types = connection.duckdb_query_result->types;
 
-		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_chunks_per_batch);
+		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_rows_per_batch);
 		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) {
 			D_ASSERT(results.empty());
 
@@ -475,7 +475,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			connection.duckdb_query_result.reset();
 			return make_uniq<ErrorResponse>(std::move(error_message));
 		}
-		auto needs_more_fetch = results.size() == max_chunks_per_batch;
+		// CreateBatch resets the cursor on exhaustion; a live cursor means more batches remain.
+		auto needs_more_fetch = connection.duckdb_query_result != nullptr;
 		if (!needs_more_fetch && connection.query_state == QuackQueryState::ACTIVE) {
 			connection.query_state = QuackQueryState::FINISHED;
 		}
@@ -501,11 +502,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(connection.duckdb_query_result->GetErrorObject());
 		}
 
-		Value max_chunks_val;
-		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_chunks", max_chunks_val);
-		auto max_chunks_per_batch = max_chunks_val.GetValue<uint64_t>();
+		Value max_rows_val;
+		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_rows", max_rows_val);
+		auto max_rows_per_batch = max_rows_val.GetValue<uint64_t>();
 
-		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_chunks_per_batch);
+		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_rows_per_batch);
 		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) { // TODO this is duplicated
 			D_ASSERT(results.empty());
 			auto error_message = connection.duckdb_query_result->GetErrorObject();
@@ -513,7 +514,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(std::move(error_message));
 		}
 		auto assigned_batch_index = connection.next_batch_index++;
-		if (results.size() < max_chunks_per_batch && connection.query_state == QuackQueryState::ACTIVE) {
+		if (!connection.duckdb_query_result && connection.query_state == QuackQueryState::ACTIVE) {
 			connection.query_state = QuackQueryState::FINISHED;
 		}
 		return make_uniq<FetchResponseMessage>(std::move(results), optional_idx(assigned_batch_index));

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -299,7 +299,8 @@ bool MessageRequiresConnection(MessageType type) {
 }
 
 // main switcheroo happens here
-unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
+unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream,
+                                                    QuackCompressionConfig &send_compression) {
 	auto db = db_ptr.lock();
 	if (!db) {
 		return make_uniq<ErrorResponse>("Database was closed");
@@ -338,7 +339,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	auto received_message = QuackMessage::DeserializeMessage(deserializer, header);
 
 	// process the message
-	auto response = HandleMessageInternal(*db, *received_message, connection);
+	auto response = HandleMessageInternal(*db, *received_message, connection, send_compression);
 
 	if (should_log) {
 		auto duration_ms = QuackNowMillis() - start_time;
@@ -381,7 +382,8 @@ static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, un
 }
 
 unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
-                                                            optional_ptr<QuackConnection> connection_p) {
+                                                            optional_ptr<QuackConnection> connection_p,
+                                                            QuackCompressionConfig &send_compression) {
 	if (connection_p) {
 		// A message unrelated to the active insert stream means it was abandoned (client source failed, no
 		// FINALIZE) — abort it so it rolls back and releases the connection lock.
@@ -480,6 +482,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		if (!needs_more_fetch && connection.query_state == QuackQueryState::ACTIVE) {
 			connection.query_state = QuackQueryState::FINISHED;
 		}
+		// Connection-scoped: a SET through the query passthrough lands in this session.
+		send_compression = QuackCompressionConfig::FromContext(*connection.duckdb_connection->context);
 		return make_uniq<PrepareResponseMessage>(types, names, std::move(results), needs_more_fetch,
 		                                         connection.query_uuid);
 	}
@@ -517,6 +521,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		if (!connection.duckdb_query_result && connection.query_state == QuackQueryState::ACTIVE) {
 			connection.query_state = QuackQueryState::FINISHED;
 		}
+		send_compression = QuackCompressionConfig::FromContext(*connection.duckdb_connection->context);
 		return make_uniq<FetchResponseMessage>(std::move(results), optional_idx(assigned_batch_index));
 	}
 

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -97,7 +97,11 @@ static unique_ptr<Catalog> QuackAttach(optional_ptr<StorageExtensionInfo> storag
 	if (attach_options.options.find("token") != attach_options.options.end()) {
 		token = attach_options.options["token"].GetValue<string>();
 	}
-	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token);
+	string compression;
+	if (attach_options.options.find("compression") != attach_options.options.end()) {
+		compression = attach_options.options["compression"].GetValue<string>();
+	}
+	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token, compression);
 }
 
 static unique_ptr<TransactionManager> QuackCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -13,6 +13,7 @@
 
 #include "storage/quack_catalog.hpp"
 #include "storage/quack_table.hpp"
+#include "quack_compression.hpp"
 #include "quack_scan.hpp"
 #include "storage/quack_insert.hpp"
 #include "quack_message.hpp"
@@ -24,10 +25,20 @@
 namespace duckdb {
 
 QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, ClientContext &context,
-                           const string &token)
-    : Catalog(db_p) {
+                           const string &token, const string &compression_spec)
+    : Catalog(db_p), attach_compression(compression_spec) {
+	// validate before connecting so a bad spec fails the ATTACH locally
+	if (!attach_compression.empty()) {
+		QuackCompressionConfig().ParseSpec(attach_compression);
+	}
+
 	// connect to the server
 	client_connection = QuackClient::ConnectToServer(context, server_uri, token);
+
+	// scope response compression to this attach via its server-side session
+	if (!attach_compression.empty()) {
+		ExecuteCommandInternal(context, StringUtil::Format("SET quack_compression='%s'", attach_compression));
+	}
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -11,6 +11,7 @@
 #include "storage/quack_insert.hpp"
 #include "storage/quack_table.hpp"
 #include "quack_client.hpp"
+#include "quack_compression.hpp"
 
 #include <chrono>
 #include <set>
@@ -162,6 +163,7 @@ private:
 //===--------------------------------------------------------------------===//
 // Send helpers
 //===--------------------------------------------------------------------===//
+
 // Serialize `chunks` into one SEND_DATA_REQUEST and register it with the async queue. The payload is
 // serialized on this (regular) execution thread; an ASYNC-pool thread does the blocking POST.
 // For PARALLEL_ORDERED: lstate.current_batch and lstate.sequence_counter must already be set.
@@ -206,6 +208,18 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 	// Encode on the producer thread: the async task runs off-thread and must not touch ClientContext.
 	auto payload = make_uniq<MemoryStream>();
 	QuackClient::EncodeRequest(context, *send_msg, *payload);
+	// Compress here too: keeps the async task pure network IO.
+	auto compression = QuackCompressionConfig::FromContext(context);
+	// the ATTACH option overrides the session setting
+	if (!quack_catalog.AttachCompression().empty()) {
+		compression.ParseSpec(quack_catalog.AttachCompression());
+	}
+	if (compression.codec != QuackCodec::NONE) {
+		auto compressed = make_uniq<MemoryStream>();
+		if (QuackCompression::Compress(compression, payload->GetData(), payload->GetPosition(), *compressed)) {
+			payload = std::move(compressed);
+		}
+	}
 	auto payload_size = payload->GetPosition();
 
 	auto connection_id = send_msg->ConnectionId();

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -113,12 +113,6 @@ unique_ptr<LocalSinkState> QuackInsert::GetLocalSinkState(ExecutionContext &cont
 //===--------------------------------------------------------------------===//
 // Async send task
 //===--------------------------------------------------------------------===//
-static int64_t NowMillis() {
-	return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
-	    .time_since_epoch()
-	    .count();
-}
-
 // Performs the blocking SEND_DATA POST on an ASYNC-pool thread. The payload was serialized on
 // the producing (regular) execution thread; this task only does the network send and checks the ack.
 class QuackSendDataTask : public AsyncTask {
@@ -132,10 +126,10 @@ public:
 
 	void Execute() override {
 		auto &client = client_wrapper->GetClient();
-		auto start_time = NowMillis();
+		auto start_time = QuackNowMillis();
 		// context=nullptr: called off the execution thread, must not touch ClientContext.
 		auto response_body = client.PostRaw(nullptr, payload->GetData(), payload_size);
-		auto duration_ms = NowMillis() - start_time;
+		auto duration_ms = QuackNowMillis() - start_time;
 
 		auto response = QuackClient::DecodeResponse(response_body);
 

--- a/test/sql/attach_fetch_large.test_slow
+++ b/test/sql/attach_fetch_large.test_slow
@@ -23,9 +23,20 @@ select count(*), sum(i) from quack_query_by_name('rpc', 'from big_tbl')
 statement ok
 detach rpc;
 
+# large fetch must behave the same with the read-ahead on the ASYNC pool or inline (async_threads=0)
+foreach at 0 8
+
+statement ok
+SET async_threads={at};
+
 query II
 select count(*), sum(i) from quack_query({server}, 'from big_tbl', token='asdf')
 ----
 10000000	49999995000000
+
+endloop
+
+statement ok
+reset async_threads;
 
 include test/template/quack_teardown.test_template

--- a/test/sql/compression.test
+++ b/test/sql/compression.test
@@ -1,0 +1,333 @@
+# name: test/sql/compression.test
+# description: payload compression on the FETCH and SEND_DATA paths
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table big as select range i from range(100000);
+
+statement ok quack_db:quack_server_con
+create table small as select range i from range(5000);
+
+statement ok quack_db:quack_server_con
+create table wide as select range i, repeat('x', 50) s from range(200000);
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+#===--------------------------------------------------------------------===#
+# setting validation
+#===--------------------------------------------------------------------===#
+
+statement error
+set quack_compression='lz4';
+----
+Unknown quack_compression
+
+statement error
+set quack_compression='gzip';
+----
+Unknown quack_compression
+
+statement error
+set quack_compression='zstd-0';
+----
+Unknown quack_compression
+
+statement error
+set quack_compression='zstd-23';
+----
+Unknown quack_compression
+
+statement error
+set quack_compression='zstd-x';
+----
+Unknown quack_compression
+
+#===--------------------------------------------------------------------===#
+# round-trips per codec, on the async-pool and sync-inline decode paths
+#===--------------------------------------------------------------------===#
+
+# force compression of every bulk payload, however small
+statement ok quack_db:quack_server_con
+set global quack_compression_min_size=0;
+
+statement ok
+set quack_compression_min_size=0;
+
+foreach codec none zstd
+
+statement ok quack_db:quack_server_con
+set global quack_compression='{codec}';
+
+statement ok
+set quack_compression='{codec}';
+
+foreach at 0 8
+
+statement ok
+SET async_threads={at};
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+query II
+select count(*), sum(i) from rpc.big
+----
+100000	4999950000
+
+# order preservation is unaffected by compression
+statement ok
+create or replace table ordered_ctas as select i from rpc.big;
+
+query I
+select count(*) from (select i, row_number() over () - 1 rn from ordered_ctas) where i != rn
+----
+0
+
+# append path: CTAS + INSERT over SEND_DATA
+statement ok
+create or replace table rpc.appended as select range i from range(100000);
+
+statement ok
+insert into rpc.appended select range i from range(50000);
+
+query II quack_db:quack_server_con
+select count(*), sum(i) from appended
+----
+150000	6249925000
+
+endloop
+
+endloop
+
+#===--------------------------------------------------------------------===#
+# explicit zstd levels
+#===--------------------------------------------------------------------===#
+
+foreach codec zstd-1 zstd-19
+
+statement ok
+set quack_compression='{codec}';
+
+statement ok quack_db:quack_server_con
+set global quack_compression='{codec}';
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+endloop
+
+#===--------------------------------------------------------------------===#
+# mismatched client/server codecs: receivers auto-detect
+#===--------------------------------------------------------------------===#
+
+foreach client_codec zstd none
+
+foreach server_codec none zstd
+
+statement ok
+set quack_compression='{client_codec}';
+
+statement ok quack_db:quack_server_con
+set global quack_compression='{server_codec}';
+
+query II
+select count(*), sum(i) from rpc.big
+----
+100000	4999950000
+
+statement ok
+create or replace table rpc.t as select range i from range(10000);
+
+query II quack_db:quack_server_con
+select count(*), sum(i) from t
+----
+10000	49995000
+
+endloop
+
+endloop
+
+#===--------------------------------------------------------------------===#
+# many small compressed FETCH responses: one chunk per round-trip
+#===--------------------------------------------------------------------===#
+
+statement ok quack_db:quack_server_con
+set global quack_compression='zstd';
+
+statement ok quack_db:quack_server_con
+set global quack_fetch_batch_rows=1;
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from small', token='asdf')
+----
+5000	12497500
+
+statement ok quack_db:quack_server_con
+reset global quack_fetch_batch_rows;
+
+# default min_size: tiny payloads skip compression and still round-trip
+statement ok
+reset quack_compression_min_size;
+
+query I
+select count(*) from quack_query({server}, 'select 1', token='asdf')
+----
+1
+
+# back to raw defaults for the connection-scoped sections below
+statement ok quack_db:quack_server_con
+set global quack_compression='none';
+
+statement ok quack_db:quack_server_con
+reset global quack_compression_min_size;
+
+statement ok
+set quack_compression='none';
+
+#===--------------------------------------------------------------------===#
+# connection-scoped server responses: opt in via the query passthrough
+#===--------------------------------------------------------------------===#
+
+# observe wire size via the client HTTP log (response Content-Length); pull real data
+# (aggregations get pushed down to the server and would transfer almost nothing)
+statement ok
+call enable_logging(['HTTP']);
+
+statement ok
+set logging_storage='memory';
+
+# server global stays 'none'; this connection opts in through its server-side session
+statement ok
+select * from quack_query_by_name('rpc', 'SET quack_compression=''zstd-1''');
+
+statement ok
+create table copy_compressed as from rpc.wide;
+
+query II
+select count(*), sum(i) from copy_compressed
+----
+200000	19999900000
+
+statement ok
+set variable compressed_bytes = (select sum(try_cast(response.headers['Content-Length'] as ubigint))
+                                 from duckdb_logs_parsed('HTTP'));
+
+# opt back out on the same connection and read again
+statement ok
+select * from quack_query_by_name('rpc', 'SET quack_compression=''none''');
+
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+create table copy_raw as from rpc.wide;
+
+query II
+select count(*), sum(i) from copy_raw
+----
+200000	19999900000
+
+statement ok
+set variable raw_bytes = (select sum(try_cast(response.headers['Content-Length'] as ubigint))
+                          from duckdb_logs_parsed('HTTP'));
+
+# the opted-in read must have moved far fewer bytes than the opted-out one
+query I
+select getvariable('raw_bytes') > 2 * getvariable('compressed_bytes')
+----
+true
+
+#===--------------------------------------------------------------------===#
+# compression as an ATTACH option and a quack_query named parameter
+#===--------------------------------------------------------------------===#
+
+# a bad spec fails the ATTACH locally, before connecting
+statement error
+attach {server} as bad_rpc (token 'asdf', compression 'lz77')
+----
+Unknown quack_compression
+
+statement ok
+attach {server} as rpc_z (token 'asdf', compression 'zstd-1')
+
+# reads through this attach come back compressed (server session was set at attach time)
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+create table copy_attach as from rpc_z.wide;
+
+query II
+select count(*), sum(i) from copy_attach
+----
+200000	19999900000
+
+statement ok
+set variable attach_response_bytes = (select sum(try_cast(response.headers['Content-Length'] as ubigint))
+                                      from duckdb_logs_parsed('HTTP'));
+
+# uploads through this attach are compressed too: the attach option overrides the (unset) session setting
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+create table rpc_z.copy_up as from copy_attach;
+
+query II quack_db:quack_server_con
+select count(*), sum(i) from copy_up
+----
+200000	19999900000
+
+statement ok
+set variable attach_request_bytes = (select sum(request.request_body_length)
+                                     from duckdb_logs_parsed('HTTP'));
+
+# quack_query with the compression parameter: scoped to that call's private connection
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+create table copy_param as select * from quack_query({server}, 'from wide', token='asdf', compression='zstd-1');
+
+query II
+select count(*), sum(i) from copy_param
+----
+200000	19999900000
+
+statement ok
+set variable param_response_bytes = (select sum(try_cast(response.headers['Content-Length'] as ubigint))
+                                     from duckdb_logs_parsed('HTTP'));
+
+# baseline uncompressed upload through a plain attach
+statement ok
+call truncate_duckdb_logs();
+
+statement ok
+create table rpc.copy_up_raw as from copy_attach;
+
+statement ok
+set variable plain_request_bytes = (select sum(request.request_body_length)
+                                    from duckdb_logs_parsed('HTTP'));
+
+# compressed paths must move far fewer bytes than their raw counterparts
+query III
+select getvariable('raw_bytes') > 2 * getvariable('attach_response_bytes'),
+       getvariable('raw_bytes') > 2 * getvariable('param_response_bytes'),
+       getvariable('plain_request_bytes') > 2 * getvariable('attach_request_bytes')
+----
+true	true	true
+
+# a bad spec on quack_query errors locally
+statement error
+select * from quack_query({server}, 'from wide', token='asdf', compression='zstd-99')
+----
+Unknown quack_compression
+
+include test/template/quack_teardown.test_template

--- a/test/sql/fetch_async.test
+++ b/test/sql/fetch_async.test
@@ -1,0 +1,124 @@
+# name: test/sql/fetch_async.test
+# description: async FETCH read-ahead: non-blocking quack scan pipelines fetches on the ASYNC pool
+# group: [sql]
+
+require parquet
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create table big as select range i from range(100000);
+
+statement ok quack_db:quack_server_con
+create table big500 as select range i from range(500000);
+
+# remote parquet source: the server-side scan is parallel/multi-row-group, but FETCH batch
+# indices are minted by the quack server, so client-side ordering must be unaffected
+statement ok quack_db:quack_server_con
+copy (select range i from range(500000)) to '{TEST_DIR}/fetch_ord.parquet' (row_group_size 50000);
+
+statement ok quack_db:quack_server_con
+create view big_pq as select i from '{TEST_DIR}/fetch_ord.parquet';
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+# one DataChunk per FETCH response => many FETCH round-trips, exercising the read-ahead pipeline.
+# Set AFTER the attach: the catalog enumeration itself is otherwise truncated to one chunk and
+# loses the views (pre-existing ExecuteCommandInternal FIXME).
+statement ok quack_db:quack_server_con
+set global quack_fetch_batch_rows=1;
+
+# the scan must behave the same whether fetches run on the ASYNC pool or inline (async_threads=0)
+foreach at 0 1 8
+
+statement ok
+SET async_threads={at};
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+query II
+select count(*), sum(i) from quack_query_by_name('rpc', 'from big')
+----
+100000	4999950000
+
+# order preservation: server-assigned batch indices flow into an order-preserving CTAS
+statement ok
+create or replace table local_ctas as from quack_query({server}, 'select i from big order by i', token='asdf');
+
+query I
+select count(*) from (select i, row_number() over () - 1 rn from local_ctas) where i != rn
+----
+0
+
+# larger ordered CTAS through the attached catalog: fetches complete out of order, but scan
+# threads must observe monotonically increasing batch indices (order-preserving plan asserts it)
+statement ok
+create or replace table ordered_ctas as select i from rpc.big500;
+
+query I
+select count(*) from (select i, row_number() over () - 1 rn from ordered_ctas) where i != rn
+----
+0
+
+# same, sourced from a remote parquet view (parallel multi-row-group scan on the server)
+statement ok
+create or replace table ordered_ctas_pq as select i from rpc.big_pq;
+
+query I
+select count(*) from (select i, row_number() over () - 1 rn from ordered_ctas_pq) where i != rn
+----
+0
+
+# early termination: LIMIT stops the scan with fetches still in flight; a follow-up query must work
+query I
+select i from quack_query({server}, 'select i from big order by i', token='asdf') limit 1
+----
+0
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+# explicit read-ahead depths
+statement ok
+set quack_fetch_read_ahead=1;
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+statement ok
+set quack_fetch_read_ahead=8;
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+statement ok
+reset quack_fetch_read_ahead;
+
+endloop
+
+statement ok
+reset async_threads;
+
+# mid-stream error: the cast fails long after the PREPARE batch, so the error surfaces on a FETCH
+statement error
+select * from quack_query({server}, 'select (case when range < 90000 then range::varchar else ''oops'' end)::int from range(100000)', token='asdf')
+----
+Could not convert string
+
+# the connection survives the failed scan
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+include test/template/quack_teardown.test_template

--- a/test/sql/fetch_projection.test
+++ b/test/sql/fetch_projection.test
@@ -4,7 +4,7 @@
 
 include test/template/quack_setup.test_template
 
-# 30000 rows x 2 cols => ~15 DataChunks of 2048 => exceeds quack_fetch_batch_chunks (12),
+# 30000 rows x 2 cols => ~15 DataChunks of 2048 => exceeds quack_fetch_batch_rows (24576),
 # forcing at least one FETCH round-trip after the initial PREPARE batch.
 statement ok quack_db:quack_server_con
 create table big as select range as a, range * 2 as b from range(30000);

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -184,6 +184,41 @@ detach rpc
 statement ok
 SET preserve_insertion_order=true;
 
+# --- HTTP logging (async fetch read-ahead path) ---
+# Async FETCH POSTs run on ASYNC-pool threads via PostRaw(nullptr, ...); the logger stamped at
+# client checkout must make them visible in the HTTP transport log, not just the Quack log.
+
+# small fetch batches so one scan makes many async FETCH round-trips
+statement ok quack_db:quack_server_con
+set global quack_fetch_batch_rows=2048;
+
+statement ok
+CALL truncate_duckdb_logs();
+
+query I
+select count(*) from quack_query({server}, 'from range(50000)')
+----
+50000
+
+# sanity: the scan actually produced multiple async fetches
+query I
+select count(*) > 1 from duckdb_logs_parsed('Quack') where message_type = 'FETCH_REQUEST'
+----
+true
+
+# every Quack-logged request (including all async FETCHes) is visible as an HTTP POST.
+# DISCONNECTs are excluded: they are context-less teardown on pooled clients whose logger stamp
+# was cleared, so they are Quack-logged (db logger) but deliberately not HTTP-logged (see below).
+query I
+select
+  (select count(*) from duckdb_logs_parsed('Quack') where message_type != 'DISCONNECT_MESSAGE')
+  = (select count(*) from duckdb_logs_parsed('HTTP') where request.type = 'POST')
+----
+true
+
+statement ok quack_db:quack_server_con
+reset global quack_fetch_batch_rows;
+
 # --- HTTP logging (context-less teardown scope) ---
 # A pooled client's DISCONNECT POST is context-less and must not be logged under the
 # connection scope of a query that already ran on that pooled connection.


### PR DESCRIPTION
Builds on top of https://github.com/duckdb/duckdb-quack/pull/208 (assuming that will get merged).

This PR adds optional zstd compression to the two bulk transfer paths: FETCH/PREPARE responses (read) and SEND_DATA requests (append). Compressed HTTP bodies get an 11-byte frame (magic + codec byte + uncompressed size) and receivers auto-detect it, so client and server settings are fully independent and mismatched configurations just work. Control messages are never compressed, so the handshake can't break. zstd comes from duckdb's vendored copy, no new dependencies.

Server response compression is connection scoped rather than global. Each FETCH/PREPARE response is compressed according to the connection's server-side session value, falling back to the server's `SET GLOBAL` as the fleet default. This lets one server serve a same-region client raw and a WAN client compressed at the same time.

## User API

```sql
-- attach: compresses this attach's uploads and its responses from the server
ATTACH 'quack:host:port' AS rpc (token '...', compression 'zstd-1');

-- quack_query: scoped to that call's private connection
SELECT * FROM quack_query('quack:host:port', 'from t', token='...', compression='zstd-1');

-- underlying settings (sender-side, on whichever node they are set)
SET quack_compression = 'none' | 'zstd' | 'zstd-1' .. 'zstd-22';  -- default zstd = level 3
SET quack_compression_min_size = 4096;                            -- below this, send raw
```

The default is `'none'`.

## Numbers

zstd-1 compresses lineitem ~3.7x on the wire. WAN (laptop wifi to EC2, SF5): **reads go from 42.6s to 14.5s (2.9x)**, appends from **23.2s to 6.7s (3.5x**, uplink fully saturated). EC2 to EC2 same region (c7g.2xlarge, 14.9 Gbps): appends are slightly faster with zstd-1 (0.96s to 0.90s), reads slightly slower (3.06s to 3.31s) but this is due to a bottleneck on the server side serial batch production (that may be addressed later on in DuckDB core).

