### PR TITLE
Reject INSERT ... RETURNING, the intended behaviour

### DIFF
--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -103,6 +103,9 @@ InsertionOrderPreservingMap<string> QuackInsert::ParamsToString() const {
 
 PhysicalOperator &QuackCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
                                            optional_ptr<PhysicalOperator> plan) {
+	if (op.return_chunk) {
+		throw NotImplementedException("RETURNING not yet supported for QUACK_INSERT");
+	}
 	D_ASSERT(plan);
 	if (!op.column_index_map.empty()) {
 		plan = planner.ResolveDefaultsProjection(op, *plan);

--- a/test/sql/returning.test
+++ b/test/sql/returning.test
@@ -1,0 +1,83 @@
+# name: test/sql/returning.test
+# description: RETURNING is not supported over quack — it must be a clean error, never silently-wrong data
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+statement ok con2
+attach {server} as d (token 'asdf');
+
+statement ok con2
+create table d.items(id integer, name varchar);
+
+# INSERT ... RETURNING used to plan fine and hand back the insert COUNT coerced into
+# column 0, with the remaining columns uninitialized (duckdb-quack#114). A single-row
+# insert disguises it: (1, 'apple') RETURNING * came back as (1, <empty>), and that 1 is
+# the count, not the id. It must throw instead.
+statement error con2
+insert into d.items values (1, 'apple') returning *;
+----
+RETURNING not yet supported for QUACK_INSERT
+
+statement error con2
+insert into d.items values (2, 'pear') returning id;
+----
+RETURNING not yet supported for QUACK_INSERT
+
+statement error con2
+insert into d.items select 3, 'plum' returning id, name;
+----
+RETURNING not yet supported for QUACK_INSERT
+
+# the rejected inserts must not have written anything
+query I con2
+select count(*) from d.items;
+----
+0
+
+# plain INSERT (no RETURNING) keeps working
+statement ok con2
+insert into d.items values (70, 'apple'), (80, 'pear'), (90, 'plum');
+
+query II con2
+select id, name from d.items order by id;
+----
+70	apple
+80	pear
+90	plum
+
+# The other DML paths that can carry RETURNING (UPDATE / DELETE / MERGE INTO) are rejected by
+# the binder before planning even reaches QuackCatalog, because a quack table is not a base
+# table. Pin that here: if any of them is ever implemented, it inherits the RETURNING question,
+# and this test should start failing rather than silently returning the wrong data.
+statement error con2
+update d.items set name = 'x' where id = 70 returning *;
+----
+Can only update base table
+
+statement error con2
+delete from d.items where id = 70 returning *;
+----
+Can only delete from base table
+
+statement error con2
+merge into d.items using (select 70 as id) s on d.items.id = s.id when matched then delete returning *;
+----
+Can only merge into base tables
+
+statement ok con2
+detach d;
+
+statement ok con1
+call quack_stop({server});
+
+endloop


### PR DESCRIPTION
QuackCatalog::PlanInsert accepted RETURNING and planned a QuackInsert, whose GetDataInternal unconditionally emits a single row holding the insert count:

    chunk.SetCardinality(1);
    chunk.SetValue(0, 0, Value::BIGINT(insert_gstate.insert_count));

So `INSERT INTO d.items VALUES (70,'apple'),(80,'pear'),(90,'plum') RETURNING *` returned one row, (3, <empty>) -- the count coerced into column 0, the rest uninitialized. The write itself was correct; only the result set was wrong. A single-row insert disguises this, since (1,'apple') RETURNING * yields (1, <empty>) and the 1 reads as the id.

This was never a deliberate choice. Until b075207 ("inserts work", 2026-03-11) PlanInsert threw NotImplementedException, so the statement was a clean error; that commit replaced the throw with the real operator and RETURNING started being silently swallowed as collateral. main restored the clean error in 74a9d43, but that never came down to this branch.

Restore it here. The guard is byte-identical to main's, so the next forward merge is a no-op on this hunk. Implementing RETURNING properly (#203) stays an independent decision, no longer forced by a data-correctness bug.

UPDATE/DELETE/MERGE INTO can also carry RETURNING, but the binder rejects them over quack before planning ("Can only update base table"), so INSERT was the only hole. test/sql/returning.test pins the whole surface.

Alternative to https://github.com/duckdb/duckdb-quack/pull/203, also fixes https://github.com/duckdb/duckdb-quack/issues/114 in making the error surface clearly.