### PR TITLE
Override httpfs settings in quack

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -86,6 +86,8 @@ private:
 
 class HttpsQuackClient : public QuackClient {
 public:
+	static constexpr uint64_t HTTP_TIMEOUT_SECONDS = 86400;
+
 	HttpsQuackClient(DatabaseInstance &db, const QuackUri &uri_p);
 	~HttpsQuackClient() override;
 

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -119,6 +119,8 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 			                                      end_time - start_time, response_message->Type(), error);
 			logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 		}
+		http_params->timeout = HTTP_TIMEOUT_SECONDS;
+		http_params->retries = 0;
 	}
 
 	return response_message;

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -40,6 +40,8 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 			http_params = http_util.InitializeParameters(db, request_url);
 		}
 	}
+	http_params->timeout = HTTP_TIMEOUT_SECONDS;
+	http_params->retries = 0;
 
 	HTTPHeaders headers;
 
@@ -119,8 +121,6 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 			                                      end_time - start_time, response_message->Type(), error);
 			logger.WriteLog(QuackLogType::NAME, QuackLogType::LEVEL, msg);
 		}
-		http_params->timeout = HTTP_TIMEOUT_SECONDS;
-		http_params->retries = 0;
 	}
 
 	return response_message;

--- a/test/sql/http_timeout.test_slow
+++ b/test/sql/http_timeout.test_slow
@@ -1,0 +1,39 @@
+# name: test/sql/http_timeout.test_slow
+# description: quack owns its request timeout and does not inherit httpfs's http_timeout/http_retries
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+call quack_serve('quack:localhost', token='asdf');
+
+statement ok con2
+create secret (type quack, token 'asdf')
+
+statement ok con2
+attach 'quack:localhost' as rpc
+
+statement ok quack_db:quack_server_con
+CREATE TABLE exec_log(started TIMESTAMP, slept BOOLEAN);
+
+statement ok
+SET http_timeout=1;
+
+statement ok
+SET http_retries=3;
+
+# The client waits for the query rather than erroring at 1 second.
+statement ok
+FROM quack_query('quack:localhost', 'INSERT INTO exec_log SELECT now(), sleep_ms(2000)', token='asdf')
+
+query I quack_db:quack_server_con
+SELECT count(*) FROM exec_log;
+----
+1
+
+statement ok con1
+call quack_stop('quack:localhost');


### PR DESCRIPTION
Currently quack inherits the httpfs timeout / retry settings which can cause issues both because the default settings are very restrictive, and because the user can override them. This PR makes it so that quack itself sets these instead of relying on the user settings.

CC @carlopi 