### PR TITLE
Add client acknowledgement after query completion

### DIFF
--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -19,6 +19,7 @@ enum class MessageType : uint8_t {
 	SUCCESS_RESPONSE = 10,
 	DISCONNECT_MESSAGE = 11,
 	CANCEL_REQUEST = 12,
+	ACKNOWLEDGEMENT = 13,
 	ERROR_RESPONSE = 100
 };
 
@@ -358,6 +359,20 @@ public:
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<SuccessResponse> Deserialize(Deserializer &deserializer);
+};
+
+class AcknowledgementMessage : public QuackMessage {
+public:
+	static constexpr MessageType TYPE = MessageType::ACKNOWLEDGEMENT;
+
+	explicit AcknowledgementMessage(string connection_id_p) : QuackMessage(TYPE, std::move(connection_id_p)) {};
+
+	void Serialize(Serializer &serializer) const override;
+	static unique_ptr<AcknowledgementMessage> Deserialize(Deserializer &deserializer);
+
+protected:
+	AcknowledgementMessage() : QuackMessage(TYPE) {
+	}
 };
 
 class ErrorResponse : public QuackMessage {

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -179,6 +179,10 @@
         "type": "idx_t"
       }
     ]
+  },
+  {
+    "class": "AcknowledgementMessage",
+    "members": []
   }
 ]
 

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -113,6 +113,9 @@ unique_ptr<QuackMessage> HttpsQuackClient::RequestInternal(optional_ptr<ClientCo
 		case MessageType::APPEND_REQUEST:
 			connection_id = request_message->Cast<AppendRequestMessage>().ConnectionId();
 			break;
+		case MessageType::ACKNOWLEDGEMENT:
+			connection_id = request_message->Cast<AcknowledgementMessage>().ConnectionId();
+			break;
 		default:
 			break;
 		}

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -171,6 +171,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_fetch_batch_chunks", "Maximum number of DataChunks returned per FETCH response",
 	                          LogicalType::UBIGINT, Value::UBIGINT(12));
 
+	config.AddExtensionOption("quack_enable_reconnects",
+	                          "Send an acknowledgement to the server after a query completes", LogicalType::BOOLEAN,
+	                          Value::BOOLEAN(false));
+
 	// Process-wide fallback anchor for whoami().uptime when whoami_started_at isn't set.
 	// Stored as BIGINT epoch-microseconds to stay TZ-invariant regardless of ICU state.
 	config.AddExtensionOption("quack_loaded_at_us", "Epoch microseconds at extension load", LogicalType::BIGINT,

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -54,6 +54,9 @@ MessageType EnumUtil::FromString<MessageType>(const char *value) {
 	if (StringUtil::Equals(value, "CANCEL_REQUEST")) {
 		return MessageType::CANCEL_REQUEST;
 	}
+	if (StringUtil::Equals(value, "ACKNOWLEDGEMENT")) {
+		return MessageType::ACKNOWLEDGEMENT;
+	}
 	if (StringUtil::Equals(value, "ERROR_RESPONSE")) {
 		return MessageType::ERROR_RESPONSE;
 	}
@@ -84,6 +87,8 @@ const char *EnumUtil::ToChars<MessageType>(MessageType value) {
 		return "DISCONNECT_MESSAGE";
 	case MessageType::CANCEL_REQUEST:
 		return "CANCEL_REQUEST";
+	case MessageType::ACKNOWLEDGEMENT:
+		return "ACKNOWLEDGEMENT";
 	case MessageType::ERROR_RESPONSE:
 		return "ERROR_RESPONSE";
 
@@ -132,6 +137,8 @@ unique_ptr<QuackMessage> QuackMessage::Deserialize(Deserializer &deserializer, M
 		return DisconnectMessage::Deserialize(deserializer);
 	case MessageType::CANCEL_REQUEST:
 		return CancelRequestMessage::Deserialize(deserializer);
+	case MessageType::ACKNOWLEDGEMENT:
+		return AcknowledgementMessage::Deserialize(deserializer);
 	case MessageType::ERROR_RESPONSE:
 		return ErrorResponse::Deserialize(deserializer);
 	default:

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -305,9 +305,16 @@ static void SendAcknowledgement(ClientContext &context, QuackScanGlobalState &gl
 	if (global_state.ack_sent.exchange(true)) {
 		return;
 	}
-	auto &client = local_state.client_wrapper->GetClient();
-	client.Request<SuccessResponse>(context,
-	                                make_uniq<AcknowledgementMessage>(bind_data.client_connection->ConnectionId()));
+	try {
+		auto &client = local_state.client_wrapper->GetClient();
+		client.Request<SuccessResponse>(context,
+		                                make_uniq<AcknowledgementMessage>(bind_data.client_connection->ConnectionId()));
+	} catch (const std::exception &e) {
+		// The query is already complete, so we swallow the failure rather than fail the query
+		DUCKDB_LOG_WARNING(
+		    context, StringUtil::Format("Quack: acknowledgement failed and was ignored (query already completed): %s",
+		                                e.what()));
+	}
 }
 
 static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChunk &output) {

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -154,6 +154,7 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<ColumnIndex> column_ids;
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
+	atomic<bool> ack_sent {false};
 	hugeint_t query_uuid;
 
 	vector<ChunkResult> TryGetResults() {
@@ -287,6 +288,27 @@ unique_ptr<LocalTableFunctionState> QuackScanInitLocal(ExecutionContext &context
 	return local_state;
 }
 
+static bool ReconnectsEnabled(ClientContext &context) {
+	Value val;
+	if (!context.TryGetCurrentSetting("quack_enable_reconnects", val)) {
+		return false;
+	}
+	return val.GetValue<bool>();
+}
+
+static void SendAcknowledgement(ClientContext &context, QuackScanGlobalState &global_state,
+                                QuackScanLocalState &local_state, QuackScanBindData &bind_data) {
+	if (!ReconnectsEnabled(context)) {
+		return;
+	}
+	if (global_state.ack_sent.exchange(true)) {
+		return;
+	}
+	auto &client = local_state.client_wrapper->GetClient();
+	client.Request<SuccessResponse>(context,
+	                                make_uniq<AcknowledgementMessage>(bind_data.client_connection->ConnectionId()));
+}
+
 static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
 	auto &bind_data = input.bind_data->CastNoConst<QuackScanBindData>();
 	auto &global_state = input.global_state->Cast<QuackScanGlobalState>();
@@ -330,6 +352,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 				// server is done, we are done
 				global_state.needs_more_fetch = false;
 				bind_data.completed = true;
+				SendAcknowledgement(context, global_state, local_state, bind_data);
 				return;
 			}
 			// set up buffer for scan in next iteration
@@ -341,6 +364,7 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		}
 		// we did not have anything cached and then request to the server did not yield anything - we are done
 		bind_data.completed = true;
+		SendAcknowledgement(context, global_state, local_state, bind_data);
 		break;
 	}
 }

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -155,6 +155,7 @@ struct QuackScanGlobalState : GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 	atomic<bool> needs_more_fetch;
 	atomic<bool> ack_sent {false};
+	atomic<int> active_fetches {0};
 	hugeint_t query_uuid;
 
 	vector<ChunkResult> TryGetResults() {
@@ -344,15 +345,24 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		// if that did not work, we request more results
 		if (local_state.results.empty() && global_state.needs_more_fetch) {
 			auto &client = local_state.client_wrapper->GetClient();
+			bool reconnects_enabled = ReconnectsEnabled(context);
+			if (reconnects_enabled) {
+				global_state.active_fetches++;
+			}
+
 			auto fetch_response = client.Request<FetchResponseMessage>(
 			    context,
 			    make_uniq<FetchRequestMessage>(bind_data.client_connection->ConnectionId(), global_state.query_uuid));
-
+			if (reconnects_enabled) {
+				global_state.active_fetches--;
+			}
 			if (fetch_response->MutableResults().empty()) {
 				// server is done, we are done
 				global_state.needs_more_fetch = false;
 				bind_data.completed = true;
-				SendAcknowledgement(context, global_state, local_state, bind_data);
+				if (global_state.active_fetches == 0) {
+					SendAcknowledgement(context, global_state, local_state, bind_data);
+				}
 				return;
 			}
 			// set up buffer for scan in next iteration
@@ -364,7 +374,9 @@ static void QuackScan(ClientContext &context, TableFunctionInput &input, DataChu
 		}
 		// we did not have anything cached and then request to the server did not yield anything - we are done
 		bind_data.completed = true;
-		SendAcknowledgement(context, global_state, local_state, bind_data);
+		if (global_state.active_fetches == 0) {
+			SendAcknowledgement(context, global_state, local_state, bind_data);
+		}
 		break;
 	}
 }

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -171,6 +171,7 @@ bool ServerSupportsMessage(MessageType type) {
 	case MessageType::APPEND_REQUEST:
 	case MessageType::DISCONNECT_MESSAGE:
 	case MessageType::CANCEL_REQUEST:
+	case MessageType::ACKNOWLEDGEMENT:
 		return true;
 	default:
 		return false;
@@ -450,6 +451,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		connection.duckdb_connection->Interrupt();
 		connection.query_state = QuackQueryState::CANCELLED;
 		connection.duckdb_query_result.reset();
+		return make_uniq<SuccessResponse>();
+	}
+	case MessageType::ACKNOWLEDGEMENT: {
 		return make_uniq<SuccessResponse>();
 	}
 	default: {

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -149,6 +149,14 @@ unique_ptr<SuccessResponse> SuccessResponse::Deserialize(Deserializer &deseriali
 }
 
 
+void AcknowledgementMessage::Serialize(Serializer &serializer) const {
+}
+
+unique_ptr<AcknowledgementMessage> AcknowledgementMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<AcknowledgementMessage>(new AcknowledgementMessage());
+	return result;
+}
+
 void CancelRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<hugeint_t>(1, "query_uuid", query_uuid);
 }

--- a/test/sql/reconnects.test
+++ b/test/sql/reconnects.test
@@ -16,7 +16,6 @@ ATTACH {server} AS remote;
 statement ok
 CALL enable_logging('Quack');
 
-# default: reconnects disabled, query works as before
 query I
 FROM remote.tbl LIMIT 3;
 ----
@@ -24,17 +23,14 @@ FROM remote.tbl LIMIT 3;
 1
 2
 
-# no ACKNOWLEDGEMENT should have been sent with the default (false)
 query I
-SELECT count(*) > 0 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT'
+SELECT count(*) > 0 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE'
 ----
 false
 
-# enable reconnects on the client side
 statement ok
 SET quack_enable_reconnects = true;
 
-# query still returns correct results with the extra ACKNOWLEDGEMENT round-trip
 query I
 FROM remote.tbl LIMIT 3;
 ----
@@ -42,9 +38,8 @@ FROM remote.tbl LIMIT 3;
 1
 2
 
-# an ACKNOWLEDGEMENT should now have been sent
 query I
-SELECT count(*) > 0 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT'
+SELECT count(*) > 0 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE'
 ----
 true
 

--- a/test/sql/reconnects.test
+++ b/test/sql/reconnects.test
@@ -1,0 +1,54 @@
+# name: test/sql/reconnects.test
+# description: test quack_enable_reconnects sends an ACKNOWLEDGEMENT after the last fetch
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+CREATE TABLE tbl AS SELECT range AS i FROM range(100);
+
+statement ok
+CREATE SECRET (TYPE quack, TOKEN 'asdf');
+
+statement ok
+ATTACH {server} AS remote;
+
+statement ok
+CALL enable_logging('Quack');
+
+# default: reconnects disabled, query works as before
+query I
+FROM remote.tbl LIMIT 3;
+----
+0
+1
+2
+
+# no ACKNOWLEDGEMENT should have been sent with the default (false)
+query I
+SELECT count(*) > 0 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT'
+----
+false
+
+# enable reconnects on the client side
+statement ok
+SET quack_enable_reconnects = true;
+
+# query still returns correct results with the extra ACKNOWLEDGEMENT round-trip
+query I
+FROM remote.tbl LIMIT 3;
+----
+0
+1
+2
+
+# an ACKNOWLEDGEMENT should now have been sent
+query I
+SELECT count(*) > 0 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT'
+----
+true
+
+statement ok
+DETACH remote;
+
+include test/template/quack_teardown.test_template

--- a/test/sql/reconnects_ack_best_effort.test
+++ b/test/sql/reconnects_ack_best_effort.test
@@ -1,0 +1,41 @@
+# name: test/sql/reconnects_ack_best_effort.test
+# description: a failed acknowledgement round-trip must NOT fail an already fully-fetched query;
+#             it is swallowed but logged at WARNING (quack_enable_reconnects).
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+CREATE TABLE tbl AS SELECT range AS i FROM range(3);
+
+statement ok
+CREATE SECRET (TYPE quack, TOKEN 'asdf');
+
+statement ok
+SET quack_enable_reconnects = true;
+
+statement ok
+CALL enable_logging(level='warning');
+
+statement ok
+PREPARE p AS SELECT i FROM quack_query({server}, 'FROM tbl', token=>'asdf');
+
+# Take the server down. The ACK POST will now fail with a connection error.
+statement ok quack_db:quack_server_con
+CALL quack_stop({server});
+
+query I
+EXECUTE p;
+----
+0
+1
+2
+
+# The swallowed failure is not silent
+query I
+SELECT count(*) FROM duckdb_logs
+WHERE log_level = 'WARNING' AND contains(message, 'acknowledgement failed and was ignored');
+----
+1
+
+include test/template/quack_teardown.test_template

--- a/test/sql/reconnects_parallel.test
+++ b/test/sql/reconnects_parallel.test
@@ -1,0 +1,70 @@
+# name: test/sql/reconnects_parallel.test
+# description: exactly-once ACK across a parallel, multi-batch scan (exercises active_fetches / "last ACK last")
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+# One chunk per FETCH batch forces ack_sent machinery is engaged.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_fetch_batch_chunks = 1;
+
+statement ok quack_db:quack_server_con
+CREATE TABLE big AS SELECT range AS i FROM range(300000);
+
+statement ok
+CREATE SECRET (TYPE quack, TOKEN 'asdf');
+
+statement ok
+ATTACH {server} AS remote;
+
+statement ok
+SET threads = 4;
+
+statement ok
+CALL enable_logging('Quack');
+
+# --- reconnects disabled: full parallel consumption completes and NO ACK is sent ---
+query I
+SELECT count(*) FROM remote.big;
+----
+300000
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT';
+----
+0
+
+statement ok
+SET quack_enable_reconnects = true;
+
+# --- reconnects enabled: full parallel consumption sends EXACTLY ONE ACK ---
+query I
+SELECT count(*) FROM remote.big;
+----
+300000
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('Quack')
+WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE';
+----
+1
+
+# A second query sends its own single ACK: exactly one per completed query, never zero, never two.
+query I
+SELECT sum(i) FROM remote.big;
+----
+44999850000
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('Quack')
+WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE';
+----
+2
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_fetch_batch_chunks;
+
+statement ok
+DETACH remote;
+
+include test/template/quack_teardown.test_template


### PR DESCRIPTION
This PR introduces an ACKNOWLEDGEMENT message that the client sends to the server once a query's results have been fully fetched, it is necessary for reconnect support. We implement a new `ACKNOWLEDGEMENT` message type, to which the server replies with a `SuccessResponse`. This is activated by a `quack_enable_reconnects` (which defaults to false). When that option is set to true, the scan sends an acknowledgment when the query completes.
  

Supersedes: https://github.com/duckdb/duckdb-quack/pull/181