### PR TITLE
Expire abandoned server-side connections

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <thread>
 
 #include "duckdb/common/optional_ptr.hpp"
@@ -19,6 +22,7 @@ class QueryResult;
 class DatabaseInstance;
 class PreparedStatement;
 class EncryptionState;
+struct QuackConnectionRegistry;
 
 enum class QuackQueryState : uint8_t { IDLE, ACTIVE, FINISHED, CANCELLED };
 
@@ -37,6 +41,36 @@ struct QuackConnection {
 	string sql_query;
 	QuackQueryState query_state = QuackQueryState::IDLE;
 	timestamp_t query_started_at {0};
+
+private:
+	friend class QuackServer;
+	friend class QuackConnectionLease;
+
+	static int64_t MonotonicMillis() noexcept;
+	void BeginRequest() noexcept;
+	void EndRequest() noexcept;
+	bool IsIdleBefore(int64_t cutoff_ms) const noexcept;
+
+	//! Request activity is updated through QuackConnectionLease. Acquisition happens
+	//! while the connection registry is locked, preventing expiry from racing with lookup.
+	std::atomic<idx_t> active_requests {0};
+	std::atomic<int64_t> last_activity_ms;
+};
+
+class QuackConnectionLease {
+public:
+	explicit QuackConnectionLease(shared_ptr<QuackConnection> connection_p);
+	~QuackConnectionLease();
+
+	QuackConnectionLease(const QuackConnectionLease &) = delete;
+	QuackConnectionLease &operator=(const QuackConnectionLease &) = delete;
+
+	optional_ptr<QuackConnection> Get() {
+		return connection.get();
+	}
+
+private:
+	shared_ptr<QuackConnection> connection;
 };
 
 struct QuackConnectionSnapshot {
@@ -52,7 +86,8 @@ public:
 	static constexpr const idx_t QUACK_VERSION = 1;
 
 public:
-	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
+	explicit QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p,
+	                     std::chrono::milliseconds connection_idle_timeout_p);
 	virtual ~QuackServer();
 
 	//! Stop accepting new connections (close the listener socket) without
@@ -66,10 +101,9 @@ public:
 	//! listen-loop teardown joins all workers, which would deadlock.
 	virtual void Close() {};
 
-	shared_ptr<QuackConnection> GetConnection(const string &connection_id);
+	unique_ptr<QuackConnectionLease> AcquireConnection(const string &connection_id);
 	string CreateNewConnection(const string &session_id);
 	bool DisconnectConnection(const string &session_id);
-	// TODO need something to destroy connections
 
 	string GenerateSessionId();
 
@@ -94,12 +128,11 @@ public:
 		return uri;
 	}
 
-	idx_t ActiveConnectionCount() {
-		std::lock_guard<std::mutex> lock(active_connections_mutex);
-		return active_connections.size();
-	}
+	idx_t ActiveConnectionCount();
 
 protected:
+	void StartConnectionReaper();
+
 	unique_ptr<QuackMessage> HandleMessage(MemoryStream &read_stream);
 	unique_ptr<QuackMessage> HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
 	                                               optional_ptr<QuackConnection> connection);
@@ -108,20 +141,24 @@ protected:
 	std::vector<std::thread> listen_threads;
 
 	weak_ptr<DatabaseInstance> db_ptr;
-	mutex active_connections_mutex;
-	unordered_map<string, shared_ptr<QuackConnection>> active_connections;
 
 	mutex session_id_rng_mutex;
 	shared_ptr<EncryptionState> session_id_rng;
 
 private:
+	static void ConnectionReaperLoop(shared_ptr<QuackConnectionRegistry> registry);
+	static void ReapIdleConnections(QuackConnectionRegistry &registry);
+	void StopConnectionReaper();
+
 	QuackUri uri;
 	string token;
+	shared_ptr<QuackConnectionRegistry> connection_registry;
 };
 
 class HttpQuackServer : public QuackServer {
 public:
-	HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p);
+	HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p,
+	                std::chrono::milliseconds connection_idle_timeout_p);
 
 	void StopAccepting() override;
 	void Close() override;

--- a/src/include/quack_storage.hpp
+++ b/src/include/quack_storage.hpp
@@ -17,7 +17,8 @@ class QuackStorageExtensionInfo : public StorageExtensionInfo {
 public:
 	static QuackStorageExtensionInfo &GetState(const DatabaseInstance &instance);
 
-	QuackServer &CreateServer(ClientContext &context, const QuackUri &listen_uri, const string &token);
+	QuackServer &CreateServer(ClientContext &context, const QuackUri &listen_uri, const string &token,
+	                          std::chrono::milliseconds connection_idle_timeout);
 	bool StopServer(ClientContext &context, const QuackUri &listen_uri);
 
 	struct ServerSnapshot {

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -52,8 +52,9 @@ void HttpQuackServer::ListenThread(HttpQuackServer *server, const string &listen
 	}
 }
 
-HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
-    : QuackServer(context_p, uri_p, token_p) {
+HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p,
+                                 std::chrono::milliseconds connection_idle_timeout_p)
+    : QuackServer(context_p, uri_p, token_p, connection_idle_timeout_p) {
 	server = make_uniq<duckdb_httplib::Server>();
 
 	// Each keep-alive connection holds a server thread for its lifetime.
@@ -107,6 +108,7 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 		                  uri_p.Http());
 	}
 
+	StartConnectionReaper();
 	listen_threads.push_back(std::thread(ListenThread, this, uri_p.Host(), uri_p.Port()));
 }
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -16,10 +16,55 @@
 #include "quack_storage.hpp"
 
 namespace duckdb {
-QuackConnection::QuackConnection(string session_id_p) : session_id(std::move(session_id_p)) {
+struct QuackConnectionRegistry {
+	explicit QuackConnectionRegistry(std::chrono::milliseconds idle_timeout_p) : idle_timeout(idle_timeout_p) {
+	}
+
+	mutex connections_mutex;
+	unordered_map<string, shared_ptr<QuackConnection>> connections;
+
+	std::chrono::milliseconds idle_timeout;
+	mutex reaper_mutex;
+	std::condition_variable reaper_cv;
+	bool reaper_stopping = false;
+	std::thread reaper_thread;
+};
+
+int64_t QuackConnection::MonotonicMillis() noexcept {
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+	    .count();
+}
+
+QuackConnection::QuackConnection(string session_id_p)
+    : session_id(std::move(session_id_p)), last_activity_ms(MonotonicMillis()) {
 }
 
 QuackConnection::~QuackConnection() {
+}
+
+void QuackConnection::BeginRequest() noexcept {
+	active_requests.fetch_add(1, std::memory_order_acq_rel);
+	last_activity_ms.store(MonotonicMillis(), std::memory_order_release);
+}
+
+void QuackConnection::EndRequest() noexcept {
+	last_activity_ms.store(MonotonicMillis(), std::memory_order_release);
+	auto previous = active_requests.fetch_sub(1, std::memory_order_acq_rel);
+	D_ASSERT(previous > 0);
+}
+
+bool QuackConnection::IsIdleBefore(int64_t cutoff_ms) const noexcept {
+	return active_requests.load(std::memory_order_acquire) == 0 &&
+	       last_activity_ms.load(std::memory_order_acquire) <= cutoff_ms;
+}
+
+QuackConnectionLease::QuackConnectionLease(shared_ptr<QuackConnection> connection_p)
+    : connection(std::move(connection_p)) {
+	connection->BeginRequest();
+}
+
+QuackConnectionLease::~QuackConnectionLease() {
+	connection->EndRequest();
 }
 
 void QuackServer::ValidateToken(const string &token) {
@@ -28,8 +73,10 @@ void QuackServer::ValidateToken(const string &token) {
 	}
 }
 
-QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p)
-    : db_ptr(context_p.db), uri(uri_p), token(token_p) {
+QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const string &token_p,
+                         std::chrono::milliseconds connection_idle_timeout_p)
+    : db_ptr(context_p.db), uri(uri_p), token(token_p),
+      connection_registry(make_shared_ptr<QuackConnectionRegistry>(connection_idle_timeout_p)) {
 	ValidateToken(token);
 }
 
@@ -47,12 +94,13 @@ string QuackServer::TokenFromSecret(ClientContext &context, const QuackUri &uri)
 }
 
 QuackServer::~QuackServer() {
+	StopConnectionReaper();
 }
 
 vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
 	vector<QuackConnectionSnapshot> result;
-	std::lock_guard<std::mutex> lock(active_connections_mutex);
-	for (auto &conn_kv : active_connections) {
+	std::lock_guard<std::mutex> lock(connection_registry->connections_mutex);
+	for (auto &conn_kv : connection_registry->connections) {
 		auto &conn = conn_kv.second;
 		QuackConnectionSnapshot snapshot;
 		snapshot.session_id = conn->session_id;
@@ -64,19 +112,19 @@ vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
 	return result;
 }
 
-shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_id) {
-	std::lock_guard<std::mutex> lock(active_connections_mutex);
-	auto it = active_connections.find(connection_id);
-	if (it != active_connections.end()) {
-		return it->second;
+unique_ptr<QuackConnectionLease> QuackServer::AcquireConnection(const string &connection_id) {
+	std::lock_guard<std::mutex> lock(connection_registry->connections_mutex);
+	auto it = connection_registry->connections.find(connection_id);
+	if (it != connection_registry->connections.end()) {
+		return make_uniq<QuackConnectionLease>(it->second);
 	}
 	return nullptr;
 }
 
 string QuackServer::CreateNewConnection(const string &session_id) {
-	std::lock_guard<std::mutex> lock(active_connections_mutex);
+	std::lock_guard<std::mutex> lock(connection_registry->connections_mutex);
 
-	D_ASSERT(active_connections.find(session_id) == active_connections.end());
+	D_ASSERT(connection_registry->connections.find(session_id) == connection_registry->connections.end());
 
 	auto db = db_ptr.lock();
 	if (!db) {
@@ -86,20 +134,84 @@ string QuackServer::CreateNewConnection(const string &session_id) {
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
 	// new_connection->duckdb_connection->context->config.streaming_buffer_size = 10 * 1000000; // 10 MB
-	active_connections[session_id] = std::move(new_connection);
+	connection_registry->connections[session_id] = std::move(new_connection);
 	return session_id;
 }
 
 bool QuackServer::DisconnectConnection(const string &session_id) {
-	std::lock_guard<std::mutex> lock(active_connections_mutex);
-
-	auto entry = active_connections.find(session_id);
-	if (entry == active_connections.end()) {
-		// unknown client
-		return false;
+	shared_ptr<QuackConnection> removed_connection;
+	{
+		std::lock_guard<std::mutex> lock(connection_registry->connections_mutex);
+		auto entry = connection_registry->connections.find(session_id);
+		if (entry == connection_registry->connections.end()) {
+			// unknown client
+			return false;
+		}
+		removed_connection = std::move(entry->second);
+		connection_registry->connections.erase(entry);
 	}
-	active_connections.erase(entry);
 	return true;
+}
+
+idx_t QuackServer::ActiveConnectionCount() {
+	std::lock_guard<std::mutex> lock(connection_registry->connections_mutex);
+	return connection_registry->connections.size();
+}
+
+void QuackServer::StartConnectionReaper() {
+	auto registry = connection_registry;
+	if (registry->idle_timeout.count() == 0) {
+		return;
+	}
+	D_ASSERT(!registry->reaper_thread.joinable());
+	auto reaper_thread = std::thread(&QuackServer::ConnectionReaperLoop, registry);
+	registry->reaper_thread = std::move(reaper_thread);
+}
+
+void QuackServer::StopConnectionReaper() {
+	auto registry = connection_registry;
+	{
+		std::lock_guard<std::mutex> lock(registry->reaper_mutex);
+		registry->reaper_stopping = true;
+	}
+	registry->reaper_cv.notify_all();
+	if (!registry->reaper_thread.joinable()) {
+		return;
+	}
+	if (registry->reaper_thread.get_id() == std::this_thread::get_id()) {
+		// Expiring the last connection can release the DatabaseInstance that owns this server.
+		// The worker only retains the shared registry state, so it can safely finish after detaching.
+		registry->reaper_thread.detach();
+	} else {
+		registry->reaper_thread.join();
+	}
+}
+
+void QuackServer::ConnectionReaperLoop(shared_ptr<QuackConnectionRegistry> registry) {
+	auto sweep_interval =
+	    registry->idle_timeout < std::chrono::seconds(1) ? registry->idle_timeout : std::chrono::milliseconds(1000);
+	std::unique_lock<std::mutex> lock(registry->reaper_mutex);
+	while (!registry->reaper_cv.wait_for(lock, sweep_interval, [&registry] { return registry->reaper_stopping; })) {
+		lock.unlock();
+		ReapIdleConnections(*registry);
+		lock.lock();
+	}
+}
+
+void QuackServer::ReapIdleConnections(QuackConnectionRegistry &registry) {
+	vector<shared_ptr<QuackConnection>> expired_connections;
+	auto cutoff = QuackConnection::MonotonicMillis() - registry.idle_timeout.count();
+	{
+		std::lock_guard<std::mutex> lock(registry.connections_mutex);
+		for (auto entry = registry.connections.begin(); entry != registry.connections.end();) {
+			if (!entry->second->IsIdleBefore(cutoff)) {
+				entry++;
+				continue;
+			}
+			expired_connections.push_back(std::move(entry->second));
+			entry = registry.connections.erase(entry);
+		}
+	}
 }
 
 static string GetSettingString(DatabaseInstance &db, const string &setting_name) {
@@ -229,10 +341,10 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 
 	// if the message requires it, obtain a connection
 	// these are basically all messages aside from connect request
-	shared_ptr<QuackConnection> connection;
+	unique_ptr<QuackConnectionLease> connection_lease;
 	if (MessageRequiresConnection(header.type)) {
-		connection = GetConnection(header.connection_id);
-		if (!connection) {
+		connection_lease = AcquireConnection(header.connection_id);
+		if (!connection_lease) {
 			return make_uniq<ErrorResponse>("Invalid connection id");
 		}
 	}
@@ -241,7 +353,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	auto received_message = QuackMessage::DeserializeMessage(deserializer, header);
 
 	// process the message
-	auto response = HandleMessageInternal(*db, *received_message, connection);
+	auto response = HandleMessageInternal(*db, *received_message, connection_lease ? connection_lease->Get() : nullptr);
 
 	if (should_log) {
 		int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/main/database.hpp"
+#include "duckdb/common/types/interval.hpp"
 
 #include "quack_startstop.hpp"
 #include "quack_storage.hpp"
@@ -12,6 +13,7 @@ struct QuackStartStopFunctionData : public TableFunctionData {
 	bool finished = false;
 	QuackUri listen_uri;
 	string token;
+	std::chrono::milliseconds connection_idle_timeout {0};
 };
 
 static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunctionBindInput &input,
@@ -68,6 +70,18 @@ static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunc
 	// thread is spawned, instead of leaving a half-built server behind.
 	QuackServer::ValidateToken(bind_data->token);
 
+	if (input.named_parameters.find("connection_idle_timeout") != input.named_parameters.end()) {
+		auto timeout = input.named_parameters["connection_idle_timeout"];
+		if (timeout.IsNull()) {
+			throw InvalidInputException("connection_idle_timeout cannot be NULL");
+		}
+		auto timeout_ms = Interval::GetMilli(timeout.GetValue<interval_t>());
+		if (timeout_ms <= 0) {
+			throw InvalidInputException("connection_idle_timeout must be at least 1 millisecond");
+		}
+		bind_data->connection_idle_timeout = std::chrono::milliseconds(timeout_ms);
+	}
+
 	return std::move(bind_data);
 }
 
@@ -77,7 +91,8 @@ static void QuackServe(ClientContext &context, TableFunctionInput &data_p, DataC
 		return;
 	}
 
-	QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
+	QuackStorageExtensionInfo::GetState(*context.db)
+	    .CreateServer(context, bind_data.listen_uri, bind_data.token, bind_data.connection_idle_timeout);
 	output.SetValue(0, 0, bind_data.listen_uri.Uri());
 	output.SetValue(1, 0, bind_data.listen_uri.Http());
 	output.SetValue(2, 0, bind_data.token);
@@ -92,6 +107,7 @@ TableFunctionSet QuackServeFunction::GetFunction() {
 	fun.named_parameters["disable_ssl"] = LogicalType::BOOLEAN;
 	fun.named_parameters["allow_other_hostname"] = LogicalType::BOOLEAN;
 	fun.named_parameters["token"] = LogicalType::VARCHAR;
+	fun.named_parameters["connection_idle_timeout"] = LogicalType::INTERVAL;
 	set.AddFunction(fun);
 	fun.arguments.clear();
 	set.AddFunction(fun);

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -19,7 +19,8 @@ QuackStorageExtensionInfo &QuackStorageExtensionInfo::GetState(const DatabaseIns
 }
 
 QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, const QuackUri &listen_uri,
-                                                     const string &token) {
+                                                     const string &token,
+                                                     std::chrono::milliseconds connection_idle_timeout) {
 	auto key = listen_uri.CanonicalUri();
 	std::lock_guard<std::mutex> lock(servers_mutex);
 	auto it = servers.find(key);
@@ -27,7 +28,7 @@ QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, con
 		throw InvalidInputException("Server already exists for %s", key);
 	}
 	unique_ptr<QuackServer> server;
-	server = make_uniq<HttpQuackServer>(context, listen_uri, token);
+	server = make_uniq<HttpQuackServer>(context, listen_uri, token, connection_idle_timeout);
 	servers.emplace(key, std::move(server));
 	return *servers[key];
 }

--- a/test/sql/connection_idle_timeout.test
+++ b/test/sql/connection_idle_timeout.test
@@ -1,0 +1,120 @@
+# name: test/sql/connection_idle_timeout.test
+# description: expire abandoned server-side connections without racing active requests
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+statement ok con1
+CREATE TABLE idle_timeout_test AS SELECT 42 AS i;
+
+# The timeout is opt-in and must be positive when supplied.
+statement error con1
+CALL quack_serve('quack:localhost', token='asdf', connection_idle_timeout=INTERVAL 0 MILLISECOND);
+----
+connection_idle_timeout must be at least 1 millisecond
+
+# Without the option, existing connections do not expire.
+statement ok con1
+CALL quack_serve('quack:localhost', token='asdf');
+
+statement ok con2
+ATTACH 'quack:localhost' AS no_timeout (token 'asdf');
+
+sleep 100 millisecond
+
+query I con1
+SELECT count(*) FROM quack_active_connections();
+----
+1
+
+statement ok con2
+DETACH no_timeout;
+
+statement ok con1
+CALL quack_stop('quack:localhost');
+
+# A request that runs longer than the timeout retains its connection lease.
+statement ok con1
+CALL quack_serve('quack:localhost', token='asdf', connection_idle_timeout=INTERVAL 50 MILLISECOND);
+
+statement ok con2
+ATTACH 'quack:localhost' AS rpc (token 'asdf');
+
+query I con2
+SELECT i FROM quack_query_by_name('rpc', 'SELECT sleep_ms(150), 42 AS i');
+----
+42
+
+query I con1
+SELECT count(*) FROM quack_active_connections();
+----
+1
+
+query I con2
+SELECT * FROM rpc.main.idle_timeout_test;
+----
+42
+
+# Graceful disconnect remains immediate.
+statement ok con2
+DETACH rpc;
+
+query I con1
+SELECT count(*) FROM quack_active_connections();
+----
+0
+
+statement ok con1
+CALL quack_stop('quack:localhost');
+
+# A client that stops sending requests without disconnecting is expired.
+statement ok con1
+CALL quack_serve('quack:localhost', token='asdf', connection_idle_timeout=INTERVAL 50 MILLISECOND);
+
+statement ok con3
+ATTACH 'quack:localhost' AS abandoned (token 'asdf');
+
+statement ok con3
+BEGIN;
+
+statement ok con3
+CREATE TABLE abandoned.main.expired_transaction(i INTEGER);
+
+statement ok con3
+INSERT INTO abandoned.main.expired_transaction VALUES (42);
+
+query I con1
+SELECT count(*) FROM quack_active_connections();
+----
+1
+
+sleep 200 millisecond
+
+query I con1
+SELECT count(*) FROM quack_active_connections();
+----
+0
+
+statement error con3
+SELECT * FROM abandoned.main.idle_timeout_test;
+----
+Invalid connection id
+
+# Destroying the expired DuckDB connection rolls back its open transaction.
+query I con1
+SELECT n
+FROM quack_query(
+    'quack:localhost',
+    'SELECT count(*) AS n FROM duckdb_tables() WHERE table_name = ''expired_transaction''',
+    token='asdf'
+);
+----
+0
+
+# Stopping a server with an active expiry worker must not hang.
+statement ok con1
+CALL quack_stop('quack:localhost');


### PR DESCRIPTION
Fixes #225

## Summary

- add an opt-in `connection_idle_timeout` interval to `quack_serve()`
- acquire an RAII request lease while the connection registry is locked
- expire only connections with no in-flight requests
- release expired DuckDB connections after unlocking, rolling back any open transaction
- keep the default connection lifetime unchanged

The registry and reaper state are shared independently of `QuackServer`. This lets the worker finish safely if releasing the final connection also releases the database instance that owns the server.

## Usage

```sql
CALL quack_serve(
    'quack:localhost',
    token = '...',
    connection_idle_timeout = INTERVAL '5 minutes'
);
```

When the option is omitted, no expiry worker is started and existing behavior is unchanged. The timeout is measured from the end of the most recent request; an in-flight request is never expired.

## Validation

- `make test` — 647 assertions across 34 test cases
- new lifecycle test repeated 10 times
- clang-format 11.0.1 check
