### PR TITLE
Feat/fetch read ahead v2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,9 @@ add_subdirectory(storage)
 add_library(
   quack_library OBJECT
   quack_active_connections.cpp
+  quack_rebalancer_core.cpp
+  quack_rebalancer_sink.cpp
+  quack_fetch_collector.cpp
   quack_clear_cache.cpp
   quack_client.cpp
   quack_data_stream.cpp

--- a/src/include/quack_claim_buffer.hpp
+++ b/src/include/quack_claim_buffer.hpp
@@ -1,0 +1,294 @@
+#pragma once
+
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/multi_file/multi_file_read_ahead.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <map>
+#include <set>
+
+namespace duckdb {
+
+enum class QuackClaimPopStatus : uint8_t {
+	BATCH,
+	EMPTY,
+	FINISHED,
+	ERRORED,
+};
+
+//! Dense-index membership tracked as a contiguous prefix + sparse overflow; the sparse set stays
+//! bounded by the producer's in-flight window. Caller provides the locking.
+struct QuackDenseIndexSet {
+	bool Contains(idx_t index) const {
+		return index <= contiguous || sparse.count(index) > 0;
+	}
+	void Insert(idx_t index) {
+		sparse.insert(index);
+		while (sparse.count(contiguous + 1) > 0) {
+			sparse.erase(contiguous + 1);
+			++contiguous;
+		}
+	}
+	//! Highest index with all of 1..index present.
+	idx_t ContiguousMax() const {
+		return contiguous;
+	}
+
+private:
+	idx_t contiguous = 0;
+	std::set<idx_t> sparse;
+};
+
+//! Claim-based delivery for dense batch streams (indices from 1): each consumer claims the next index
+//! and waits for exactly that batch; unordered consumers pop any. PAYLOAD is one batch's storage.
+template <class PAYLOAD>
+class QuackClaimBuffer {
+public:
+	using PopStatus = QuackClaimPopStatus;
+
+	//! Claim the next batch index to consume; each index gets exactly one claimant.
+	idx_t ClaimBatch() {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return next_claim++;
+	}
+
+	//! Bound the buffered bytes; PushBatch blocks while full (producer backpressure). 0 = unbounded.
+	void SetCapacity(idx_t bytes) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		capacity = bytes;
+	}
+
+	//! Publish a batch under its dense index. With a capacity set, `bytes` is the batch's weight and
+	//! the call blocks until it fits (at least one batch is always admitted — no self-deadlock).
+	void PushBatch(idx_t batch_index, PAYLOAD payload, idx_t bytes = 0) {
+		shared_ptr<ReadAheadJobCompletion> waiter;
+		{
+			annotated_unique_lock<annotated_mutex> guard(lock);
+			if (Seen(batch_index)) {
+				// duplicate delivery (transport-level retry) — the first copy won
+				return;
+			}
+			// producer backpressure: wait until the batch fits. An empty buffer always admits one, and
+			// the head of the stream is always admitted so later batches can't starve the next pop.
+			while (capacity > 0 && buffered_bytes > 0 && buffered_bytes + bytes > capacity && !finished && !errored &&
+			       !HeadOfStream(batch_index)) {
+				cv.wait(guard);
+			}
+			if (finished || errored) {
+				return;
+			}
+			if (Seen(batch_index)) {
+				// a concurrent duplicate got in while this push waited on capacity
+				return;
+			}
+			RecordSeen(batch_index);
+			batches[batch_index] = Entry {std::move(payload), bytes};
+			buffered_bytes += bytes;
+			pushed_count++;
+			auto entry = waiters.find(batch_index);
+			if (entry != waiters.end()) {
+				waiter = std::move(entry->second);
+				waiters.erase(entry);
+			}
+		}
+		cv.notify_all();
+		if (waiter) {
+			// wakes exactly the scan task parked on this batch index
+			waiter->FinishIOTask();
+		}
+	}
+
+	//! Register a per-claim wake event; nullptr when the claim is already poppable (caller retries).
+	shared_ptr<ReadAheadJobCompletion> RegisterWaiter(idx_t claim) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		// Checked under the same lock PushBatch inserts with, so a concurrent publish either
+		// makes us retry the pop here or finds the registered waiter — no lost wakeup.
+		if (batches.find(claim) != batches.end() || finished || errored) {
+			return nullptr;
+		}
+		auto entry = waiters.find(claim);
+		if (entry != waiters.end()) {
+			return entry->second;
+		}
+		auto completion = make_shared_ptr<ReadAheadJobCompletion>(1);
+		waiters.emplace(claim, completion);
+		return completion;
+	}
+
+	//! Pop the claimed batch if present. FINISHED means the stream ended and the claim can never arrive.
+	PopStatus TryPopClaimed(idx_t claim, PAYLOAD &payload_out) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (errored) {
+			return PopStatus::ERRORED;
+		}
+		auto entry = batches.find(claim);
+		if (entry != batches.end()) {
+			payload_out = std::move(entry->second.payload);
+			buffered_bytes -= entry->second.bytes;
+			batches.erase(entry);
+			cv.notify_all(); // pushers may be waiting on capacity
+			return PopStatus::BATCH;
+		}
+		// Indices are dense and Finish() runs after the last push, so an absent claim can never arrive.
+		if (finished) {
+			return PopStatus::FINISHED;
+		}
+		return PopStatus::EMPTY;
+	}
+
+	//! Pop the lowest available batch regardless of claims (unordered consumption).
+	PopStatus TryPopAny(idx_t &batch_index_out, PAYLOAD &payload_out) {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		if (errored) {
+			return PopStatus::ERRORED;
+		}
+		if (!batches.empty()) {
+			auto entry = batches.begin();
+			batch_index_out = entry->first;
+			payload_out = std::move(entry->second.payload);
+			buffered_bytes -= entry->second.bytes;
+			batches.erase(entry);
+			cv.notify_all(); // pushers may be waiting on capacity
+			return PopStatus::BATCH;
+		}
+		if (finished) {
+			return PopStatus::FINISHED;
+		}
+		return PopStatus::EMPTY;
+	}
+
+	//! Block until the claimed batch arrives, the stream ends, or a short timeout elapses.
+	void WaitForBatch(idx_t claim) {
+		annotated_unique_lock<annotated_mutex> guard(lock);
+		if (batches.find(claim) != batches.end() || finished || errored) {
+			return;
+		}
+		// Bounded wait so the consumer can re-check cancellation even if the batch never arrives.
+		cv.wait_for(guard, std::chrono::milliseconds(200));
+	}
+
+	//! Block until any batch is available, the stream ends, or a short timeout elapses.
+	void WaitForAny() {
+		annotated_unique_lock<annotated_mutex> guard(lock);
+		if (!batches.empty() || finished || errored) {
+			return;
+		}
+		// Bounded wait so the consumer can re-check cancellation even if no batch ever arrives.
+		cv.wait_for(guard, std::chrono::milliseconds(200));
+	}
+
+	//! End the stream. When expected_total is set, error out unless exactly that many batches were
+	//! pushed — validates that a dense stream arrived completely.
+	void Finish(optional_idx expected_total = optional_idx()) {
+		std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
+		{
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			if (expected_total.IsValid() && !errored && pushed_count != expected_total.GetIndex()) {
+				errored = true;
+				error = ErrorData(ExceptionType::IO,
+				                  StringUtil::Format("Quack stream ended with %llu of %llu batches received",
+				                                     pushed_count, expected_total.GetIndex()));
+			}
+			finished = true;
+			drained = std::move(waiters);
+			waiters.clear();
+		}
+		cv.notify_all();
+		// wake every parked claimant so it observes FINISHED (or the count-mismatch error)
+		for (auto &entry : drained) {
+			entry.second->FinishIOTask();
+		}
+	}
+
+	void SetError(ErrorData error_p) {
+		std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
+		{
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			if (!errored) {
+				errored = true;
+				error = std::move(error_p);
+			}
+			finished = true;
+			drained = std::move(waiters);
+			waiters.clear();
+		}
+		cv.notify_all();
+		// wake every parked claimant so it observes ERRORED
+		for (auto &entry : drained) {
+			entry.second->FinishIOTask();
+		}
+	}
+
+	bool HasError() {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return errored;
+	}
+
+	//! The producer closed the stream (Finish or SetError ran).
+	bool Finished() {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return finished;
+	}
+
+	ErrorData GetError() {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return error;
+	}
+
+	//! The stream ended and every published batch has been consumed.
+	bool Exhausted() {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return finished && batches.empty();
+	}
+
+private:
+	//! No pending batch precedes this one, so the consumer's next pop is waiting on exactly this index;
+	//! admitting it over capacity is the only way forward, and overshoots the cap by at most one batch.
+	bool HeadOfStream(idx_t batch_index) const DUCKDB_REQUIRES(lock) {
+		return batches.empty() || batches.begin()->first > batch_index;
+	}
+
+	//! True when this dense index was already pushed once (whether or not it was popped since).
+	bool Seen(idx_t batch_index) const DUCKDB_REQUIRES(lock) {
+		return seen.Contains(batch_index);
+	}
+
+	void RecordSeen(idx_t batch_index) DUCKDB_REQUIRES(lock) {
+		seen.Insert(batch_index);
+	}
+
+private:
+	struct Entry {
+		PAYLOAD payload;
+		idx_t bytes;
+	};
+
+	annotated_mutex lock;
+	std::condition_variable cv;
+	idx_t next_claim DUCKDB_GUARDED_BY(lock) = 1;
+	//! batch_index -> published batch, awaiting a consumer.
+	std::map<idx_t, Entry> batches DUCKDB_GUARDED_BY(lock);
+	idx_t buffered_bytes DUCKDB_GUARDED_BY(lock) = 0;
+	idx_t capacity DUCKDB_GUARDED_BY(lock) = 0;
+	//! batch_index -> wake event for the parked claimant; publishing that index fires exactly this one.
+	std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> waiters DUCKDB_GUARDED_BY(lock);
+	//! Batches ever pushed, checked against Finish(expected_total); dedupe keeps retries from inflating it.
+	idx_t pushed_count DUCKDB_GUARDED_BY(lock) = 0;
+	//! Push dedupe.
+	QuackDenseIndexSet seen DUCKDB_GUARDED_BY(lock);
+	bool finished DUCKDB_GUARDED_BY(lock) = false;
+	bool errored DUCKDB_GUARDED_BY(lock) = false;
+	ErrorData error DUCKDB_GUARDED_BY(lock);
+};
+
+//! One batch stored as owned chunks — the client fetch buffer and the server insert stream.
+using QuackChunkBatch = vector<unique_ptr<DataChunk>>;
+using QuackChunkClaimBuffer = QuackClaimBuffer<QuackChunkBatch>;
+//! The client fetch path reads more naturally with its historical name.
+using QuackFetchBuffer = QuackChunkClaimBuffer;
+
+} // namespace duckdb

--- a/src/include/quack_claim_buffer.hpp
+++ b/src/include/quack_claim_buffer.hpp
@@ -23,13 +23,12 @@ enum class QuackClaimPopStatus : uint8_t {
 };
 
 enum class QuackPushStatus : uint8_t {
-	PUSHED,      //! inserted and (if claimed) its waiter woken
-	DROPPED,     //! duplicate delivery or closed stream — the batch is consumed, nothing to retry
-	NO_CAPACITY, //! not inserted; retry the same batch once capacity frees (wake via the interrupt)
+	PUSHED,      //! inserted, and the waiter for this index is awake
+	DROPPED,     //! a duplicate, or the stream is closed: the batch is consumed, do not retry
+	NO_CAPACITY, //! not inserted: retry the same batch after capacity frees
 };
 
-//! Dense-index membership tracked as a contiguous prefix + sparse overflow; the sparse set stays
-//! bounded by the producer's in-flight window. Caller provides the locking.
+//! Dense-index membership: a contiguous prefix plus a sparse overflow set. The caller locks.
 struct QuackDenseIndexSet {
 	bool Contains(idx_t index) const {
 		return index <= contiguous || sparse.count(index) > 0;
@@ -41,7 +40,7 @@ struct QuackDenseIndexSet {
 			++contiguous;
 		}
 	}
-	//! Highest index with all of 1..index present.
+	//! The highest index for which all of 1..index are present.
 	idx_t ContiguousMax() const {
 		return contiguous;
 	}
@@ -51,37 +50,35 @@ private:
 	std::set<idx_t> sparse;
 };
 
-//! Claim-based delivery for dense batch streams (indices from 1): each consumer claims the next index
-//! and waits for exactly that batch; unordered consumers pop any. PAYLOAD is one batch's storage.
+//! Delivery for dense batch streams, indexed from 1. Each consumer claims the next index and waits
+//! for that batch only. Unordered consumers pop any batch. PAYLOAD is the storage of one batch.
 template <class PAYLOAD>
 class QuackClaimBuffer {
 public:
 	using PopStatus = QuackClaimPopStatus;
 
-	//! Claim the next batch index to consume; each index gets exactly one claimant.
 	idx_t ClaimBatch() {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		return next_claim++;
 	}
 
-	//! Bound the buffered bytes; PushBatch blocks while full (producer backpressure). 0 = unbounded.
+	//! Limit the buffered bytes. A full buffer holds the producer back. 0 = no limit.
 	void SetCapacity(idx_t bytes) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		capacity = bytes;
 	}
 
-	//! Publish a batch under its dense index. With a capacity set, `bytes` is the batch's weight and
-	//! the call blocks until it fits (at least one batch is always admitted — no self-deadlock).
+	//! Publish a batch under its dense index. The call waits until the batch fits. An empty buffer
+	//! and the head of the stream always admit one, so the producer cannot deadlock.
 	void PushBatch(idx_t batch_index, PAYLOAD payload, idx_t bytes = 0) {
 		shared_ptr<ReadAheadJobCompletion> waiter;
 		{
 			annotated_unique_lock<annotated_mutex> guard(lock);
 			if (Seen(batch_index)) {
-				// duplicate delivery (transport-level retry) — the first copy won
+				// a transport retry delivered this batch again
 				return;
 			}
-			// producer backpressure: wait until the batch fits. An empty buffer always admits one, and
-			// the head of the stream is always admitted so later batches can't starve the next pop.
+			// The head of the stream always gets in. Later batches cannot starve the next pop.
 			while (capacity > 0 && buffered_bytes > 0 && buffered_bytes + bytes > capacity && !finished && !errored &&
 			       !HeadOfStream(batch_index)) {
 				cv.wait(guard);
@@ -90,7 +87,7 @@ public:
 				return;
 			}
 			if (Seen(batch_index)) {
-				// a concurrent duplicate got in while this push waited on capacity
+				// a duplicate got in while this push waited
 				return;
 			}
 			RecordSeen(batch_index);
@@ -105,14 +102,12 @@ public:
 		}
 		cv.notify_all();
 		if (waiter) {
-			// wakes exactly the scan task parked on this batch index
 			waiter->FinishIOTask();
 		}
 	}
 
-	//! Non-blocking PushBatch for yieldable producers. NO_CAPACITY leaves `payload` untouched so the
-	//! caller can park and retry the same batch; with `interrupt` set, the next capacity-freeing pop
-	//! (or stream close) fires it. Registration and pops share one lock — no lost wakeup.
+	//! PushBatch that does not wait. NO_CAPACITY does not touch `payload`, so the caller can park and
+	//! retry the same batch. With `interrupt` set, the next pop or the stream close fires it.
 	QuackPushStatus TryPushBatch(idx_t batch_index, PAYLOAD &payload, idx_t bytes,
 	                             optional_ptr<const InterruptState> interrupt) {
 		shared_ptr<ReadAheadJobCompletion> waiter;
@@ -122,7 +117,7 @@ public:
 				return QuackPushStatus::DROPPED;
 			}
 			if (Seen(batch_index)) {
-				// duplicate delivery (transport-level retry) — the first copy won
+				// a transport retry delivered this batch again
 				return QuackPushStatus::DROPPED;
 			}
 			if (capacity > 0 && buffered_bytes > 0 && buffered_bytes + bytes > capacity && !HeadOfStream(batch_index)) {
@@ -143,17 +138,16 @@ public:
 		}
 		cv.notify_all();
 		if (waiter) {
-			// wakes exactly the scan task parked on this batch index
 			waiter->FinishIOTask();
 		}
 		return QuackPushStatus::PUSHED;
 	}
 
-	//! Register a per-claim wake event; nullptr when the claim is already poppable (caller retries).
+	//! Returns nullptr if the claim is poppable now: the caller retries the pop.
 	shared_ptr<ReadAheadJobCompletion> RegisterWaiter(idx_t claim) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
-		// Checked under the same lock PushBatch inserts with, so a concurrent publish either
-		// makes us retry the pop here or finds the registered waiter — no lost wakeup.
+		// One lock guards this check and the insert. A publish either makes the caller retry the pop,
+		// or it finds this waiter. No wakeup is lost.
 		if (batches.find(claim) != batches.end() || finished || errored) {
 			return nullptr;
 		}
@@ -166,7 +160,7 @@ public:
 		return completion;
 	}
 
-	//! Pop the claimed batch if present. FINISHED means the stream ended and the claim can never arrive.
+	//! FINISHED means the stream ended and the claim cannot arrive.
 	PopStatus TryPopClaimed(idx_t claim, PAYLOAD &payload_out) {
 		vector<InterruptState> capacity_wakes;
 		PopStatus status;
@@ -183,7 +177,7 @@ public:
 				capacity_wakes = TakeCapacityWaiters();
 				status = PopStatus::BATCH;
 			} else if (finished) {
-				// Indices are dense and Finish() runs after the last push, so an absent claim can never arrive.
+				// Indices are dense and Finish() runs after the last push.
 				return PopStatus::FINISHED;
 			} else {
 				return PopStatus::EMPTY;
@@ -194,7 +188,6 @@ public:
 		return status;
 	}
 
-	//! Pop the lowest available batch regardless of claims (unordered consumption).
 	PopStatus TryPopAny(idx_t &batch_index_out, PAYLOAD &payload_out) {
 		vector<InterruptState> capacity_wakes;
 		{
@@ -217,28 +210,25 @@ public:
 		return PopStatus::BATCH;
 	}
 
-	//! Block until the claimed batch arrives, the stream ends, or a short timeout elapses.
 	void WaitForBatch(idx_t claim) {
 		annotated_unique_lock<annotated_mutex> guard(lock);
 		if (batches.find(claim) != batches.end() || finished || errored) {
 			return;
 		}
-		// Bounded wait so the consumer can re-check cancellation even if the batch never arrives.
+		// The wait has a limit, so the consumer can look for a cancel again.
 		cv.wait_for(guard, std::chrono::milliseconds(200));
 	}
 
-	//! Block until any batch is available, the stream ends, or a short timeout elapses.
 	void WaitForAny() {
 		annotated_unique_lock<annotated_mutex> guard(lock);
 		if (!batches.empty() || finished || errored) {
 			return;
 		}
-		// Bounded wait so the consumer can re-check cancellation even if no batch ever arrives.
+		// The wait has a limit, so the consumer can look for a cancel again.
 		cv.wait_for(guard, std::chrono::milliseconds(200));
 	}
 
-	//! End the stream. When expected_total is set, error out unless exactly that many batches were
-	//! pushed — validates that a dense stream arrived completely.
+	//! End the stream. With expected_total set, a different push count becomes an error.
 	void Finish(optional_idx expected_total = optional_idx()) {
 		std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
 		vector<InterruptState> capacity_wakes;
@@ -256,11 +246,9 @@ public:
 			capacity_wakes = TakeCapacityWaiters();
 		}
 		cv.notify_all();
-		// wake every parked claimant so it observes FINISHED (or the count-mismatch error)
 		for (auto &entry : drained) {
 			entry.second->FinishIOTask();
 		}
-		// capacity-parked producers retry, observe the closed stream, and drop their batch
 		WakeCapacity(capacity_wakes);
 	}
 
@@ -279,11 +267,9 @@ public:
 			capacity_wakes = TakeCapacityWaiters();
 		}
 		cv.notify_all();
-		// wake every parked claimant so it observes ERRORED
 		for (auto &entry : drained) {
 			entry.second->FinishIOTask();
 		}
-		// capacity-parked producers retry, observe the closed stream, and drop their batch
 		WakeCapacity(capacity_wakes);
 	}
 
@@ -292,7 +278,7 @@ public:
 		return errored;
 	}
 
-	//! The producer closed the stream (Finish or SetError ran).
+	//! Finish() or SetError() ran.
 	bool Finished() {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		return finished;
@@ -303,20 +289,20 @@ public:
 		return error;
 	}
 
-	//! The stream ended and every published batch has been consumed.
+	//! The stream ended and every batch left the buffer.
 	bool Exhausted() {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		return finished && batches.empty();
 	}
 
 private:
-	//! No pending batch precedes this one, so the consumer's next pop is waiting on exactly this index;
-	//! admitting it over capacity is the only way forward, and overshoots the cap by at most one batch.
+	//! No pending batch is before this one, so the next pop waits for this index. Admit it over the
+	//! limit: that is the only way to make progress.
 	bool HeadOfStream(idx_t batch_index) const DUCKDB_REQUIRES(lock) {
 		return batches.empty() || batches.begin()->first > batch_index;
 	}
 
-	//! True when this dense index was already pushed once (whether or not it was popped since).
+	//! This index was pushed before, even if a pop removed it since.
 	bool Seen(idx_t batch_index) const DUCKDB_REQUIRES(lock) {
 		return seen.Contains(batch_index);
 	}
@@ -331,7 +317,7 @@ private:
 		return taken;
 	}
 
-	//! Fired outside the lock; a spurious wake just makes the producer retry and maybe re-park.
+	//! Fired outside the lock. An unnecessary wake only makes the producer retry.
 	static void WakeCapacity(vector<InterruptState> &wakes) {
 		for (auto &state : wakes) {
 			state.Callback();
@@ -347,27 +333,24 @@ private:
 	annotated_mutex lock;
 	std::condition_variable cv;
 	idx_t next_claim DUCKDB_GUARDED_BY(lock) = 1;
-	//! batch_index -> published batch, awaiting a consumer.
 	std::map<idx_t, Entry> batches DUCKDB_GUARDED_BY(lock);
 	idx_t buffered_bytes DUCKDB_GUARDED_BY(lock) = 0;
 	idx_t capacity DUCKDB_GUARDED_BY(lock) = 0;
-	//! batch_index -> wake event for the parked claimant; publishing that index fires exactly this one.
+	//! A publish of one index fires the waiter for that index only.
 	std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> waiters DUCKDB_GUARDED_BY(lock);
-	//! Tasks parked by TryPushBatch on capacity; all fired on any capacity-freeing pop or stream close.
+	//! Parked by TryPushBatch. A pop that frees bytes, or a stream close, fires all of them.
 	vector<InterruptState> capacity_waiters DUCKDB_GUARDED_BY(lock);
-	//! Batches ever pushed, checked against Finish(expected_total); dedupe keeps retries from inflating it.
+	//! Checked against Finish(expected_total). Dedupe keeps retries out of this count.
 	idx_t pushed_count DUCKDB_GUARDED_BY(lock) = 0;
-	//! Push dedupe.
 	QuackDenseIndexSet seen DUCKDB_GUARDED_BY(lock);
 	bool finished DUCKDB_GUARDED_BY(lock) = false;
 	bool errored DUCKDB_GUARDED_BY(lock) = false;
 	ErrorData error DUCKDB_GUARDED_BY(lock);
 };
 
-//! One batch stored as owned chunks — the client fetch buffer and the server insert stream.
+//! One batch as owned chunks: the client fetch buffer and the server insert stream.
 using QuackChunkBatch = vector<unique_ptr<DataChunk>>;
 using QuackChunkClaimBuffer = QuackClaimBuffer<QuackChunkBatch>;
-//! The client fetch path reads more naturally with its historical name.
 using QuackFetchBuffer = QuackChunkClaimBuffer;
 
 } // namespace duckdb

--- a/src/include/quack_claim_buffer.hpp
+++ b/src/include/quack_claim_buffer.hpp
@@ -4,7 +4,9 @@
 #include "duckdb/common/multi_file/multi_file_read_ahead.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/parallel/interrupt.hpp"
 
 #include <chrono>
 #include <condition_variable>
@@ -18,6 +20,12 @@ enum class QuackClaimPopStatus : uint8_t {
 	EMPTY,
 	FINISHED,
 	ERRORED,
+};
+
+enum class QuackPushStatus : uint8_t {
+	PUSHED,      //! inserted and (if claimed) its waiter woken
+	DROPPED,     //! duplicate delivery or closed stream — the batch is consumed, nothing to retry
+	NO_CAPACITY, //! not inserted; retry the same batch once capacity frees (wake via the interrupt)
 };
 
 //! Dense-index membership tracked as a contiguous prefix + sparse overflow; the sparse set stays
@@ -102,6 +110,45 @@ public:
 		}
 	}
 
+	//! Non-blocking PushBatch for yieldable producers. NO_CAPACITY leaves `payload` untouched so the
+	//! caller can park and retry the same batch; with `interrupt` set, the next capacity-freeing pop
+	//! (or stream close) fires it. Registration and pops share one lock — no lost wakeup.
+	QuackPushStatus TryPushBatch(idx_t batch_index, PAYLOAD &payload, idx_t bytes,
+	                             optional_ptr<const InterruptState> interrupt) {
+		shared_ptr<ReadAheadJobCompletion> waiter;
+		{
+			annotated_unique_lock<annotated_mutex> guard(lock);
+			if (finished || errored) {
+				return QuackPushStatus::DROPPED;
+			}
+			if (Seen(batch_index)) {
+				// duplicate delivery (transport-level retry) — the first copy won
+				return QuackPushStatus::DROPPED;
+			}
+			if (capacity > 0 && buffered_bytes > 0 && buffered_bytes + bytes > capacity && !HeadOfStream(batch_index)) {
+				if (interrupt) {
+					capacity_waiters.push_back(*interrupt);
+				}
+				return QuackPushStatus::NO_CAPACITY;
+			}
+			RecordSeen(batch_index);
+			batches[batch_index] = Entry {std::move(payload), bytes};
+			buffered_bytes += bytes;
+			pushed_count++;
+			auto entry = waiters.find(batch_index);
+			if (entry != waiters.end()) {
+				waiter = std::move(entry->second);
+				waiters.erase(entry);
+			}
+		}
+		cv.notify_all();
+		if (waiter) {
+			// wakes exactly the scan task parked on this batch index
+			waiter->FinishIOTask();
+		}
+		return QuackPushStatus::PUSHED;
+	}
+
 	//! Register a per-claim wake event; nullptr when the claim is already poppable (caller retries).
 	shared_ptr<ReadAheadJobCompletion> RegisterWaiter(idx_t claim) {
 		annotated_lock_guard<annotated_mutex> guard(lock);
@@ -121,44 +168,53 @@ public:
 
 	//! Pop the claimed batch if present. FINISHED means the stream ended and the claim can never arrive.
 	PopStatus TryPopClaimed(idx_t claim, PAYLOAD &payload_out) {
-		annotated_lock_guard<annotated_mutex> guard(lock);
-		if (errored) {
-			return PopStatus::ERRORED;
+		vector<InterruptState> capacity_wakes;
+		PopStatus status;
+		{
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			if (errored) {
+				return PopStatus::ERRORED;
+			}
+			auto entry = batches.find(claim);
+			if (entry != batches.end()) {
+				payload_out = std::move(entry->second.payload);
+				buffered_bytes -= entry->second.bytes;
+				batches.erase(entry);
+				capacity_wakes = TakeCapacityWaiters();
+				status = PopStatus::BATCH;
+			} else if (finished) {
+				// Indices are dense and Finish() runs after the last push, so an absent claim can never arrive.
+				return PopStatus::FINISHED;
+			} else {
+				return PopStatus::EMPTY;
+			}
 		}
-		auto entry = batches.find(claim);
-		if (entry != batches.end()) {
-			payload_out = std::move(entry->second.payload);
-			buffered_bytes -= entry->second.bytes;
-			batches.erase(entry);
-			cv.notify_all(); // pushers may be waiting on capacity
-			return PopStatus::BATCH;
-		}
-		// Indices are dense and Finish() runs after the last push, so an absent claim can never arrive.
-		if (finished) {
-			return PopStatus::FINISHED;
-		}
-		return PopStatus::EMPTY;
+		cv.notify_all(); // pushers may be waiting on capacity
+		WakeCapacity(capacity_wakes);
+		return status;
 	}
 
 	//! Pop the lowest available batch regardless of claims (unordered consumption).
 	PopStatus TryPopAny(idx_t &batch_index_out, PAYLOAD &payload_out) {
-		annotated_lock_guard<annotated_mutex> guard(lock);
-		if (errored) {
-			return PopStatus::ERRORED;
-		}
-		if (!batches.empty()) {
+		vector<InterruptState> capacity_wakes;
+		{
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			if (errored) {
+				return PopStatus::ERRORED;
+			}
+			if (batches.empty()) {
+				return finished ? PopStatus::FINISHED : PopStatus::EMPTY;
+			}
 			auto entry = batches.begin();
 			batch_index_out = entry->first;
 			payload_out = std::move(entry->second.payload);
 			buffered_bytes -= entry->second.bytes;
 			batches.erase(entry);
-			cv.notify_all(); // pushers may be waiting on capacity
-			return PopStatus::BATCH;
+			capacity_wakes = TakeCapacityWaiters();
 		}
-		if (finished) {
-			return PopStatus::FINISHED;
-		}
-		return PopStatus::EMPTY;
+		cv.notify_all(); // pushers may be waiting on capacity
+		WakeCapacity(capacity_wakes);
+		return PopStatus::BATCH;
 	}
 
 	//! Block until the claimed batch arrives, the stream ends, or a short timeout elapses.
@@ -185,6 +241,7 @@ public:
 	//! pushed — validates that a dense stream arrived completely.
 	void Finish(optional_idx expected_total = optional_idx()) {
 		std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
+		vector<InterruptState> capacity_wakes;
 		{
 			annotated_lock_guard<annotated_mutex> guard(lock);
 			if (expected_total.IsValid() && !errored && pushed_count != expected_total.GetIndex()) {
@@ -196,16 +253,20 @@ public:
 			finished = true;
 			drained = std::move(waiters);
 			waiters.clear();
+			capacity_wakes = TakeCapacityWaiters();
 		}
 		cv.notify_all();
 		// wake every parked claimant so it observes FINISHED (or the count-mismatch error)
 		for (auto &entry : drained) {
 			entry.second->FinishIOTask();
 		}
+		// capacity-parked producers retry, observe the closed stream, and drop their batch
+		WakeCapacity(capacity_wakes);
 	}
 
 	void SetError(ErrorData error_p) {
 		std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
+		vector<InterruptState> capacity_wakes;
 		{
 			annotated_lock_guard<annotated_mutex> guard(lock);
 			if (!errored) {
@@ -215,12 +276,15 @@ public:
 			finished = true;
 			drained = std::move(waiters);
 			waiters.clear();
+			capacity_wakes = TakeCapacityWaiters();
 		}
 		cv.notify_all();
 		// wake every parked claimant so it observes ERRORED
 		for (auto &entry : drained) {
 			entry.second->FinishIOTask();
 		}
+		// capacity-parked producers retry, observe the closed stream, and drop their batch
+		WakeCapacity(capacity_wakes);
 	}
 
 	bool HasError() {
@@ -261,6 +325,19 @@ private:
 		seen.Insert(batch_index);
 	}
 
+	vector<InterruptState> TakeCapacityWaiters() DUCKDB_REQUIRES(lock) {
+		auto taken = std::move(capacity_waiters);
+		capacity_waiters.clear();
+		return taken;
+	}
+
+	//! Fired outside the lock; a spurious wake just makes the producer retry and maybe re-park.
+	static void WakeCapacity(vector<InterruptState> &wakes) {
+		for (auto &state : wakes) {
+			state.Callback();
+		}
+	}
+
 private:
 	struct Entry {
 		PAYLOAD payload;
@@ -276,6 +353,8 @@ private:
 	idx_t capacity DUCKDB_GUARDED_BY(lock) = 0;
 	//! batch_index -> wake event for the parked claimant; publishing that index fires exactly this one.
 	std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> waiters DUCKDB_GUARDED_BY(lock);
+	//! Tasks parked by TryPushBatch on capacity; all fired on any capacity-freeing pop or stream close.
+	vector<InterruptState> capacity_waiters DUCKDB_GUARDED_BY(lock);
 	//! Batches ever pushed, checked against Finish(expected_total); dedupe keeps retries from inflating it.
 	idx_t pushed_count DUCKDB_GUARDED_BY(lock) = 0;
 	//! Push dedupe.

--- a/src/include/quack_fetch_ahead.hpp
+++ b/src/include/quack_fetch_ahead.hpp
@@ -49,14 +49,13 @@ public:
 	void StopAndDrain();
 
 private:
-	//! Register fetch tasks until in-flight + buffered batches reach `depth`. Each task names its batch
-	//! and carries its own encoded payload, so a transport retry re-asks for the SAME batch (idempotent).
+	//! Register fetch tasks until the batches in flight and in the buffer reach `depth`. Each task
+	//! names its batch and holds its own payload, so a transport retry asks for the SAME batch.
 	void TopUp(ClientContext &context);
 	//! Account one popped batch and refill the pipeline.
 	void BatchConsumed(ClientContext &context);
-	//! Record a received index and advance the contiguous-received watermark (the ack).
 	void RecordReceived(idx_t index);
-	//! Highest index with all of 1..ack received; the server may drop retained batches <= it.
+	//! The highest index for which all of 1..ack arrived. The server can drop the batches below it.
 	idx_t CurrentAck();
 	//! Return a checked-out client to the idle stack.
 	void ReturnClient(unique_ptr<QuackClientWrapper> client);
@@ -81,17 +80,16 @@ private:
 	//! In-flight fetches + buffered batches not yet popped; bounded by depth.
 	atomic<idx_t> outstanding {0};
 	atomic<idx_t> in_flight {0};
-	//! Next client-visible batch index to request; requests are issued in dense order, matching the
-	//! scan threads' claim sequence.
+	//! The next index to request. Requests go out in dense order, as the scan threads claim them.
 	atomic<idx_t> next_request {1};
-	//! Received indices; the contiguous prefix is the ack watermark sent to the server.
+	//! The contiguous prefix of these is the ack the client sends to the server.
 	mutex ack_lock;
 	QuackDenseIndexSet acked;
 	atomic<bool> stop {false};
 	//! Set on the first empty FETCH response; no further fetches are issued.
 	atomic<bool> no_more_fetches {false};
-	//! Client-visible total announced by the terminal FETCH response (INVALID_INDEX until seen);
-	//! passed to the buffer's Finish so a short stream errors instead of truncating silently.
+	//! The total the terminal FETCH response announced, INVALID_INDEX until it arrives. Finish reads
+	//! it, so a short stream errors instead of truncating.
 	atomic<uint64_t> expected_total {DConstants::INVALID_INDEX};
 };
 

--- a/src/include/quack_fetch_ahead.hpp
+++ b/src/include/quack_fetch_ahead.hpp
@@ -9,9 +9,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/parallel/async_result.hpp"
 
-#include <condition_variable>
-#include <map>
-
+#include "quack_claim_buffer.hpp"
 #include "quack_client.hpp"
 
 namespace duckdb {
@@ -27,45 +25,6 @@ enum class QuackFetchResult : uint8_t {
 	FINISHED,
 	//! Batch not ready; the scan yielded via input.async_result and will be rescheduled.
 	BLOCKED
-};
-
-//! Claim-based delivery: FETCH batch indices are dense, so each scan thread claims the next index and
-//! waits for exactly that batch — per-thread order is monotone; downstream sinks reassemble global order.
-class QuackFetchBuffer {
-public:
-	enum class PopStatus : uint8_t {
-		BATCH,
-		EMPTY,
-		FINISHED,
-		ERRORED,
-	};
-
-	//! Claim the next batch index to consume; each index gets exactly one claimant.
-	idx_t ClaimBatch();
-	//! Publish a decoded batch under its server-assigned index.
-	void PushBatch(idx_t batch_index, vector<unique_ptr<DataChunk>> chunks);
-	//! Pop the claimed batch if present. FINISHED means the stream ended and the claim can never arrive.
-	PopStatus TryPopClaimed(idx_t claim, vector<unique_ptr<DataChunk>> &chunks_out);
-	//! Register a per-claim wake event; nullptr when the claim is already poppable (caller retries).
-	shared_ptr<ReadAheadJobCompletion> RegisterWaiter(idx_t claim);
-	//! Block until the claimed batch arrives, the stream ends, or a short timeout elapses.
-	void WaitForBatch(idx_t claim);
-
-	void Finish();
-	void SetError(ErrorData error_p);
-	ErrorData GetError();
-
-private:
-	annotated_mutex lock;
-	std::condition_variable cv;
-	idx_t next_claim DUCKDB_GUARDED_BY(lock) = 1;
-	//! batch_index -> decoded chunks, awaiting its claimant.
-	std::map<idx_t, vector<unique_ptr<DataChunk>>> batches DUCKDB_GUARDED_BY(lock);
-	//! batch_index -> wake event for the parked claimant; publishing that index fires exactly this one.
-	std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> waiters DUCKDB_GUARDED_BY(lock);
-	bool finished DUCKDB_GUARDED_BY(lock) = false;
-	bool errored DUCKDB_GUARDED_BY(lock) = false;
-	ErrorData error DUCKDB_GUARDED_BY(lock);
 };
 
 //! Client-side FETCH read-ahead: keeps up to `depth` fetches in flight on the ASYNC pool so scan
@@ -90,10 +49,15 @@ public:
 	void StopAndDrain();
 
 private:
-	//! Register fetch tasks until in-flight + buffered batches reach `depth`.
-	void TopUp();
+	//! Register fetch tasks until in-flight + buffered batches reach `depth`. Each task names its batch
+	//! and carries its own encoded payload, so a transport retry re-asks for the SAME batch (idempotent).
+	void TopUp(ClientContext &context);
 	//! Account one popped batch and refill the pipeline.
-	void BatchConsumed();
+	void BatchConsumed(ClientContext &context);
+	//! Record a received index and advance the contiguous-received watermark (the ack).
+	void RecordReceived(idx_t index);
+	//! Highest index with all of 1..ack received; the server may drop retained batches <= it.
+	idx_t CurrentAck();
 	//! Return a checked-out client to the idle stack.
 	void ReturnClient(unique_ptr<QuackClientWrapper> client);
 	//! Task epilogue: recycle the client, settle counters, finish the buffer after the last fetch.
@@ -102,9 +66,7 @@ private:
 private:
 	unique_ptr<ManagedAsyncTaskQueue> queue;
 	shared_ptr<QuackFetchBuffer> buffer;
-	//! The FETCH request bytes, encoded once; identical for every fetch of the query.
-	unique_ptr<MemoryStream> payload;
-	idx_t payload_size = 0;
+	hugeint_t query_uuid;
 	string connection_id;
 	optional_idx client_query_id;
 	//! Context logger captured on the creating thread; pool threads have no ClientContext.
@@ -119,9 +81,18 @@ private:
 	//! In-flight fetches + buffered batches not yet popped; bounded by depth.
 	atomic<idx_t> outstanding {0};
 	atomic<idx_t> in_flight {0};
+	//! Next client-visible batch index to request; requests are issued in dense order, matching the
+	//! scan threads' claim sequence.
+	atomic<idx_t> next_request {1};
+	//! Received indices; the contiguous prefix is the ack watermark sent to the server.
+	mutex ack_lock;
+	QuackDenseIndexSet acked;
 	atomic<bool> stop {false};
 	//! Set on the first empty FETCH response; no further fetches are issued.
 	atomic<bool> no_more_fetches {false};
+	//! Client-visible total announced by the terminal FETCH response (INVALID_INDEX until seen);
+	//! passed to the buffer's Finish so a short stream errors instead of truncating silently.
+	atomic<uint64_t> expected_total {DConstants::INVALID_INDEX};
 };
 
 } // namespace duckdb

--- a/src/include/quack_fetch_collector.hpp
+++ b/src/include/quack_fetch_collector.hpp
@@ -71,15 +71,15 @@ struct QuackFetchStream {
 	//! fails instead of truncating.
 	optional_idx announced_total;
 
-	//! A payload the stream is holding on to, so it can be served again byte for byte.
+	//! A payload the stream keeps, so it can serve the same bytes again.
 	struct RetainedPayload {
 		shared_ptr<MemoryStream> payload;
 		idx_t rows = 0;
 	};
 
 	//! Kept until the client acks them, so a transport retry gets the SAME batch again. The client's
-	//! read-ahead window bounds this map, unless a result cache is retaining the whole result: then
-	//! `retain_all` holds the acks off and the map grows to the size of the result.
+	//! read-ahead window bounds this map. With `retain_all` an ack releases nothing, and the map
+	//! grows to the size of the result.
 	mutex serve_lock;
 	std::map<idx_t, RetainedPayload> served;
 	//! Set while a result cache pins this stream. Guarded by serve_lock.
@@ -87,13 +87,13 @@ struct QuackFetchStream {
 	//! Rows in `served`. Guarded by serve_lock.
 	idx_t retained_rows = 0;
 
-	//! Hold every served payload from now on, and count what is already there.
+	//! Keep every payload from now on. An ack then releases nothing.
 	void RetainAll() {
 		lock_guard<mutex> guard(serve_lock);
 		retain_all = true;
 	}
 
-	//! Add a payload the connection served outside the FETCH handler (the PREPARE inline drain).
+	//! Add a payload that the PREPARE inline drain served, outside the FETCH handler.
 	void Retain(idx_t dense_index, shared_ptr<MemoryStream> payload, idx_t rows) {
 		lock_guard<mutex> guard(serve_lock);
 		if (!served.emplace(dense_index, RetainedPayload {std::move(payload), rows}).second) {
@@ -107,7 +107,7 @@ struct QuackFetchStream {
 		return retained_rows;
 	}
 
-	//! Stop retaining and drop what is held: the result grew past what the server will keep.
+	//! Stop retaining and drop what is held. The result grew past the cache limit.
 	void DropRetention() {
 		lock_guard<mutex> guard(serve_lock);
 		retain_all = false;

--- a/src/include/quack_fetch_collector.hpp
+++ b/src/include/quack_fetch_collector.hpp
@@ -71,10 +71,49 @@ struct QuackFetchStream {
 	//! fails instead of truncating.
 	optional_idx announced_total;
 
+	//! A payload the stream is holding on to, so it can be served again byte for byte.
+	struct RetainedPayload {
+		shared_ptr<MemoryStream> payload;
+		idx_t rows = 0;
+	};
+
 	//! Kept until the client acks them, so a transport retry gets the SAME batch again. The client's
-	//! read-ahead window bounds this map.
+	//! read-ahead window bounds this map, unless a result cache is retaining the whole result: then
+	//! `retain_all` holds the acks off and the map grows to the size of the result.
 	mutex serve_lock;
-	std::map<idx_t, shared_ptr<MemoryStream>> served;
+	std::map<idx_t, RetainedPayload> served;
+	//! Set while a result cache pins this stream. Guarded by serve_lock.
+	bool retain_all = false;
+	//! Rows in `served`. Guarded by serve_lock.
+	idx_t retained_rows = 0;
+
+	//! Hold every served payload from now on, and count what is already there.
+	void RetainAll() {
+		lock_guard<mutex> guard(serve_lock);
+		retain_all = true;
+	}
+
+	//! Add a payload the connection served outside the FETCH handler (the PREPARE inline drain).
+	void Retain(idx_t dense_index, shared_ptr<MemoryStream> payload, idx_t rows) {
+		lock_guard<mutex> guard(serve_lock);
+		if (!served.emplace(dense_index, RetainedPayload {std::move(payload), rows}).second) {
+			return;
+		}
+		retained_rows += rows;
+	}
+
+	idx_t RetainedRows() {
+		lock_guard<mutex> guard(serve_lock);
+		return retained_rows;
+	}
+
+	//! Stop retaining and drop what is held: the result grew past what the server will keep.
+	void DropRetention() {
+		lock_guard<mutex> guard(serve_lock);
+		retain_all = false;
+		served.clear();
+		retained_rows = 0;
+	}
 
 private:
 	mutex bind_lock;

--- a/src/include/quack_fetch_collector.hpp
+++ b/src/include/quack_fetch_collector.hpp
@@ -21,20 +21,20 @@ class ClientContext;
 class PhysicalOperator;
 struct PreparedStatementData;
 
-//! One sealed FETCH_RESPONSE wire payload awaiting delivery. The batch-index field is patched twice:
-//! the dense index at emit time, the client-visible remap (dense − prepare_batches) at reply time.
+//! One sealed FETCH_RESPONSE payload. Two patches write its batch-index field: the dense index at
+//! emit time, then the client-visible index (dense minus prepare_batches) at reply time.
 struct QuackFetchPayload {
 	unique_ptr<MemoryStream> payload;
 	idx_t payload_size = 0;
-	//! Offset of the fixed-width batch-index field (patch target).
+	//! Where the fixed-width batch-index field starts: the patch target.
 	idx_t index_offset = 0;
-	//! Rows in the batch (drives the PREPARE inline-drain loop).
+	//! The rows in the batch. The PREPARE inline drain counts them.
 	idx_t rows = 0;
 };
 using QuackFetchPayloadBuffer = QuackClaimBuffer<QuackFetchPayload>;
 
-//! Server-side state for one client-facing query result: the claim buffer the fetch collector fills
-//! (sealed wire payloads, out of order, byte-capacity bounded) and the FETCH handlers drain.
+//! Server state for one client-facing result. The fetch collector fills the claim buffer with sealed
+//! payloads, out of order and under a byte limit. The FETCH handlers drain it.
 struct QuackFetchStream {
 	QuackFetchPayloadBuffer buffer;
 
@@ -48,7 +48,7 @@ struct QuackFetchStream {
 		bind_cv.notify_all();
 	}
 
-	//! Wait until the query is planned (true) or failed before planning (false — see buffer error).
+	//! true = the query is planned. false = it failed before that; the buffer holds the error.
 	bool WaitBound() {
 		unique_lock<mutex> guard(bind_lock);
 		while (!bound && !buffer.HasError() && !buffer.Exhausted()) {
@@ -62,18 +62,17 @@ struct QuackFetchStream {
 		return bound;
 	}
 
-	//! Valid after WaitBound() returned true.
 	vector<LogicalType> types;
 	vector<string> names;
-	//! Dense batches the PREPARE response consumed inline; FETCH responses subtract this so the
-	//! client-facing indices stay dense from 1. Written by PREPARE before any FETCH arrives.
+	//! The dense batches PREPARE consumed inline. FETCH subtracts this, so the client-facing indices
+	//! stay dense from 1. PREPARE writes it before the first FETCH arrives.
 	idx_t prepare_batches = 0;
-	//! Total dense batches the producer emitted; shipped on the terminal FINISHED response so a short
-	//! stream fails loudly instead of truncating.
+	//! The dense batches the producer emitted. The terminal response carries it, so a short stream
+	//! fails instead of truncating.
 	optional_idx announced_total;
 
-	//! Served payloads retained until the client acks them, so a transport retry re-serves the SAME
-	//! batch instead of losing it; bounded by the client's in-flight read-ahead window.
+	//! Kept until the client acks them, so a transport retry gets the SAME batch again. The client's
+	//! read-ahead window bounds this map.
 	mutex serve_lock;
 	std::map<idx_t, shared_ptr<MemoryStream>> served;
 
@@ -83,8 +82,7 @@ private:
 	bool bound = false;
 };
 
-//! Plugged into ClientConfig::get_result_collector so the query executes in parallel into `stream`
-//! instead of a single lazily-driven cursor.
+//! Installed in ClientConfig::get_result_collector, so the query runs in parallel into `stream`.
 unique_ptr<PhysicalOperator> MakeQuackFetchCollector(ClientContext &context, PreparedStatementData &data,
                                                      shared_ptr<QuackFetchStream> stream);
 

--- a/src/include/quack_fetch_collector.hpp
+++ b/src/include/quack_fetch_collector.hpp
@@ -1,0 +1,91 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// quack_fetch_collector.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+
+#include "quack_claim_buffer.hpp"
+
+#include <condition_variable>
+
+namespace duckdb {
+
+class ClientContext;
+class PhysicalOperator;
+struct PreparedStatementData;
+
+//! One sealed FETCH_RESPONSE wire payload awaiting delivery. The batch-index field is patched twice:
+//! the dense index at emit time, the client-visible remap (dense − prepare_batches) at reply time.
+struct QuackFetchPayload {
+	unique_ptr<MemoryStream> payload;
+	idx_t payload_size = 0;
+	//! Offset of the fixed-width batch-index field (patch target).
+	idx_t index_offset = 0;
+	//! Rows in the batch (drives the PREPARE inline-drain loop).
+	idx_t rows = 0;
+};
+using QuackFetchPayloadBuffer = QuackClaimBuffer<QuackFetchPayload>;
+
+//! Server-side state for one client-facing query result: the claim buffer the fetch collector fills
+//! (sealed wire payloads, out of order, byte-capacity bounded) and the FETCH handlers drain.
+struct QuackFetchStream {
+	QuackFetchPayloadBuffer buffer;
+
+	void SignalBound(vector<LogicalType> types_p, vector<string> names_p) {
+		{
+			lock_guard<mutex> guard(bind_lock);
+			types = std::move(types_p);
+			names = std::move(names_p);
+			bound = true;
+		}
+		bind_cv.notify_all();
+	}
+
+	//! Wait until the query is planned (true) or failed before planning (false — see buffer error).
+	bool WaitBound() {
+		unique_lock<mutex> guard(bind_lock);
+		while (!bound && !buffer.HasError() && !buffer.Exhausted()) {
+			bind_cv.wait_for(guard, std::chrono::milliseconds(50));
+		}
+		return bound;
+	}
+
+	bool Bound() {
+		lock_guard<mutex> guard(bind_lock);
+		return bound;
+	}
+
+	//! Valid after WaitBound() returned true.
+	vector<LogicalType> types;
+	vector<string> names;
+	//! Dense batches the PREPARE response consumed inline; FETCH responses subtract this so the
+	//! client-facing indices stay dense from 1. Written by PREPARE before any FETCH arrives.
+	idx_t prepare_batches = 0;
+	//! Total dense batches the producer emitted; shipped on the terminal FINISHED response so a short
+	//! stream fails loudly instead of truncating.
+	optional_idx announced_total;
+
+	//! Served payloads retained until the client acks them, so a transport retry re-serves the SAME
+	//! batch instead of losing it; bounded by the client's in-flight read-ahead window.
+	mutex serve_lock;
+	std::map<idx_t, shared_ptr<MemoryStream>> served;
+
+private:
+	mutex bind_lock;
+	std::condition_variable bind_cv;
+	bool bound = false;
+};
+
+//! Plugged into ClientConfig::get_result_collector so the query executes in parallel into `stream`
+//! instead of a single lazily-driven cursor.
+unique_ptr<PhysicalOperator> MakeQuackFetchCollector(ClientContext &context, PreparedStatementData &data,
+                                                     shared_ptr<QuackFetchStream> stream);
+
+} // namespace duckdb

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -2,11 +2,14 @@
 
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/error_data.hpp"
 
 namespace duckdb {
+
+class ClientContext;
 
 //! Quack wire-protocol version. Client and server agree on it during the connection handshake.
 static constexpr idx_t QUACK_VERSION = 2;
@@ -54,6 +57,31 @@ private:
 
 string MessageTypeToString(MessageType type);
 
+//! Fixed-width (8-byte LE) batch-index wire field, serialized LAST so an already-encoded payload can
+//! be stamped in place. 0 = invalid/absent; PLACEHOLDER = never stamped (receivers reject it).
+struct QuackBatchIndexField {
+	static constexpr uint64_t PLACEHOLDER = 0xF1DCBA99C0FFEE42ULL;
+	static constexpr uint64_t INVALID = 0;
+
+	static void Encode(uint64_t value, data_ptr_t out) {
+		for (idx_t i = 0; i < 8; i++) {
+			out[i] = static_cast<data_t>((value >> (i * 8)) & 0xFF);
+		}
+	}
+	static uint64_t Decode(const_data_ptr_t in) {
+		uint64_t value = 0;
+		for (idx_t i = 0; i < 8; i++) {
+			value |= static_cast<uint64_t>(in[i]) << (i * 8);
+		}
+		return value;
+	}
+	//! Stamp the dense index into an encoded payload.
+	static void Patch(data_ptr_t payload, idx_t payload_size, idx_t offset, idx_t batch_index) {
+		D_ASSERT(offset + 8 <= payload_size);
+		Encode(batch_index, payload + offset);
+	}
+};
+
 struct MessageHeader {
 	MessageHeader(MessageType type_p, string connection_id_p)
 	    : type(type_p), connection_id(std::move(connection_id_p)) {
@@ -69,12 +97,19 @@ struct MessageHeader {
 
 class QuackMessage {
 public:
-	void ToMemoryStream(MemoryStream &write_stream) const;
+	virtual void ToMemoryStream(MemoryStream &write_stream) const;
 	static unique_ptr<QuackMessage> FromMemoryStream(MemoryStream &read_stream);
+
+	//! Pre-serialized payload carried instead of a serializable body (see QuackRawPayloadResponse);
+	//! the HTTP layer sends these bytes directly. Null for normal messages.
+	virtual optional_ptr<MemoryStream> RawPayload() const {
+		return nullptr;
+	}
 
 	template <class TARGET>
 	TARGET &Cast() {
-		if (header.type != TARGET::TYPE) {
+		// a raw-payload carrier shares the payload's type tag but not its layout
+		if (header.type != TARGET::TYPE || RawPayload()) {
 			throw InternalException("Failed to cast message to type - message type mismatch");
 		}
 		return reinterpret_cast<TARGET &>(*this);
@@ -82,7 +117,7 @@ public:
 
 	template <class TARGET>
 	const TARGET &Cast() const {
-		if (header.type != TARGET::TYPE) {
+		if (header.type != TARGET::TYPE || RawPayload()) {
 			throw InternalException("Failed to cast message to type - message type mismatch");
 		}
 		return reinterpret_cast<const TARGET &>(*this);
@@ -282,8 +317,8 @@ class FetchRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_REQUEST;
 
-	explicit FetchRequestMessage(string connection_id_p, hugeint_t uuid)
-	    : QuackMessage(TYPE, std::move(connection_id_p)), uuid(uuid) {
+	FetchRequestMessage(string connection_id_p, hugeint_t uuid, idx_t batch_index, idx_t ack_index)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), uuid(uuid), batch_index(batch_index), ack_index(ack_index) {
 	}
 
 protected:
@@ -295,8 +330,15 @@ public:
 	static unique_ptr<FetchRequestMessage> Deserialize(Deserializer &deserializer);
 
 	hugeint_t uuid;
+	//! Client-visible dense batch index (from 1) this request claims. Every request names its batch,
+	//! so a transport-level retry re-asks for the SAME batch instead of popping the next one.
+	idx_t batch_index = 0;
+	//! Highest index with all of 1..ack_index received; the server may drop retained batches <= it.
+	idx_t ack_index = 0;
 };
 
+// One dense batch of a query result (server -> client). Data responses are pre-serialized by
+// FetchResponsePayloadWriter; this class serializes only the empty terminal FINISHED response.
 class FetchResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_RESPONSE;
@@ -310,6 +352,11 @@ public:
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<FetchResponseMessage> Deserialize(Deserializer &deserializer);
 
+	//! batch_index encoded as the fixed-width QuackBatchIndexField wire string (generator hook).
+	string EncodeBatchIndexFixed() const;
+	//! Decode + validate the wire string back into batch_index; rejects unstamped payloads.
+	void ApplyBatchIndexFixed(const string &bytes);
+
 	vector<unique_ptr<DataChunkWrapper>> &MutableResults() {
 		return results;
 	}
@@ -318,9 +365,18 @@ public:
 		return batch_index;
 	}
 
+	//! Client-visible total batch count; only set on the terminal FINISHED response.
+	void SetTotalBatches(optional_idx total_batches_p) {
+		total_batches = total_batches_p;
+	}
+	optional_idx TotalBatches() const {
+		return total_batches;
+	}
+
 private:
 	vector<unique_ptr<DataChunkWrapper>> results;
 	optional_idx batch_index;
+	optional_idx total_batches;
 };
 
 // Streams one or more DataChunks of insert data to the server, keyed by (connection_id, query_uuid).
@@ -405,6 +461,98 @@ private:
 	//! Set only on dead-range markers: batches [batch_index, dead_range_end) are dead (a filtered/pruned
 	//! gap the sink never crossed). Lets the server skip the gap instead of stalling. Invalid on data messages.
 	optional_idx dead_range_end;
+};
+
+//! Incrementally builds one serialized chunk-carrying message on the producing thread — no separate
+//! serialization pass at cut time. The chunk count (zero-padded LEB128) and the dense batch index
+//! (QuackBatchIndexField, LAST field) are fixed-width placeholders patched later. Subclasses MUST
+//! mirror the generated Serialize field-for-field; a debug round-trip check in Seal pins the two.
+class QuackChunkPayloadWriter {
+public:
+	//! Fixed width of the padded chunk-count varint.
+	static constexpr idx_t CHUNK_COUNT_VARINT_WIDTH = 5;
+
+	virtual ~QuackChunkPayloadWriter();
+
+	//! Serialize one chunk into the payload; the chunk may be reused by the caller afterwards.
+	void AppendChunk(DataChunk &chunk);
+	//! Serialized bytes so far; after Seal, the final payload size.
+	idx_t SizeBytes() const;
+	//! Bytes allocated by the backing stream.
+	idx_t AllocatedBytes() const;
+
+	struct SealedPayload {
+		unique_ptr<MemoryStream> payload;
+		idx_t payload_size;
+		//! Offset of the batch-index placeholder (QuackBatchIndexField::Patch target).
+		idx_t index_offset;
+	};
+	//! Patch the chunk count, write the subclass tail fields (ending with the batch-index
+	//! placeholder), close the message and return the payload ready for stamping.
+	SealedPayload Seal();
+
+protected:
+	//! capacity_hint: the previous sealed payload's size, pre-reserved so steady streaming never grows.
+	QuackChunkPayloadWriter(ClientContext &context, idx_t capacity_hint);
+
+	//! Write the message envelope and open the body object. Called once from the subclass ctor.
+	void OpenMessage(const MessageHeader &header);
+	//! The body serializer, for subclass prefix/tail fields.
+	Serializer &Body();
+	//! Open the chunk list: field header + padded count placeholder. Chunks append after this.
+	void BeginChunkList(uint16_t field_id, const char *tag);
+	//! Write the fixed batch-index field (placeholder) and record its patch offset. Must be the
+	//! subclass's LAST tail field.
+	void WriteBatchIndexField(uint16_t field_id, const char *tag);
+	//! Subclass hook called by Seal, after the chunk count is patched: write the tail fields.
+	virtual void WriteTail() = 0;
+	//! The message type this writer encodes (debug round-trip check).
+	virtual MessageType WrittenType() const = 0;
+
+private:
+	class PayloadSerializer;
+
+	unique_ptr<MemoryStream> stream;
+	unique_ptr<PayloadSerializer> serializer;
+	idx_t chunk_count = 0;
+	idx_t chunk_count_offset = 0;
+	idx_t index_offset = 0;
+	idx_t sealed_size = 0;
+};
+
+//! Builds FETCH_RESPONSE payloads (server fetch-collector path). total_batches is never set on
+//! data-carrying responses, so the writer omits it (matching the generated default handling).
+class FetchResponsePayloadWriter : public QuackChunkPayloadWriter {
+public:
+	FetchResponsePayloadWriter(ClientContext &context, idx_t capacity_hint);
+
+protected:
+	void WriteTail() override;
+	MessageType WrittenType() const override {
+		return MessageType::FETCH_RESPONSE;
+	}
+};
+
+//! Carries a pre-serialized response payload; the HTTP layer detects RawPayload() and sends the bytes
+//! directly. Never Cast<> this to the payload's message type — it only shares the header type tag.
+class QuackRawPayloadResponse : public QuackMessage {
+public:
+	//! shared_ptr: served FETCH payloads stay retained on the stream for idempotent re-serves.
+	QuackRawPayloadResponse(MessageType type, shared_ptr<MemoryStream> payload_p)
+	    : QuackMessage(type), payload(std::move(payload_p)) {
+	}
+
+	void Serialize(Serializer &serializer) const override {
+		throw InternalException("QuackRawPayloadResponse must not be serialized; send RawPayload() directly");
+	}
+
+	//! The payload bytes; GetPosition() is the payload size.
+	optional_ptr<MemoryStream> RawPayload() const override {
+		return payload.get();
+	}
+
+private:
+	shared_ptr<MemoryStream> payload;
 };
 
 // Success reply to a SendDataRequestMessage. `accept_budget` is a placeholder for a future flow-control

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -57,8 +57,8 @@ private:
 
 string MessageTypeToString(MessageType type);
 
-//! Fixed-width (8-byte LE) batch-index wire field, serialized LAST so an already-encoded payload can
-//! be stamped in place. 0 = invalid/absent; PLACEHOLDER = never stamped (receivers reject it).
+//! An 8-byte little-endian batch index. It is serialized LAST, so a stamp can write it into an
+//! encoded payload. 0 = absent. PLACEHOLDER = never stamped, and the receiver rejects it.
 struct QuackBatchIndexField {
 	static constexpr uint64_t PLACEHOLDER = 0xF1DCBA99C0FFEE42ULL;
 	static constexpr uint64_t INVALID = 0;
@@ -75,7 +75,6 @@ struct QuackBatchIndexField {
 		}
 		return value;
 	}
-	//! Stamp the dense index into an encoded payload.
 	static void Patch(data_ptr_t payload, idx_t payload_size, idx_t offset, idx_t batch_index) {
 		D_ASSERT(offset + 8 <= payload_size);
 		Encode(batch_index, payload + offset);
@@ -100,15 +99,15 @@ public:
 	virtual void ToMemoryStream(MemoryStream &write_stream) const;
 	static unique_ptr<QuackMessage> FromMemoryStream(MemoryStream &read_stream);
 
-	//! Pre-serialized payload carried instead of a serializable body (see QuackRawPayloadResponse);
-	//! the HTTP layer sends these bytes directly. Null for normal messages.
+	//! A serialized payload instead of a body. The HTTP layer sends these bytes as they are. It is
+	//! null for a normal message.
 	virtual optional_ptr<MemoryStream> RawPayload() const {
 		return nullptr;
 	}
 
 	template <class TARGET>
 	TARGET &Cast() {
-		// a raw-payload carrier shares the payload's type tag but not its layout
+		// a raw-payload carrier has the payload's type tag, but not its layout
 		if (header.type != TARGET::TYPE || RawPayload()) {
 			throw InternalException("Failed to cast message to type - message type mismatch");
 		}
@@ -330,15 +329,15 @@ public:
 	static unique_ptr<FetchRequestMessage> Deserialize(Deserializer &deserializer);
 
 	hugeint_t uuid;
-	//! Client-visible dense batch index (from 1) this request claims. Every request names its batch,
-	//! so a transport-level retry re-asks for the SAME batch instead of popping the next one.
+	//! The dense batch index this request claims, from 1. Every request names its batch, so a
+	//! transport retry asks for the SAME batch.
 	idx_t batch_index = 0;
-	//! Highest index with all of 1..ack_index received; the server may drop retained batches <= it.
+	//! All of 1..ack_index arrived. The server can drop the batches it kept below this index.
 	idx_t ack_index = 0;
 };
 
-// One dense batch of a query result (server -> client). Data responses are pre-serialized by
-// FetchResponsePayloadWriter; this class serializes only the empty terminal FINISHED response.
+// One dense batch of a result, server to client. FetchResponsePayloadWriter serializes the data
+// responses, so this class serializes the empty terminal response only.
 class FetchResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::FETCH_RESPONSE;
@@ -352,9 +351,9 @@ public:
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<FetchResponseMessage> Deserialize(Deserializer &deserializer);
 
-	//! batch_index encoded as the fixed-width QuackBatchIndexField wire string (generator hook).
+	//! batch_index as the fixed-width wire string. The generator calls this.
 	string EncodeBatchIndexFixed() const;
-	//! Decode + validate the wire string back into batch_index; rejects unstamped payloads.
+	//! Decode the wire string back into batch_index. An unstamped payload is an error.
 	void ApplyBatchIndexFixed(const string &bytes);
 
 	vector<unique_ptr<DataChunkWrapper>> &MutableResults() {
@@ -365,7 +364,7 @@ public:
 		return batch_index;
 	}
 
-	//! Client-visible total batch count; only set on the terminal FINISHED response.
+	//! Set on the terminal response only.
 	void SetTotalBatches(optional_idx total_batches_p) {
 		total_batches = total_batches_p;
 	}
@@ -463,50 +462,44 @@ private:
 	optional_idx dead_range_end;
 };
 
-//! Incrementally builds one serialized chunk-carrying message on the producing thread — no separate
-//! serialization pass at cut time. The chunk count (zero-padded LEB128) and the dense batch index
-//! (QuackBatchIndexField, LAST field) are fixed-width placeholders patched later. Subclasses MUST
-//! mirror the generated Serialize field-for-field; a debug round-trip check in Seal pins the two.
+//! Builds one serialized message step by step, on the producing thread. A cut then needs no second
+//! serialization. Two fields have a fixed width and a later patch: the chunk count, as a padded
+//! LEB128, and the batch index, which is the LAST field. A subclass MUST write the same fields, in
+//! the same order, as the generated Serialize. A debug check in Seal compares the two.
 class QuackChunkPayloadWriter {
 public:
-	//! Fixed width of the padded chunk-count varint.
 	static constexpr idx_t CHUNK_COUNT_VARINT_WIDTH = 5;
 
 	virtual ~QuackChunkPayloadWriter();
 
-	//! Serialize one chunk into the payload; the chunk may be reused by the caller afterwards.
+	//! The caller can reuse the chunk after this call.
 	void AppendChunk(DataChunk &chunk);
-	//! Serialized bytes so far; after Seal, the final payload size.
+	//! After Seal: the final payload size.
 	idx_t SizeBytes() const;
-	//! Bytes allocated by the backing stream.
 	idx_t AllocatedBytes() const;
 
 	struct SealedPayload {
 		unique_ptr<MemoryStream> payload;
 		idx_t payload_size;
-		//! Offset of the batch-index placeholder (QuackBatchIndexField::Patch target).
+		//! Where the batch-index placeholder starts: the patch target.
 		idx_t index_offset;
 	};
-	//! Patch the chunk count, write the subclass tail fields (ending with the batch-index
-	//! placeholder), close the message and return the payload ready for stamping.
+	//! Patch the chunk count, write the subclass tail fields, close the message, and return the
+	//! payload. The batch-index placeholder is the last field written.
 	SealedPayload Seal();
 
 protected:
-	//! capacity_hint: the previous sealed payload's size, pre-reserved so steady streaming never grows.
+	//! capacity_hint is the previous payload's size. It is reserved, so a steady stream never grows.
 	QuackChunkPayloadWriter(ClientContext &context, idx_t capacity_hint);
 
-	//! Write the message envelope and open the body object. Called once from the subclass ctor.
 	void OpenMessage(const MessageHeader &header);
-	//! The body serializer, for subclass prefix/tail fields.
 	Serializer &Body();
-	//! Open the chunk list: field header + padded count placeholder. Chunks append after this.
+	//! Write the field header and the padded count placeholder. The chunks follow.
 	void BeginChunkList(uint16_t field_id, const char *tag);
-	//! Write the fixed batch-index field (placeholder) and record its patch offset. Must be the
-	//! subclass's LAST tail field.
+	//! Write the batch-index placeholder and record its offset. It MUST be the last tail field.
 	void WriteBatchIndexField(uint16_t field_id, const char *tag);
-	//! Subclass hook called by Seal, after the chunk count is patched: write the tail fields.
+	//! Seal calls this after it patches the chunk count. Write the tail fields here.
 	virtual void WriteTail() = 0;
-	//! The message type this writer encodes (debug round-trip check).
 	virtual MessageType WrittenType() const = 0;
 
 private:
@@ -520,8 +513,8 @@ private:
 	idx_t sealed_size = 0;
 };
 
-//! Builds FETCH_RESPONSE payloads (server fetch-collector path). total_batches is never set on
-//! data-carrying responses, so the writer omits it (matching the generated default handling).
+//! Builds FETCH_RESPONSE payloads. A response that carries data never sets total_batches, so this
+//! writer leaves it out, as the generated code does for a default value.
 class FetchResponsePayloadWriter : public QuackChunkPayloadWriter {
 public:
 	FetchResponsePayloadWriter(ClientContext &context, idx_t capacity_hint);
@@ -533,11 +526,11 @@ protected:
 	}
 };
 
-//! Carries a pre-serialized response payload; the HTTP layer detects RawPayload() and sends the bytes
-//! directly. Never Cast<> this to the payload's message type — it only shares the header type tag.
+//! Carries a serialized payload. The HTTP layer finds it with RawPayload() and sends the bytes as
+//! they are. Never Cast<> this to the payload's message type: only the header type tag is the same.
 class QuackRawPayloadResponse : public QuackMessage {
 public:
-	//! shared_ptr: served FETCH payloads stay retained on the stream for idempotent re-serves.
+	//! A shared_ptr, because a served payload stays on the stream for a safe re-serve.
 	QuackRawPayloadResponse(MessageType type, shared_ptr<MemoryStream> payload_p)
 	    : QuackMessage(type), payload(std::move(payload_p)) {
 	}
@@ -546,7 +539,6 @@ public:
 		throw InternalException("QuackRawPayloadResponse must not be serialized; send RawPayload() directly");
 	}
 
-	//! The payload bytes; GetPosition() is the payload size.
 	optional_ptr<MemoryStream> RawPayload() const override {
 		return payload.get();
 	}

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -58,6 +58,18 @@
         "id": 1,
         "name": "uuid",
         "type": "hugeint_t"
+      },
+      {
+        "id": 2,
+        "name": "batch_index",
+        "type": "idx_t",
+        "default": 0
+      },
+      {
+        "id": 3,
+        "name": "ack_index",
+        "type": "idx_t",
+        "default": 0
       }
     ]
   },
@@ -188,10 +200,23 @@
       },
       {
         "id": 2,
-        "name": "batch_index",
-        "type": "optional_idx"
+        "name": "total_batches",
+        "type": "optional_idx",
+        "default": "optional_idx()"
+      },
+      {
+        "id": 3,
+        "name": "batch_index_fixed",
+        "type": "string",
+        "serialize_property": "EncodeBatchIndexFixed()",
+        "deserialize_skip_assign": true
       }
-    ]
+    ],
+    "methods": {
+      "ApplyBatchIndexFixed": [
+        "batch_index_fixed"
+      ]
+    }
   },
   {
     "class": "CancelRequestMessage",

--- a/src/include/quack_rebalancer_core.hpp
+++ b/src/include/quack_rebalancer_core.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/execution/operator/persistent/batch_memory_manager.hpp"
+#include "duckdb/execution/operator/persistent/batch_task_manager.hpp"
+
+namespace duckdb {
+
+//! A batch that has been made wire-ready (e.g. serialized) but not yet stamped with its dense index.
+struct QuackPreparedBatch {
+	virtual ~QuackPreparedBatch() = default;
+};
+
+//! Accumulates one fragment on its producing thread, directly in the emitter's final form — the
+//! accumulation buffer IS the prepared batch, so cutting costs no extra copy or serialization pass.
+class QuackFragmentBuilder {
+public:
+	virtual ~QuackFragmentBuilder() = default;
+	//! Append one chunk; the chunk may be reused by the caller afterwards.
+	virtual void Append(ClientContext &context, DataChunk &chunk) = 0;
+	//! Bytes accumulated so far — the cut measure. After Seal: the final fragment size.
+	virtual idx_t SizeBytes() const = 0;
+	//! Bytes allocated — the memory-accounting measure.
+	virtual idx_t AllocatedBytes() const = 0;
+	//! Close the fragment into a stampable batch.
+	virtual unique_ptr<QuackPreparedBatch> Seal(ClientContext &context) = 0;
+};
+
+//! Compacts sub-half-vector chunks into staged ~STANDARD_VECTOR_SIZE chunks so sparse sources
+//! (filtered scans) don't pay per-chunk framing overhead; larger chunks pass straight through.
+class QuackChunkStager {
+public:
+	template <class FLUSH>
+	void Append(DataChunk &chunk, FLUSH &&flush) {
+		if (chunk.size() * 2 >= STANDARD_VECTOR_SIZE) {
+			Flush(flush);
+			flush(chunk);
+			return;
+		}
+		if (staged && staged->size() + chunk.size() > STANDARD_VECTOR_SIZE) {
+			Flush(flush);
+		}
+		if (!staged) {
+			staged = make_uniq<DataChunk>();
+			staged->Initialize(Allocator::DefaultAllocator(), chunk.GetTypes());
+		}
+		staged->Append(chunk);
+		if (staged->size() == STANDARD_VECTOR_SIZE) {
+			Flush(flush);
+		}
+	}
+
+	template <class FLUSH>
+	void Flush(FLUSH &&flush) {
+		if (staged && staged->size() > 0) {
+			flush(*staged);
+			staged->Reset();
+		}
+	}
+
+private:
+	unique_ptr<DataChunk> staged;
+};
+
+//! Emits dense batches: OpenFragment accumulates chunks in emit-ready form on the producing thread
+//! (before the dense index is known); EmitPrepared stamps + sends at release time, concurrently and
+//! out of dense order (receivers reassemble by index). Finish runs once, after all EmitPrepared.
+class QuackBatchEmitter {
+public:
+	virtual ~QuackBatchEmitter() = default;
+	//! size_hint: the previous sealed fragment's size (0 for a thread's first fragment), so
+	//! implementations can pre-reserve capacity and avoid growth copies while accumulating.
+	virtual unique_ptr<QuackFragmentBuilder> OpenFragment(ClientContext &context, idx_t size_hint) = 0;
+	virtual void EmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> batch) = 0;
+	virtual void Finish(ClientContext &context, idx_t total_batches) = 0;
+};
+
+//! A stamped batch waiting to be emitted; emission runs outside the stamping lock, on any thread.
+struct QuackEmitTask {
+	QuackEmitTask(idx_t dense_index_p, idx_t memory_usage_p, unique_ptr<QuackPreparedBatch> prepared_p)
+	    : dense_index(dense_index_p), memory_usage(memory_usage_p), prepared(std::move(prepared_p)) {
+	}
+
+	idx_t dense_index;
+	idx_t memory_usage;
+	unique_ptr<QuackPreparedBatch> prepared;
+};
+
+//! Maps sparse executor batches onto dense (1,2,3,…) indices, one fragment = one dense batch.
+//! Stamping is ordered — only the settled prefix (up to and including the current minimum batch,
+//! whose dense prefix is known) is released under the lock — but emission is parallel and out of order.
+class QuackRebalancerCore {
+public:
+	QuackRebalancerCore(ClientContext &context, idx_t buffer_bytes_override_p, idx_t initial_memory_request,
+	                    unique_ptr<QuackBatchEmitter> emitter_p);
+
+	//! Open a fragment accumulator on the calling thread (delegates to the emitter).
+	unique_ptr<QuackFragmentBuilder> OpenFragment(ClientContext &context, idx_t size_hint) {
+		return emitter->OpenFragment(context, size_hint);
+	}
+
+	//! PARALLEL_ORDERED: shelve a sealed fragment of an executor batch (fragments of one batch only
+	//! ever come from its owning thread, in order), then stamp + emit the settled prefix.
+	void AddPendingFragment(ClientContext &context, idx_t executor_batch, idx_t min_batch_index, idx_t memory_usage,
+	                        unique_ptr<QuackPreparedBatch> prepared);
+	//! SERIAL_ORDERED / UNORDERED: a sealed fragment that is stampable immediately; stamped and emitted inline.
+	void AddSettledData(ClientContext &context, unique_ptr<QuackPreparedBatch> prepared);
+
+	//! Emit one stamped batch if any is queued; returns false when the queue is empty.
+	bool ExecuteTask(ClientContext &context);
+	void ExecuteTasks(ClientContext &context);
+
+	//! Over the pending-bytes budget and not the minimum batch: stop sinking, help emit, maybe block.
+	bool OutOfMemory(idx_t batch_index);
+
+	//! Final release: stamp everything still shelved (Finalize).
+	void FinalizeCut(ClientContext &context);
+	//! Stamped batches still queued for emission — lets Finalize decide inline drain vs parallel event.
+	idx_t TaskCount() {
+		return task_manager.TaskCount();
+	}
+	//! After the last EmitBatch returned: verify accounting and let the emitter close the stream.
+	void FinalizeFinish(ClientContext &context);
+
+	BatchMemoryManager &MemoryManager() {
+		return memory_manager;
+	}
+	idx_t TotalBatches() const {
+		return next_dense.load() - 1;
+	}
+
+private:
+	struct Fragment {
+		Fragment(idx_t memory_usage_p, unique_ptr<QuackPreparedBatch> prepared_p)
+		    : memory_usage(memory_usage_p), prepared(std::move(prepared_p)) {
+		}
+
+		idx_t memory_usage;
+		unique_ptr<QuackPreparedBatch> prepared;
+	};
+
+	//! Stamp every shelved fragment of batches below min_exclusive with the next dense indices and queue
+	//! them for emission — a pointer walk under the lock; the payloads were prepared at cut time.
+	void ReleaseSettled(idx_t min_exclusive);
+
+private:
+	BatchMemoryManager memory_manager;
+	BatchTaskManager<QuackEmitTask> task_manager;
+	annotated_mutex lock;
+	//! Prepared fragments of not-yet-settled executor batches, keyed by executor batch index.
+	std::map<idx_t, vector<Fragment>> raw_batches DUCKDB_GUARDED_BY(lock);
+	//! The next dense index to hand out; stamping order defines the stream order.
+	atomic<idx_t> next_dense {1};
+	//! Test/ops override: >0 also treats this many pending bytes as out-of-memory.
+	idx_t buffer_bytes_override;
+	unique_ptr<QuackBatchEmitter> emitter;
+};
+
+} // namespace duckdb

--- a/src/include/quack_rebalancer_core.hpp
+++ b/src/include/quack_rebalancer_core.hpp
@@ -9,28 +9,26 @@
 
 namespace duckdb {
 
-//! A batch that has been made wire-ready (e.g. serialized) but not yet stamped with its dense index.
+//! A wire-ready batch that has no dense index yet.
 struct QuackPreparedBatch {
 	virtual ~QuackPreparedBatch() = default;
 };
 
-//! Accumulates one fragment on its producing thread, directly in the emitter's final form — the
-//! accumulation buffer IS the prepared batch, so cutting costs no extra copy or serialization pass.
+//! Accumulates one fragment on its producing thread, in the emitter's final form. The buffer IS the
+//! prepared batch, so a cut costs no copy and no second serialization.
 class QuackFragmentBuilder {
 public:
 	virtual ~QuackFragmentBuilder() = default;
-	//! Append one chunk; the chunk may be reused by the caller afterwards.
 	virtual void Append(ClientContext &context, DataChunk &chunk) = 0;
-	//! Bytes accumulated so far — the cut measure. After Seal: the final fragment size.
+	//! The cut measure. After Seal: the final fragment size.
 	virtual idx_t SizeBytes() const = 0;
-	//! Bytes allocated — the memory-accounting measure.
+	//! The memory-accounting measure.
 	virtual idx_t AllocatedBytes() const = 0;
-	//! Close the fragment into a stampable batch.
 	virtual unique_ptr<QuackPreparedBatch> Seal(ClientContext &context) = 0;
 };
 
-//! Compacts sub-half-vector chunks into staged ~STANDARD_VECTOR_SIZE chunks so sparse sources
-//! (filtered scans) don't pay per-chunk framing overhead; larger chunks pass straight through.
+//! Merges small chunks into full ones, so a sparse source does not pay the framing cost of each
+//! chunk. Large chunks go through without a copy.
 class QuackChunkStager {
 public:
 	template <class FLUSH>
@@ -65,28 +63,27 @@ private:
 	unique_ptr<DataChunk> staged;
 };
 
-//! Emits dense batches: OpenFragment accumulates chunks in emit-ready form on the producing thread
-//! (before the dense index is known); TryEmitPrepared stamps + sends at release time, concurrently
-//! and out of dense order (receivers reassemble by index). Finish runs once, after all emits.
+//! OpenFragment accumulates chunks on the producing thread, before the dense index is known.
+//! TryEmitPrepared stamps and sends at release time, in parallel and out of dense order: the
+//! receiver puts them back in order by index. Finish runs once, after all emits.
 class QuackBatchEmitter {
 public:
 	virtual ~QuackBatchEmitter() = default;
-	//! size_hint: the previous sealed fragment's size (0 for a thread's first fragment), so
-	//! implementations can pre-reserve capacity and avoid growth copies while accumulating.
+	//! size_hint is the previous sealed fragment's size, 0 for a thread's first fragment. It lets an
+	//! implementation reserve capacity and prevent growth copies.
 	virtual unique_ptr<QuackFragmentBuilder> OpenFragment(ClientContext &context, idx_t size_hint) = 0;
-	//! false = the delivery target is at capacity and `batch` was NOT consumed (retry the same batch
-	//! later); with `interrupt` set, capacity freeing fires it. Emitters that cannot capacity-block
-	//! consume the batch and always return true.
+	//! false = the delivery target is full and `batch` was NOT consumed: retry the same batch later.
+	//! With `interrupt` set, capacity freeing fires it. An emitter that cannot fill up returns true.
 	virtual bool TryEmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> &batch,
 	                             optional_ptr<const InterruptState> interrupt) = 0;
 	virtual void Finish(ClientContext &context, idx_t total_batches) = 0;
 };
 
-//! Progress of an emit drain: BLOCKED means a batch is parked on delivery capacity and remains
-//! queued; the caller yields (interrupt registered) or guarantees a later interrupt-carrying drain.
+//! BLOCKED = a batch is parked on delivery capacity and stays queued. The caller must yield with a
+//! registered interrupt, or make sure a later drain carries one.
 enum class QuackEmitProgress : uint8_t { DONE, BLOCKED };
 
-//! A stamped batch waiting to be emitted; emission runs outside the stamping lock, on any thread.
+//! A stamped batch that waits for emission. Emission runs outside the stamping lock, on any thread.
 struct QuackEmitTask {
 	QuackEmitTask(idx_t dense_index_p, idx_t memory_usage_p, unique_ptr<QuackPreparedBatch> prepared_p)
 	    : dense_index(dense_index_p), memory_usage(memory_usage_p), prepared(std::move(prepared_p)) {
@@ -97,51 +94,48 @@ struct QuackEmitTask {
 	unique_ptr<QuackPreparedBatch> prepared;
 };
 
-//! Maps sparse executor batches onto dense (1,2,3,…) indices, one fragment = one dense batch.
-//! Stamping is ordered — only the settled prefix (up to and including the current minimum batch,
-//! whose dense prefix is known) is released under the lock — but emission is parallel and out of order.
+//! Maps sparse executor batches onto dense indices 1,2,3,... One fragment becomes one dense batch.
+//! Stamping is ordered: the lock releases only the settled prefix, up to the current minimum batch.
+//! Emission is parallel and out of order.
 class QuackRebalancerCore {
 public:
 	QuackRebalancerCore(ClientContext &context, idx_t buffer_bytes_override_p, idx_t initial_memory_request,
 	                    unique_ptr<QuackBatchEmitter> emitter_p);
 
-	//! Open a fragment accumulator on the calling thread (delegates to the emitter).
 	unique_ptr<QuackFragmentBuilder> OpenFragment(ClientContext &context, idx_t size_hint) {
 		return emitter->OpenFragment(context, size_hint);
 	}
 
-	//! PARALLEL_ORDERED: shelve a sealed fragment of an executor batch (fragments of one batch only
-	//! ever come from its owning thread, in order), then stamp + emit the settled prefix.
+	//! PARALLEL_ORDERED: shelve a sealed fragment, then stamp and emit the settled prefix. All
+	//! fragments of one executor batch come from its owning thread, in order.
 	void AddPendingFragment(ClientContext &context, idx_t executor_batch, idx_t min_batch_index, idx_t memory_usage,
 	                        unique_ptr<QuackPreparedBatch> prepared);
-	//! SERIAL_ORDERED / UNORDERED: stamp a sealed fragment with the next dense index. Emission is the
-	//! caller's job (TryEmitStamped) so a capacity-parked batch can be retried without re-stamping.
+	//! SERIAL_ORDERED / UNORDERED: stamp a sealed fragment. The caller emits it, so a parked batch
+	//! can be retried without a second stamp.
 	unique_ptr<QuackEmitTask> StampSettled(unique_ptr<QuackPreparedBatch> prepared) {
 		return make_uniq<QuackEmitTask>(next_dense++, 0, std::move(prepared));
 	}
-	//! Emit one already-stamped batch; false = parked on delivery capacity (task keeps the batch).
+	//! false = parked on delivery capacity. The task keeps the batch.
 	bool TryEmitStamped(ClientContext &context, QuackEmitTask &task, optional_ptr<const InterruptState> interrupt);
 
-	//! Drain queued emit tasks (capacity-parked retries first, then the settled queue). A null
-	//! interrupt probes: a capacity-parked batch is shelved for a later interrupt-carrying drain.
+	//! Drain the emit tasks: parked retries first, then the settled queue. A null interrupt only
+	//! probes, and it shelves a parked batch for a later drain that carries one.
 	QuackEmitProgress ExecuteTasks(ClientContext &context, optional_ptr<const InterruptState> interrupt = nullptr);
-	//! A capacity-parked emit is waiting for a retry.
 	bool HasParkedEmits() {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		return !parked_tasks.empty();
 	}
 
-	//! Over the pending-bytes budget and not the minimum batch: stop sinking, help emit, maybe block.
+	//! Over the byte budget and not the minimum batch: stop sinking, help to emit, and maybe block.
 	bool OutOfMemory(idx_t batch_index);
 
-	//! Final release: stamp everything still shelved (Finalize).
 	void FinalizeCut(ClientContext &context);
-	//! Stamped batches still queued for emission — lets Finalize decide inline drain vs parallel event.
+	//! Lets Finalize choose between an inline drain and a parallel event.
 	idx_t TaskCount() {
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		return task_manager.TaskCount() + parked_tasks.size();
 	}
-	//! After the last EmitBatch returned: verify accounting and let the emitter close the stream.
+	//! Verify the accounting, then let the emitter close the stream.
 	void FinalizeFinish(ClientContext &context);
 
 	BatchMemoryManager &MemoryManager() {
@@ -161,22 +155,21 @@ private:
 		unique_ptr<QuackPreparedBatch> prepared;
 	};
 
-	//! Stamp every shelved fragment of batches below min_exclusive with the next dense indices and queue
-	//! them for emission — a pointer walk under the lock; the payloads were prepared at cut time.
+	//! Stamp every shelved fragment below min_exclusive and queue it. This is a pointer walk under
+	//! the lock: the payloads were prepared at cut time.
 	void ReleaseSettled(idx_t min_exclusive);
 
 private:
 	BatchMemoryManager memory_manager;
 	BatchTaskManager<QuackEmitTask> task_manager;
 	annotated_mutex lock;
-	//! Prepared fragments of not-yet-settled executor batches, keyed by executor batch index.
 	std::map<idx_t, vector<Fragment>> raw_batches DUCKDB_GUARDED_BY(lock);
-	//! The next dense index to hand out; stamping order defines the stream order.
+	//! Stamping order defines the stream order.
 	atomic<idx_t> next_dense {1};
-	//! Emit tasks that hit delivery capacity mid-drain; retried lowest-index-first (the head of the
-	//! stream is always admitted, so retrying in index order guarantees progress).
+	//! Retried lowest index first. The head of the stream always gets in, so index order makes
+	//! progress certain.
 	std::map<idx_t, unique_ptr<QuackEmitTask>> parked_tasks DUCKDB_GUARDED_BY(lock);
-	//! Test/ops override: >0 also treats this many pending bytes as out-of-memory.
+	//! Test override: a value above 0 also counts this many pending bytes as out of memory.
 	idx_t buffer_bytes_override;
 	unique_ptr<QuackBatchEmitter> emitter;
 };

--- a/src/include/quack_rebalancer_core.hpp
+++ b/src/include/quack_rebalancer_core.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/operator/persistent/batch_memory_manager.hpp"
 #include "duckdb/execution/operator/persistent/batch_task_manager.hpp"
+#include "duckdb/parallel/interrupt.hpp"
 
 namespace duckdb {
 
@@ -64,17 +66,25 @@ private:
 };
 
 //! Emits dense batches: OpenFragment accumulates chunks in emit-ready form on the producing thread
-//! (before the dense index is known); EmitPrepared stamps + sends at release time, concurrently and
-//! out of dense order (receivers reassemble by index). Finish runs once, after all EmitPrepared.
+//! (before the dense index is known); TryEmitPrepared stamps + sends at release time, concurrently
+//! and out of dense order (receivers reassemble by index). Finish runs once, after all emits.
 class QuackBatchEmitter {
 public:
 	virtual ~QuackBatchEmitter() = default;
 	//! size_hint: the previous sealed fragment's size (0 for a thread's first fragment), so
 	//! implementations can pre-reserve capacity and avoid growth copies while accumulating.
 	virtual unique_ptr<QuackFragmentBuilder> OpenFragment(ClientContext &context, idx_t size_hint) = 0;
-	virtual void EmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> batch) = 0;
+	//! false = the delivery target is at capacity and `batch` was NOT consumed (retry the same batch
+	//! later); with `interrupt` set, capacity freeing fires it. Emitters that cannot capacity-block
+	//! consume the batch and always return true.
+	virtual bool TryEmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> &batch,
+	                             optional_ptr<const InterruptState> interrupt) = 0;
 	virtual void Finish(ClientContext &context, idx_t total_batches) = 0;
 };
+
+//! Progress of an emit drain: BLOCKED means a batch is parked on delivery capacity and remains
+//! queued; the caller yields (interrupt registered) or guarantees a later interrupt-carrying drain.
+enum class QuackEmitProgress : uint8_t { DONE, BLOCKED };
 
 //! A stamped batch waiting to be emitted; emission runs outside the stamping lock, on any thread.
 struct QuackEmitTask {
@@ -104,12 +114,22 @@ public:
 	//! ever come from its owning thread, in order), then stamp + emit the settled prefix.
 	void AddPendingFragment(ClientContext &context, idx_t executor_batch, idx_t min_batch_index, idx_t memory_usage,
 	                        unique_ptr<QuackPreparedBatch> prepared);
-	//! SERIAL_ORDERED / UNORDERED: a sealed fragment that is stampable immediately; stamped and emitted inline.
-	void AddSettledData(ClientContext &context, unique_ptr<QuackPreparedBatch> prepared);
+	//! SERIAL_ORDERED / UNORDERED: stamp a sealed fragment with the next dense index. Emission is the
+	//! caller's job (TryEmitStamped) so a capacity-parked batch can be retried without re-stamping.
+	unique_ptr<QuackEmitTask> StampSettled(unique_ptr<QuackPreparedBatch> prepared) {
+		return make_uniq<QuackEmitTask>(next_dense++, 0, std::move(prepared));
+	}
+	//! Emit one already-stamped batch; false = parked on delivery capacity (task keeps the batch).
+	bool TryEmitStamped(ClientContext &context, QuackEmitTask &task, optional_ptr<const InterruptState> interrupt);
 
-	//! Emit one stamped batch if any is queued; returns false when the queue is empty.
-	bool ExecuteTask(ClientContext &context);
-	void ExecuteTasks(ClientContext &context);
+	//! Drain queued emit tasks (capacity-parked retries first, then the settled queue). A null
+	//! interrupt probes: a capacity-parked batch is shelved for a later interrupt-carrying drain.
+	QuackEmitProgress ExecuteTasks(ClientContext &context, optional_ptr<const InterruptState> interrupt = nullptr);
+	//! A capacity-parked emit is waiting for a retry.
+	bool HasParkedEmits() {
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return !parked_tasks.empty();
+	}
 
 	//! Over the pending-bytes budget and not the minimum batch: stop sinking, help emit, maybe block.
 	bool OutOfMemory(idx_t batch_index);
@@ -118,7 +138,8 @@ public:
 	void FinalizeCut(ClientContext &context);
 	//! Stamped batches still queued for emission — lets Finalize decide inline drain vs parallel event.
 	idx_t TaskCount() {
-		return task_manager.TaskCount();
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		return task_manager.TaskCount() + parked_tasks.size();
 	}
 	//! After the last EmitBatch returned: verify accounting and let the emitter close the stream.
 	void FinalizeFinish(ClientContext &context);
@@ -152,6 +173,9 @@ private:
 	std::map<idx_t, vector<Fragment>> raw_batches DUCKDB_GUARDED_BY(lock);
 	//! The next dense index to hand out; stamping order defines the stream order.
 	atomic<idx_t> next_dense {1};
+	//! Emit tasks that hit delivery capacity mid-drain; retried lowest-index-first (the head of the
+	//! stream is always admitted, so retrying in index order guarantees progress).
+	std::map<idx_t, unique_ptr<QuackEmitTask>> parked_tasks DUCKDB_GUARDED_BY(lock);
 	//! Test/ops override: >0 also treats this many pending bytes as out-of-memory.
 	idx_t buffer_bytes_override;
 	unique_ptr<QuackBatchEmitter> emitter;

--- a/src/include/quack_rebalancer_sink.hpp
+++ b/src/include/quack_rebalancer_sink.hpp
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// quack_rebalancer_sink.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/execution/physical_operator.hpp"
+
+#include "quack_rebalancer_core.hpp"
+
+namespace duckdb {
+
+class DatabaseInstance;
+
+//! Single source of truth for the tuning-setting defaults, shared by the registrations in
+//! quack_extension.cpp and every read-site fallback.
+static constexpr idx_t QUACK_TARGET_BATCH_BYTES_DEFAULT = 32ULL * 1024ULL * 1024ULL;
+static constexpr idx_t QUACK_REBALANCE_BUFFER_BYTES_DEFAULT = 0;
+static constexpr idx_t QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT = 256ULL * 1024ULL * 1024ULL;
+static constexpr idx_t QUACK_PREPARE_INLINE_ROWS_DEFAULT = 24576;
+
+//! How a rebalancing sink preserves source order in the dense batch stream it produces.
+enum class AppendOrderMode : uint8_t {
+	UNORDERED,        //! preserve_insertion_order=false → arrival order is the order.
+	PARALLEL_ORDERED, //! parallel thread executors (table/parquet scans); sparse executor batch indices
+	                  //! are stamped densely once settled below the watermark.
+	SERIAL_ORDERED    //! single-threaded sink (e.g. range()); everything is trivially settled.
+};
+
+//! Shared sink-side state for operators built around a QuackRebalancerCore (client INSERT sink,
+//! server fetch collector); they route Sink/NextBatch/Combine/Finalize through the functions below.
+class QuackRebalancerGlobalState : public GlobalSinkState {
+public:
+	QuackRebalancerGlobalState(AppendOrderMode order_mode_p, idx_t target_bytes_p, idx_t minimum_memory_per_thread_p)
+	    : order_mode(order_mode_p), target_bytes(target_bytes_p),
+	      minimum_memory_per_thread(minimum_memory_per_thread_p), row_count(0) {
+	}
+
+	idx_t MaxThreads(idx_t source_max_threads) override;
+
+	AppendOrderMode order_mode;
+	idx_t target_bytes;
+	//! One fragment = one wire message: the cut size IS the message size.
+	idx_t FragmentGrain() const {
+		return target_bytes;
+	}
+	idx_t minimum_memory_per_thread;
+	atomic<idx_t> row_count;
+	unique_ptr<QuackRebalancerCore> core;
+	//! Weak to avoid a cyclical reference; set by operators whose GetResult needs the client context.
+	weak_ptr<ClientContext> client_context;
+};
+
+class QuackRebalancerLocalState : public LocalSinkState {
+public:
+	//! The fragment this thread is currently building (opened lazily on the first chunk).
+	unique_ptr<QuackFragmentBuilder> builder;
+	//! Size of the last sealed fragment — pre-reservation hint for the next OpenFragment.
+	idx_t size_hint = 0;
+	//! Memory accounted to the global manager for the current builder (PARALLEL_ORDERED only).
+	idx_t local_memory_usage = 0;
+	//! Buffered bytes in the current builder and the last chunk's contribution (pre-append cut check).
+	idx_t fragment_bytes = 0;
+	idx_t last_chunk_bytes = 0;
+	idx_t local_count = 0;
+	//! PARALLEL_ORDERED: executor batch currently being buffered (invalid before first Sink/NextBatch).
+	optional_idx batch_index;
+	//! PARALLEL_ORDERED: over budget — help emit queued batches instead of sinking.
+	bool processing_tasks = false;
+};
+
+//! Build the shared global state + core for a rebalancing sink: reads quack_target_batch_bytes /
+//! quack_rebalance_buffer_bytes, applies the core batch-operator memory heuristic, wires the emitter.
+unique_ptr<QuackRebalancerGlobalState> MakeQuackRebalancerGlobalState(ClientContext &context,
+                                                                      const vector<LogicalType> &types,
+                                                                      AppendOrderMode order_mode,
+                                                                      unique_ptr<QuackBatchEmitter> emitter);
+
+SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input);
+SinkNextBatchType QuackRebalancerNextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input);
+SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, OperatorSinkCombineInput &input);
+SinkFinalizeType QuackRebalancerFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                         QuackRebalancerGlobalState &gstate);
+
+//! Read an unsigned setting with a fallback default.
+idx_t QuackGetUBigintSetting(ClientContext &context, const char *name, idx_t default_value);
+idx_t QuackGetUBigintSetting(DatabaseInstance &db, const char *name, idx_t default_value);
+
+} // namespace duckdb

--- a/src/include/quack_rebalancer_sink.hpp
+++ b/src/include/quack_rebalancer_sink.hpp
@@ -16,23 +16,22 @@ namespace duckdb {
 
 class DatabaseInstance;
 
-//! Single source of truth for the tuning-setting defaults, shared by the registrations in
-//! quack_extension.cpp and every read-site fallback.
+//! The defaults for the tuning settings. quack_extension.cpp and every read site use these.
 static constexpr idx_t QUACK_TARGET_BATCH_BYTES_DEFAULT = 32ULL * 1024ULL * 1024ULL;
 static constexpr idx_t QUACK_REBALANCE_BUFFER_BYTES_DEFAULT = 0;
 static constexpr idx_t QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT = 256ULL * 1024ULL * 1024ULL;
 static constexpr idx_t QUACK_PREPARE_INLINE_ROWS_DEFAULT = 24576;
 
-//! How a rebalancing sink preserves source order in the dense batch stream it produces.
+//! How a rebalancing sink keeps the source order in the dense batch stream.
 enum class AppendOrderMode : uint8_t {
-	UNORDERED,        //! preserve_insertion_order=false → arrival order is the order.
-	PARALLEL_ORDERED, //! parallel thread executors (table/parquet scans); sparse executor batch indices
-	                  //! are stamped densely once settled below the watermark.
-	SERIAL_ORDERED    //! single-threaded sink (e.g. range()); everything is trivially settled.
+	UNORDERED,        //! preserve_insertion_order is off: arrival order is the order.
+	PARALLEL_ORDERED, //! a parallel source: sparse executor batch indices become dense once they
+	                  //! settle below the watermark.
+	SERIAL_ORDERED    //! a single-threaded sink: every fragment is settled on arrival.
 };
 
-//! Shared sink-side state for operators built around a QuackRebalancerCore (client INSERT sink,
-//! server fetch collector); they route Sink/NextBatch/Combine/Finalize through the functions below.
+//! Sink state shared by the operators that use a QuackRebalancerCore: the client INSERT sink and
+//! the server fetch collector. Both route Sink/NextBatch/Combine/Finalize through the functions below.
 class QuackRebalancerGlobalState : public GlobalSinkState {
 public:
 	QuackRebalancerGlobalState(AppendOrderMode order_mode_p, idx_t target_bytes_p, idx_t minimum_memory_per_thread_p)
@@ -44,40 +43,39 @@ public:
 
 	AppendOrderMode order_mode;
 	idx_t target_bytes;
-	//! One fragment = one wire message: the cut size IS the message size.
+	//! One fragment is one wire message, so the cut size IS the message size.
 	idx_t FragmentGrain() const {
 		return target_bytes;
 	}
 	idx_t minimum_memory_per_thread;
 	atomic<idx_t> row_count;
 	unique_ptr<QuackRebalancerCore> core;
-	//! Weak to avoid a cyclical reference; set by operators whose GetResult needs the client context.
+	//! Weak, to prevent a reference cycle. Set only if GetResult needs the client context.
 	weak_ptr<ClientContext> client_context;
 };
 
 class QuackRebalancerLocalState : public LocalSinkState {
 public:
-	//! The fragment this thread is currently building (opened lazily on the first chunk).
 	unique_ptr<QuackFragmentBuilder> builder;
-	//! Size of the last sealed fragment — pre-reservation hint for the next OpenFragment.
+	//! The size of the last sealed fragment: a reservation hint for the next OpenFragment.
 	idx_t size_hint = 0;
-	//! Memory accounted to the global manager for the current builder (PARALLEL_ORDERED only).
+	//! PARALLEL_ORDERED: the memory the global manager counts for the current builder.
 	idx_t local_memory_usage = 0;
-	//! Buffered bytes in the current builder and the last chunk's contribution (pre-append cut check).
+	//! The builder's bytes, and the last chunk's part of them. The cut check reads both.
 	idx_t fragment_bytes = 0;
 	idx_t last_chunk_bytes = 0;
 	idx_t local_count = 0;
-	//! PARALLEL_ORDERED: executor batch currently being buffered (invalid before first Sink/NextBatch).
+	//! PARALLEL_ORDERED: the executor batch in the builder. Invalid before the first Sink/NextBatch.
 	optional_idx batch_index;
-	//! PARALLEL_ORDERED: over budget — help emit queued batches instead of sinking.
+	//! PARALLEL_ORDERED: over budget, so help to emit queued batches instead of sinking.
 	bool processing_tasks = false;
-	//! SERIAL_ORDERED / UNORDERED: a stamped batch parked on delivery capacity; retried (same index,
-	//! same payload) at the top of the next Sink call or in Combine before anything else runs.
+	//! SERIAL_ORDERED / UNORDERED: a stamped batch parked on delivery capacity. The next Sink call,
+	//! or Combine, retries the same index and the same payload before it does anything else.
 	unique_ptr<QuackEmitTask> pending_emit;
 };
 
-//! Build the shared global state + core for a rebalancing sink: reads quack_target_batch_bytes /
-//! quack_rebalance_buffer_bytes, applies the core batch-operator memory heuristic, wires the emitter.
+//! Build the global state and the core. Reads quack_target_batch_bytes and
+//! quack_rebalance_buffer_bytes, applies core's batch-operator memory heuristic, wires the emitter.
 unique_ptr<QuackRebalancerGlobalState> MakeQuackRebalancerGlobalState(ClientContext &context,
                                                                       const vector<LogicalType> &types,
                                                                       AppendOrderMode order_mode,
@@ -89,7 +87,6 @@ SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, Operator
 SinkFinalizeType QuackRebalancerFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                          QuackRebalancerGlobalState &gstate);
 
-//! Read an unsigned setting with a fallback default.
 idx_t QuackGetUBigintSetting(ClientContext &context, const char *name, idx_t default_value);
 idx_t QuackGetUBigintSetting(DatabaseInstance &db, const char *name, idx_t default_value);
 

--- a/src/include/quack_rebalancer_sink.hpp
+++ b/src/include/quack_rebalancer_sink.hpp
@@ -71,6 +71,9 @@ public:
 	optional_idx batch_index;
 	//! PARALLEL_ORDERED: over budget — help emit queued batches instead of sinking.
 	bool processing_tasks = false;
+	//! SERIAL_ORDERED / UNORDERED: a stamped batch parked on delivery capacity; retried (same index,
+	//! same payload) at the top of the next Sink call or in Combine before anything else runs.
+	unique_ptr<QuackEmitTask> pending_emit;
 };
 
 //! Build the shared global state + core for a rebalancing sink: reads quack_target_batch_bytes /

--- a/src/include/quack_result_cache.hpp
+++ b/src/include/quack_result_cache.hpp
@@ -12,12 +12,9 @@ class DatabaseInstance;
 struct QuackConnection;
 struct QuackFetchStream;
 
-//! Server-side retention of a connection's last client query, so a client that loses the
-//! connection can be served the same bytes again.
-//!
-//! The fetch stream already keeps every payload it has served, keyed by dense batch index, so a
-//! transport retry gets identical bytes. This cache is that retention held open: it pins the
-//! stream past the point the client's acks would otherwise release it, and counts what it holds.
+//! Keeps a connection's last client query, so a client that reconnects can get the same bytes.
+//! The fetch stream already holds each payload it served, for a transport retry. This cache holds
+//! that retention open after the client acks, and counts what it holds.
 struct QuackResultCache {
 	QuackResultCache(string sql_p, hugeint_t query_uuid_p, shared_ptr<QuackFetchStream> stream_p,
 	                 shared_ptr<atomic<idx_t>> live_caches_p)
@@ -36,7 +33,7 @@ struct QuackResultCache {
 	string sql;
 	//! UUID the cached query is currently served under.
 	hugeint_t query_uuid;
-	//! Its own reference, so an internal query swapping the connection's stream cannot drop it.
+	//! Held here too, because an internal query can replace the connection's stream.
 	shared_ptr<QuackFetchStream> stream;
 	//! Rows in the payloads the stream is holding for this cache.
 	idx_t retained_rows = 0;
@@ -56,9 +53,8 @@ idx_t CacheMaxRows(DatabaseInstance &db);
 int64_t ResultTtlMicros(DatabaseInstance &db);
 
 //! Detaches the cache once idle past the TTL, failing an unfinished stream like a cancelled query.
-//! Returns the doomed cache (null if kept) so the caller can destroy it off the request path. The
-//! caller must abort the connection's fetch stream when `still_serving` comes back true, which
-//! releases the abandoned query behind it.
+//! Returns the cache, so the caller can destroy it off the request path. If `still_serving` is
+//! true, the caller must also abort the fetch stream. That releases the abandoned query.
 unique_ptr<QuackResultCache> ExpireCacheIfStale(QuackConnection &connection, timestamp_t now, int64_t ttl_micros,
                                                 bool &still_serving);
 

--- a/src/include/quack_result_cache.hpp
+++ b/src/include/quack_result_cache.hpp
@@ -3,22 +3,25 @@
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/types.hpp"
-#include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/vector.hpp"
-#include "duckdb/main/query_result.hpp"
 
 namespace duckdb {
 
 class DatabaseInstance;
-class DataChunkWrapper;
 struct QuackConnection;
+struct QuackFetchStream;
 
-//! Replayable server-side copy of the result stream of a connection's last client query
+//! Server-side retention of a connection's last client query, so a client that loses the
+//! connection can be served the same bytes again.
+//!
+//! The fetch stream already keeps every payload it has served, keyed by dense batch index, so a
+//! transport retry gets identical bytes. This cache is that retention held open: it pins the
+//! stream past the point the client's acks would otherwise release it, and counts what it holds.
 struct QuackResultCache {
-	QuackResultCache(BufferManager &buffer_manager, string sql_p, hugeint_t query_uuid_p, vector<LogicalType> types,
+	QuackResultCache(string sql_p, hugeint_t query_uuid_p, shared_ptr<QuackFetchStream> stream_p,
 	                 shared_ptr<atomic<idx_t>> live_caches_p)
-	    : sql(std::move(sql_p)), query_uuid(query_uuid_p), retained(buffer_manager, std::move(types)),
+	    : sql(std::move(sql_p)), query_uuid(query_uuid_p), stream(std::move(stream_p)),
 	      last_served_at(Timestamp::GetCurrentTimestamp()), live_caches(std::move(live_caches_p)) {
 		D_ASSERT(live_caches);
 		(*live_caches)++;
@@ -33,10 +36,10 @@ struct QuackResultCache {
 	string sql;
 	//! UUID the cached query is currently served under.
 	hugeint_t query_uuid;
-	//! Chunks retained as they are served, buffer managed so cached data counts against the memory limit
-	ColumnDataCollection retained;
-	//! Unproduced remainder of the live result
-	unique_ptr<QueryResult> tail;
+	//! Its own reference, so an internal query swapping the connection's stream cannot drop it.
+	shared_ptr<QuackFetchStream> stream;
+	//! Rows in the payloads the stream is holding for this cache.
+	idx_t retained_rows = 0;
 	//! Last time this cache served a batch, anchors the quack_result_ttl expiry clock
 	timestamp_t last_served_at {0};
 	//! Caches live on the owning server, counted so the TTL sweep can skip a server with nothing cached
@@ -53,13 +56,10 @@ idx_t CacheMaxRows(DatabaseInstance &db);
 int64_t ResultTtlMicros(DatabaseInstance &db);
 
 //! Detaches the cache once idle past the TTL, failing an unfinished stream like a cancelled query.
-//! Returns the doomed cache (null if kept) so the caller can destroy it off the request path.
-unique_ptr<QuackResultCache> ExpireCacheIfStale(QuackConnection &connection, timestamp_t now, int64_t ttl_micros);
-
-//! True while the connection's active query still has unserved chunks (cached or live).
-bool HasMoreResults(QuackConnection &connection);
-
-//! Serve up to max_rows of the active query.
-vector<unique_ptr<DataChunkWrapper>> ServeBatch(QuackConnection &connection, idx_t max_rows, idx_t max_cache_rows);
+//! Returns the doomed cache (null if kept) so the caller can destroy it off the request path. The
+//! caller must abort the connection's fetch stream when `still_serving` comes back true, which
+//! releases the abandoned query behind it.
+unique_ptr<QuackResultCache> ExpireCacheIfStale(QuackConnection &connection, timestamp_t now, int64_t ttl_micros,
+                                                bool &still_serving);
 
 } // namespace duckdb

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -92,8 +92,6 @@ struct QuackConnection {
 	//! producer and the insert driver both take it; request handlers must not.
 	mutex statement_lock;
 	unique_ptr<Connection> duckdb_connection;
-	//! Only the result cache reads this now. The fetch stream carries the client's result.
-	unique_ptr<QueryResult> duckdb_query_result;
 	//! Replay cache of the last client query's result stream, null unless quack_enable_reconnects.
 	unique_ptr<QuackResultCache> result_cache;
 	//! The owning server's live-cache counter, handed to every cache this connection creates.
@@ -105,7 +103,7 @@ struct QuackConnection {
 	string session_id;
 
 	void SyncCachedRows() {
-		cached_rows = result_cache ? result_cache->retained.Count() : DConstants::INVALID_INDEX;
+		cached_rows = result_cache ? result_cache->retained_rows : DConstants::INVALID_INDEX;
 	}
 
 	//! The only way to drop the cache, keeps the lock-free cached_rows mirror in sync with the drop

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -21,6 +21,7 @@ class Connection;
 class MemoryStream;
 class QueryResult;
 class DatabaseInstance;
+struct QuackFetchStream;
 class PreparedStatement;
 class EncryptionState;
 class QuackDataStream;
@@ -61,15 +62,24 @@ struct QuackInsertState {
 	shared_ptr<QuackDataStream> StreamForDeadRangeOrBuffer(const string &sid, idx_t lo, idx_t hi);
 };
 
+//! The fetch-collector stream the connection's active query fills (one at a time): the query runs on a
+//! background thread with a rebalancing result collector; FETCH handlers drain the stream's buffer.
+struct QuackFetchState {
+	mutex lock;
+	shared_ptr<QuackFetchStream> stream;
+	std::thread thread;
+	hugeint_t uuid = 0;
+	//! Abort tombstone: late FETCHes for this uuid get the failure deterministically without keeping
+	//! the stream (and its buffered payloads) alive.
+	ErrorData abort_error;
+};
+
 struct QuackConnection {
 	explicit QuackConnection(string session_id_p);
 	~QuackConnection();
 
 	mutex lock;
 	unique_ptr<Connection> duckdb_connection;
-	unique_ptr<QueryResult> duckdb_query_result;
-	//! Monotonic counter assigned per FETCH batch — enables order-preserving parallel scans on
-	idx_t next_batch_index = 1;
 	//! Current query UUID
 	hugeint_t query_uuid;
 	string session_id;
@@ -83,6 +93,8 @@ struct QuackConnection {
 
 	//! The INSERT this connection is currently driving via a client SEND_DATA stream (one at a time).
 	QuackInsertState insert;
+	//! The client-facing query result this connection is currently producing.
+	QuackFetchState fetch;
 };
 
 struct QuackConnectionSnapshot {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -85,7 +85,12 @@ struct QuackConnection {
 	//! True if the lease timeout has elapsed, latching the expiry ("cannot be revived").
 	bool LeaseExpiredLocked(time_point<steady_clock> now) DUCKDB_REQUIRES(lease_lock);
 
+	//! Short-held: guards the session state below (sql_query, query_state, query_started_at,
+	//! query_uuid) and the result cache. Never held across a statement.
 	mutex lock;
+	//! Held for a whole statement on `duckdb_connection`, which runs one at a time. The fetch
+	//! producer and the insert driver both take it; request handlers must not.
+	mutex statement_lock;
 	unique_ptr<Connection> duckdb_connection;
 	//! Only the result cache reads this now. The fetch stream carries the client's result.
 	unique_ptr<QueryResult> duckdb_query_result;
@@ -124,7 +129,8 @@ struct QuackConnection {
 	bool lease_expired DUCKDB_GUARDED_BY(lease_lock) = false;
 
 	string sql_query;
-	QuackQueryState query_state = QuackQueryState::IDLE;
+	//! Read unlocked by the cache sweep and the connection listing, so it must be atomic.
+	atomic<QuackQueryState> query_state {QuackQueryState::IDLE};
 	timestamp_t query_started_at {0};
 
 	//! The INSERT this connection is currently driving via a client SEND_DATA stream (one at a time).

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -85,11 +85,10 @@ struct QuackConnection {
 	//! True if the lease timeout has elapsed, latching the expiry ("cannot be revived").
 	bool LeaseExpiredLocked(time_point<steady_clock> now) DUCKDB_REQUIRES(lease_lock);
 
-	//! Short-held: guards the session state below (sql_query, query_state, query_started_at,
-	//! query_uuid) and the result cache. Never held across a statement.
+	//! Guards the session state below and the result cache. Never held across a statement.
 	mutex lock;
-	//! Held for a whole statement on `duckdb_connection`, which runs one at a time. The fetch
-	//! producer and the insert driver both take it; request handlers must not.
+	//! Held for a whole statement, because `duckdb_connection` runs one at a time. The fetch
+	//! producer and the insert driver take it. Request handlers must not.
 	mutex statement_lock;
 	unique_ptr<Connection> duckdb_connection;
 	//! Replay cache of the last client query's result stream, null unless quack_enable_reconnects.

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -62,15 +62,14 @@ struct QuackInsertState {
 	shared_ptr<QuackDataStream> StreamForDeadRangeOrBuffer(const string &sid, idx_t lo, idx_t hi);
 };
 
-//! The fetch-collector stream the connection's active query fills (one at a time): the query runs on a
-//! background thread with a rebalancing result collector; FETCH handlers drain the stream's buffer.
+//! The stream the connection's active query fills, one at a time. The query runs on a background
+//! thread with a rebalancing result collector, and the FETCH handlers drain the stream's buffer.
 struct QuackFetchState {
 	mutex lock;
 	shared_ptr<QuackFetchStream> stream;
 	std::thread thread;
 	hugeint_t uuid = 0;
-	//! Abort tombstone: late FETCHes for this uuid get the failure deterministically without keeping
-	//! the stream (and its buffered payloads) alive.
+	//! A late FETCH for this uuid gets this error. The stream and its payloads can then go away.
 	ErrorData abort_error;
 };
 
@@ -93,7 +92,6 @@ struct QuackConnection {
 
 	//! The INSERT this connection is currently driving via a client SEND_DATA stream (one at a time).
 	QuackInsertState insert;
-	//! The client-facing query result this connection is currently producing.
 	QuackFetchState fetch;
 };
 

--- a/src/include/storage/quack_insert.hpp
+++ b/src/include/storage/quack_insert.hpp
@@ -11,15 +11,9 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/common/index_vector.hpp"
 
-namespace duckdb {
+#include "quack_rebalancer_sink.hpp"
 
-//! How an INSERT preserves source order when uploading rows to the server.
-enum class AppendOrderMode : uint8_t {
-	UNORDERED,        //! preserve_insertion_order=false → fast path, no stamp.
-	PARALLEL_ORDERED, //! parallel thread executors (table/parquet scans); each thread stamps chunks with
-	                  //! (executor batch_index, sequence_index, is_last_in_batch); server reorders.
-	SERIAL_ORDERED    //! single-threaded sink (e.g. range()); the lone producer mints a new batch per flush.
-};
+namespace duckdb {
 
 class QuackInsert : public PhysicalOperator {
 public:

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -20,6 +20,7 @@
 #include "quack_clear_cache.hpp"
 #include "quack_extension.hpp"
 #include "quack_log.hpp"
+#include "quack_rebalancer_sink.hpp"
 #include "quack_scan.hpp"
 #include "quack_scan_from_client.hpp"
 #include "quack_cancel.hpp"
@@ -173,10 +174,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_authorization_function", "Name of a callback function for authorization",
 	                          LogicalType::VARCHAR, Value("quack_nop_authorization"), nullptr, SetScope::GLOBAL);
 
-	config.AddExtensionOption("quack_fetch_batch_rows",
-	                          "Rows accumulated per FETCH response batch (whole DataChunks, so the last chunk "
-	                          "may overshoot the cap)",
-	                          LogicalType::UBIGINT, Value::UBIGINT(24576));
+	config.AddExtensionOption("quack_prepare_inline_rows",
+	                          "Rows returned inline in the PREPARE response before the remainder is left to "
+	                          "FETCH; drains whole batches, so it may overshoot to a batch boundary",
+	                          LogicalType::UBIGINT, Value::UBIGINT(QUACK_PREPARE_INLINE_ROWS_DEFAULT));
 
 	config.AddExtensionOption("quack_fetch_read_ahead",
 	                          "FETCH requests kept in flight ahead of the scan (0 = number of async threads)",
@@ -187,9 +188,29 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "stressing out-of-order batch arrival",
 	                          LogicalType::UBIGINT, Value::UBIGINT(0));
 
+	config.AddExtensionOption("quack_debug_emit_delay_ms",
+	                          "DEBUG SETTING: max random delay in ms before the fetch collector publishes a "
+	                          "batch, stressing out-of-order emission",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+
+	config.AddExtensionOption("quack_target_batch_bytes",
+	                          "Target in-memory size of one rebalanced batch (one wire message payload); "
+	                          "batches are cut when they reach this size",
+	                          LogicalType::UBIGINT, Value::UBIGINT(QUACK_TARGET_BATCH_BYTES_DEFAULT));
+
+	config.AddExtensionOption("quack_rebalance_buffer_bytes",
+	                          "Pending (unstamped) bytes the batch rebalancer buffers before gating non-minimum "
+	                          "producers (0 = automatic, memory-manager governed)",
+	                          LogicalType::UBIGINT, Value::UBIGINT(QUACK_REBALANCE_BUFFER_BYTES_DEFAULT));
+
 	config.AddExtensionOption("quack_send_data_flush_rows",
 	                          "Rows a thread buffers before flushing one SEND_DATA_REQUEST (0 = default 204800)",
 	                          LogicalType::UBIGINT, Value::UBIGINT(0));
+
+	config.AddExtensionOption("quack_fetch_producer_buffer_bytes",
+	                          "Server-side cap on bytes buffered ahead by the fetch collector; the query "
+	                          "executor blocks when the client falls this far behind",
+	                          LogicalType::UBIGINT, Value::UBIGINT(QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT));
 
 	config.AddExtensionOption("quack_server_max_connections",
 	                          "Maximum concurrent connections the RPC server accepts; beyond this new "

--- a/src/quack_fetch_ahead.cpp
+++ b/src/quack_fetch_ahead.cpp
@@ -46,8 +46,7 @@ private:
 		auto &client = client_wrapper->GetClient();
 		auto start_time = QuackNowMillis();
 		// context=nullptr: called off the execution thread, must not touch ClientContext.
-		// This task's payload names its batch index, so an HTTP-level retry of this POST asks the
-		// server for the SAME batch again instead of popping the next one.
+		// The payload names its batch index, so an HTTP retry asks for the SAME batch again.
 		auto response_body = client.PostRaw(nullptr, payload->GetData(), payload_size);
 		auto duration_ms = QuackNowMillis() - start_time;
 
@@ -78,7 +77,7 @@ private:
 		}
 		bool pushed = false;
 		if (wrappers.empty()) {
-			// terminal response: this request's index lies beyond the stream's total
+			// terminal response: this index is above the stream's total
 			auto total = fetch_response.TotalBatches();
 			if (total.IsValid()) {
 				fetcher.expected_total = total.GetIndex();
@@ -112,9 +111,8 @@ private:
 private:
 	QuackFetcher &fetcher;
 	unique_ptr<QuackClientWrapper> client_wrapper;
-	//! The client-visible batch index this task requests; fixed at registration.
 	idx_t request_index;
-	//! This task's encoded FETCH request (index + ack baked in); identical across HTTP retries.
+	//! The encoded request. It holds the index and the ack, and it does not change on a retry.
 	unique_ptr<MemoryStream> payload;
 	idx_t payload_size;
 };
@@ -152,7 +150,7 @@ QuackFetcher::QuackFetcher(ClientContext &context, QuackClientConnection &connec
 	this->query_uuid = query_uuid;
 	connection_id = connection.ConnectionId();
 	logger = context.logger;
-	// Captured once: async tasks read it concurrently for request logging, and it is per-query state.
+	// Read once: the async tasks read it together, and it belongs to this query.
 	if (context.transaction.HasActiveTransaction()) {
 		auto raw_query_id = context.transaction.GetActiveQuery();
 		if (raw_query_id != DConstants::INVALID_INDEX) {
@@ -230,8 +228,8 @@ void QuackFetcher::TopUp(ClientContext &context) {
 			client = std::move(idle_clients.back());
 			idle_clients.pop_back();
 		}
-		// Each task requests one explicit index, assigned in dense order; its payload is encoded once
-		// here (with the current ack) and never changes, so HTTP retries are idempotent.
+		// Each task asks for one index, in dense order. Its payload is encoded once here, with the
+		// current ack, and it does not change. An HTTP retry is therefore safe.
 		auto request_index = next_request++;
 		FetchRequestMessage fetch_msg(connection_id, query_uuid, request_index, CurrentAck());
 		auto request_payload = make_uniq<MemoryStream>();
@@ -273,8 +271,8 @@ void QuackFetcher::FinishTask(unique_ptr<QuackClientWrapper> client, bool pushed
 		--outstanding;
 	}
 	if (--in_flight == 0 && no_more_fetches) {
-		// Clean end of stream: validate against the server's announced total (the buffer counted its
-		// own pushes), so lost batches fail loudly. Error/cancel paths never reach here with a total.
+		// A clean end: check the buffer's push count against the total the server announced, so a
+		// lost batch fails. An error or a cancel never reaches this point with a total.
 		auto expected = expected_total.load();
 		buffer->Finish(expected == DConstants::INVALID_INDEX ? optional_idx() : optional_idx(expected));
 	}

--- a/src/quack_fetch_ahead.cpp
+++ b/src/quack_fetch_ahead.cpp
@@ -14,125 +14,16 @@
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
-// QuackFetchBuffer
-//===--------------------------------------------------------------------===//
-idx_t QuackFetchBuffer::ClaimBatch() {
-	annotated_lock_guard<annotated_mutex> guard(lock);
-	return next_claim++;
-}
-
-void QuackFetchBuffer::PushBatch(idx_t batch_index, vector<unique_ptr<DataChunk>> chunks) {
-	shared_ptr<ReadAheadJobCompletion> waiter;
-	{
-		annotated_lock_guard<annotated_mutex> guard(lock);
-		if (finished || errored) {
-			return;
-		}
-		batches[batch_index] = std::move(chunks);
-		auto entry = waiters.find(batch_index);
-		if (entry != waiters.end()) {
-			waiter = std::move(entry->second);
-			waiters.erase(entry);
-		}
-	}
-	cv.notify_all();
-	if (waiter) {
-		// wakes exactly the scan task parked on this batch index
-		waiter->FinishIOTask();
-	}
-}
-
-shared_ptr<ReadAheadJobCompletion> QuackFetchBuffer::RegisterWaiter(idx_t claim) {
-	annotated_lock_guard<annotated_mutex> guard(lock);
-	// Checked under the same lock PushBatch inserts with, so a concurrent publish either
-	// makes us retry the pop here or finds the registered waiter — no lost wakeup.
-	if (batches.find(claim) != batches.end() || finished || errored) {
-		return nullptr;
-	}
-	auto entry = waiters.find(claim);
-	if (entry != waiters.end()) {
-		return entry->second;
-	}
-	auto completion = make_shared_ptr<ReadAheadJobCompletion>(1);
-	waiters.emplace(claim, completion);
-	return completion;
-}
-
-QuackFetchBuffer::PopStatus QuackFetchBuffer::TryPopClaimed(idx_t claim, vector<unique_ptr<DataChunk>> &chunks_out) {
-	annotated_lock_guard<annotated_mutex> guard(lock);
-	if (errored) {
-		return PopStatus::ERRORED;
-	}
-	auto entry = batches.find(claim);
-	if (entry != batches.end()) {
-		chunks_out = std::move(entry->second);
-		batches.erase(entry);
-		return PopStatus::BATCH;
-	}
-	// Indices are dense and Finish() runs after the last push, so an absent claim can never arrive.
-	if (finished) {
-		return PopStatus::FINISHED;
-	}
-	return PopStatus::EMPTY;
-}
-
-void QuackFetchBuffer::WaitForBatch(idx_t claim) {
-	annotated_unique_lock<annotated_mutex> guard(lock);
-	if (batches.find(claim) != batches.end() || finished || errored) {
-		return;
-	}
-	// Bounded wait so the scan can re-check cancellation even if the batch never arrives.
-	cv.wait_for(guard, std::chrono::milliseconds(200));
-}
-
-void QuackFetchBuffer::Finish() {
-	std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
-	{
-		annotated_lock_guard<annotated_mutex> guard(lock);
-		finished = true;
-		drained = std::move(waiters);
-		waiters.clear();
-	}
-	cv.notify_all();
-	// wake every parked claimant so it observes FINISHED
-	for (auto &entry : drained) {
-		entry.second->FinishIOTask();
-	}
-}
-
-void QuackFetchBuffer::SetError(ErrorData error_p) {
-	std::map<idx_t, shared_ptr<ReadAheadJobCompletion>> drained;
-	{
-		annotated_lock_guard<annotated_mutex> guard(lock);
-		if (!errored) {
-			errored = true;
-			error = std::move(error_p);
-		}
-		finished = true;
-		drained = std::move(waiters);
-		waiters.clear();
-	}
-	cv.notify_all();
-	// wake every parked claimant so it observes ERRORED
-	for (auto &entry : drained) {
-		entry.second->FinishIOTask();
-	}
-}
-
-ErrorData QuackFetchBuffer::GetError() {
-	annotated_lock_guard<annotated_mutex> guard(lock);
-	return error;
-}
-
-//===--------------------------------------------------------------------===//
 // Async fetch task
 //===--------------------------------------------------------------------===//
 // Runs the FETCH POST + response decode on an ASYNC-pool thread, publishing the decoded batch.
 // TODO: possibly converge with core's multi-file read-ahead abstraction.
 class QuackFetchDataTask : public AsyncTask {
 public:
-	QuackFetchDataTask(QuackFetcher &fetcher_p, unique_ptr<QuackClientWrapper> client_wrapper_p)
-	    : fetcher(fetcher_p), client_wrapper(std::move(client_wrapper_p)) {
+	QuackFetchDataTask(QuackFetcher &fetcher_p, unique_ptr<QuackClientWrapper> client_wrapper_p, idx_t request_index_p,
+	                   unique_ptr<MemoryStream> payload_p, idx_t payload_size_p)
+	    : fetcher(fetcher_p), client_wrapper(std::move(client_wrapper_p)), request_index(request_index_p),
+	      payload(std::move(payload_p)), payload_size(payload_size_p) {
 	}
 
 	void Execute() override {
@@ -155,7 +46,9 @@ private:
 		auto &client = client_wrapper->GetClient();
 		auto start_time = QuackNowMillis();
 		// context=nullptr: called off the execution thread, must not touch ClientContext.
-		auto response_body = client.PostRaw(nullptr, fetcher.payload->GetData(), fetcher.payload_size);
+		// This task's payload names its batch index, so an HTTP-level retry of this POST asks the
+		// server for the SAME batch again instead of popping the next one.
+		auto response_body = client.PostRaw(nullptr, payload->GetData(), payload_size);
 		auto duration_ms = QuackNowMillis() - start_time;
 
 		auto response = QuackClient::DecodeResponse(response_body);
@@ -185,11 +78,20 @@ private:
 		}
 		bool pushed = false;
 		if (wrappers.empty()) {
+			// terminal response: this request's index lies beyond the stream's total
+			auto total = fetch_response.TotalBatches();
+			if (total.IsValid()) {
+				fetcher.expected_total = total.GetIndex();
+			}
 			fetcher.no_more_fetches = true;
 		} else {
 			auto batch_index = fetch_response.BatchIndex();
 			if (!batch_index.IsValid()) {
 				throw IOException("fetch_response with data is missing its batch index");
+			}
+			if (batch_index.GetIndex() != request_index) {
+				throw IOException("fetch_response carries batch %llu but batch %llu was requested",
+				                  batch_index.GetIndex(), request_index);
 			}
 			// Convert to owned chunks (buffers are shared, Reference is cheap) so decode stays here.
 			vector<unique_ptr<DataChunk>> chunks;
@@ -200,8 +102,8 @@ private:
 				owned->Reference(wrapper->Chunk());
 				chunks.push_back(std::move(owned));
 			}
-			// the thread that claimed this index pops exactly this batch
-			fetcher.buffer->PushBatch(batch_index.GetIndex(), std::move(chunks));
+			fetcher.buffer->PushBatch(request_index, std::move(chunks));
+			fetcher.RecordReceived(request_index);
 			pushed = true;
 		}
 		fetcher.FinishTask(nullptr, pushed);
@@ -210,6 +112,11 @@ private:
 private:
 	QuackFetcher &fetcher;
 	unique_ptr<QuackClientWrapper> client_wrapper;
+	//! The client-visible batch index this task requests; fixed at registration.
+	idx_t request_index;
+	//! This task's encoded FETCH request (index + ack baked in); identical across HTTP retries.
+	unique_ptr<MemoryStream> payload;
+	idx_t payload_size;
 };
 
 //===--------------------------------------------------------------------===//
@@ -242,18 +149,21 @@ QuackFetcher::QuackFetcher(ClientContext &context, QuackClientConnection &connec
 	// Claims start at 1: server-assigned FETCH batch indices are dense from 1 (the PREPARE batch is 0).
 	buffer = make_shared_ptr<QuackFetchBuffer>();
 
-	FetchRequestMessage fetch_msg(connection.ConnectionId(), query_uuid);
-	payload = make_uniq<MemoryStream>();
-	QuackClient::EncodeRequest(context, fetch_msg, *payload);
-	payload_size = payload->GetPosition();
-	connection_id = fetch_msg.ConnectionId();
-	client_query_id = fetch_msg.ClientQueryId();
+	this->query_uuid = query_uuid;
+	connection_id = connection.ConnectionId();
 	logger = context.logger;
+	// Captured once: async tasks read it concurrently for request logging, and it is per-query state.
+	if (context.transaction.HasActiveTransaction()) {
+		auto raw_query_id = context.transaction.GetActiveQuery();
+		if (raw_query_id != DConstants::INVALID_INDEX) {
+			client_query_id = raw_query_id;
+		}
+	}
 
 	for (idx_t i = 0; i < depth; i++) {
 		idle_clients.push_back(connection.GetClient(context));
 	}
-	TopUp();
+	TopUp(context);
 }
 
 QuackFetcher::~QuackFetcher() {
@@ -267,19 +177,19 @@ QuackFetchResult QuackFetcher::GetBatch(ClientContext &context, TableFunctionInp
 	}
 	while (true) {
 		switch (buffer->TryPopClaimed(claim.GetIndex(), chunks)) {
-		case QuackFetchBuffer::PopStatus::BATCH:
+		case QuackClaimPopStatus::BATCH:
 			batch_index = claim.GetIndex();
 			claim = optional_idx();
-			BatchConsumed();
+			BatchConsumed(context);
 			return QuackFetchResult::BATCH;
-		case QuackFetchBuffer::PopStatus::FINISHED:
+		case QuackClaimPopStatus::FINISHED:
 			return QuackFetchResult::FINISHED;
-		case QuackFetchBuffer::PopStatus::ERRORED:
+		case QuackClaimPopStatus::ERRORED:
 			buffer->GetError().Throw();
 			return QuackFetchResult::FINISHED;
-		case QuackFetchBuffer::PopStatus::EMPTY: {
+		case QuackClaimPopStatus::EMPTY: {
 			// refill any free pipeline slots before parking
-			TopUp();
+			TopUp(context);
 			if (input.results_execution_mode == AsyncResultsExecutionMode::TASK_EXECUTOR && input.interrupt_state) {
 				auto completion = buffer->RegisterWaiter(claim.GetIndex());
 				if (!completion || !completion->TryPark(*input.interrupt_state)) {
@@ -301,7 +211,7 @@ QuackFetchResult QuackFetcher::GetBatch(ClientContext &context, TableFunctionInp
 	}
 }
 
-void QuackFetcher::TopUp() {
+void QuackFetcher::TopUp(ClientContext &context) {
 	while (!stop && !no_more_fetches) {
 		auto current = outstanding.load();
 		if (current >= depth) {
@@ -320,14 +230,33 @@ void QuackFetcher::TopUp() {
 			client = std::move(idle_clients.back());
 			idle_clients.pop_back();
 		}
+		// Each task requests one explicit index, assigned in dense order; its payload is encoded once
+		// here (with the current ack) and never changes, so HTTP retries are idempotent.
+		auto request_index = next_request++;
+		FetchRequestMessage fetch_msg(connection_id, query_uuid, request_index, CurrentAck());
+		auto request_payload = make_uniq<MemoryStream>();
+		QuackClient::EncodeRequest(context, fetch_msg, *request_payload);
+		auto request_size = request_payload->GetPosition();
 		++in_flight;
-		queue->Register(make_uniq<QuackFetchDataTask>(*this, std::move(client)), payload_size);
+		queue->Register(make_uniq<QuackFetchDataTask>(*this, std::move(client), request_index,
+		                                              std::move(request_payload), request_size),
+		                request_size);
 	}
 }
 
-void QuackFetcher::BatchConsumed() {
+void QuackFetcher::BatchConsumed(ClientContext &context) {
 	--outstanding;
-	TopUp();
+	TopUp(context);
+}
+
+void QuackFetcher::RecordReceived(idx_t index) {
+	lock_guard<mutex> guard(ack_lock);
+	acked.Insert(index);
+}
+
+idx_t QuackFetcher::CurrentAck() {
+	lock_guard<mutex> guard(ack_lock);
+	return acked.ContiguousMax();
 }
 
 void QuackFetcher::ReturnClient(unique_ptr<QuackClientWrapper> client) {
@@ -344,7 +273,10 @@ void QuackFetcher::FinishTask(unique_ptr<QuackClientWrapper> client, bool pushed
 		--outstanding;
 	}
 	if (--in_flight == 0 && no_more_fetches) {
-		buffer->Finish();
+		// Clean end of stream: validate against the server's announced total (the buffer counted its
+		// own pushes), so lost batches fail loudly. Error/cancel paths never reach here with a total.
+		auto expected = expected_total.load();
+		buffer->Finish(expected == DConstants::INVALID_INDEX ? optional_idx() : optional_idx(expected));
 	}
 }
 

--- a/src/quack_fetch_collector.cpp
+++ b/src/quack_fetch_collector.cpp
@@ -16,13 +16,13 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Fetch-buffer emitter
 //===--------------------------------------------------------------------===//
-//! A fragment serialized into a FETCH_RESPONSE payload, awaiting its dense index.
+//! A fragment serialized into a FETCH_RESPONSE payload. It has no dense index yet.
 struct QuackPreparedFetchBatch : public QuackPreparedBatch {
 	QuackFetchPayload entry;
 };
 
-//! Streams one fragment straight into a FETCH_RESPONSE payload — the accumulation buffer IS the wire
-//! response, so the FETCH handler replies with patched bytes instead of serializing on the reply thread.
+//! The accumulation buffer IS the wire response, so the FETCH handler patches 8 bytes and replies.
+//! It serializes nothing on the reply thread.
 class QuackFetchFragmentBuilder : public QuackFragmentBuilder {
 public:
 	QuackFetchFragmentBuilder(ClientContext &context, idx_t size_hint)
@@ -59,8 +59,8 @@ private:
 	idx_t rows = 0;
 };
 
-// Stamps each dense batch's index into its sealed payload and publishes it into the stream's claim
-// buffer. A full buffer parks the producing task instead of the thread — backpressure into the executor.
+// Stamps the dense index into the sealed payload, then publishes it. A full buffer parks the
+// producing task, not the thread.
 class QuackFetchBufferEmitter : public QuackBatchEmitter {
 public:
 	QuackFetchBufferEmitter(shared_ptr<QuackFetchStream> stream_p, idx_t debug_delay_ms_p)
@@ -71,12 +71,12 @@ public:
 		return make_uniq<QuackFetchFragmentBuilder>(context, size_hint);
 	}
 
-	//! NO_CAPACITY leaves the batch with the caller for a retry (the patch below is idempotent — a
-	//! retry re-stamps the same index); DROPPED/PUSHED both consume it.
+	//! NO_CAPACITY leaves the batch with the caller. A retry stamps the same index again, which is
+	//! safe. DROPPED and PUSHED both consume the batch.
 	bool TryEmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> &batch,
 	                     optional_ptr<const InterruptState> interrupt) override {
 		if (debug_delay_ms > 0) {
-			// DEBUG SETTING: randomize publish order to stress head-of-stream admission
+			// DEBUG SETTING: make the publish order random, to stress head-of-stream admission
 			RandomEngine random;
 			ThreadUtil::SleepMs(random.NextRandomInteger(0, NumericCast<uint32_t>(debug_delay_ms)));
 		}
@@ -91,9 +91,9 @@ public:
 	}
 
 	void Finish(ClientContext &context, idx_t total_batches) override {
-		// Deliberately NOT finishing the buffer: the claimed statement can sit mid-way through a
-		// multi-statement query, and the client must not see the stream end while later statements run.
-		// RunFetchQuery closes the stream once the WHOLE query returned, validated against this total.
+		// Do NOT finish the buffer here. The claimed statement can sit in the middle of a
+		// multi-statement query, and the client must not see the stream end while more statements run.
+		// RunFetchQuery closes the stream, and it checks the count against this total.
 		stream->announced_total = total_batches;
 	}
 
@@ -105,8 +105,7 @@ private:
 //===--------------------------------------------------------------------===//
 // Fetch collector operator
 //===--------------------------------------------------------------------===//
-// Result collector producing the client-facing dense batch stream via the shared rebalancer sink;
-// the statement's own result is empty — the data's real exit is the stream's claim buffer.
+// The data leaves through the stream's claim buffer, so the statement's own result stays empty.
 class QuackFetchCollector : public PhysicalResultCollector {
 public:
 	QuackFetchCollector(PhysicalPlan &physical_plan, PreparedStatementData &data, shared_ptr<QuackFetchStream> stream_p,
@@ -148,7 +147,7 @@ public:
 	}
 
 	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) const override {
-		// the data left through the stream's claim buffer; the statement's own result is empty
+		// the data left through the claim buffer
 		auto &gstate = state.Cast<QuackRebalancerGlobalState>();
 		auto context = gstate.client_context.lock();
 		if (!context) {
@@ -163,8 +162,8 @@ public:
 		return order_mode != AppendOrderMode::SERIAL_ORDERED;
 	}
 
-	//! Request executor batch indices only for PARALLEL_ORDERED, so the executor's assertion never fires
-	//! for sources that don't supply a batch index.
+	//! Ask for batch indices only in PARALLEL_ORDERED mode. A source that supplies none would then
+	//! fail an assertion in the executor.
 	OperatorPartitionInfo RequiredPartitionInfo() const override {
 		return order_mode == AppendOrderMode::PARALLEL_ORDERED ? OperatorPartitionInfo(/*batch_index=*/true)
 		                                                       : OperatorPartitionInfo();
@@ -177,8 +176,8 @@ public:
 
 unique_ptr<PhysicalOperator> MakeQuackFetchCollector(ClientContext &context, PreparedStatementData &data,
                                                      shared_ptr<QuackFetchStream> stream) {
-	// The stream carries the FIRST result-returning statement of the (possibly multi-statement) query,
-	// matching how core picks the head of a result chain; everything else keeps the default collector.
+	// The stream carries the FIRST statement that returns a result, as core does for a result chain.
+	// Every other statement keeps the default collector.
 	if (data.properties.return_type != StatementReturnType::QUERY_RESULT || stream->Bound()) {
 		return PhysicalResultCollector::GetResultCollector(context, data);
 	}

--- a/src/quack_fetch_collector.cpp
+++ b/src/quack_fetch_collector.cpp
@@ -60,7 +60,7 @@ private:
 };
 
 // Stamps each dense batch's index into its sealed payload and publishes it into the stream's claim
-// buffer, blocking on the buffer's byte capacity — backpressure straight into the executor.
+// buffer. A full buffer parks the producing task instead of the thread — backpressure into the executor.
 class QuackFetchBufferEmitter : public QuackBatchEmitter {
 public:
 	QuackFetchBufferEmitter(shared_ptr<QuackFetchStream> stream_p, idx_t debug_delay_ms_p)
@@ -71,17 +71,23 @@ public:
 		return make_uniq<QuackFetchFragmentBuilder>(context, size_hint);
 	}
 
-	void EmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> batch) override {
+	//! NO_CAPACITY leaves the batch with the caller for a retry (the patch below is idempotent — a
+	//! retry re-stamps the same index); DROPPED/PUSHED both consume it.
+	bool TryEmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> &batch,
+	                     optional_ptr<const InterruptState> interrupt) override {
 		if (debug_delay_ms > 0) {
 			// DEBUG SETTING: randomize publish order to stress head-of-stream admission
 			RandomEngine random;
 			ThreadUtil::SleepMs(random.NextRandomInteger(0, NumericCast<uint32_t>(debug_delay_ms)));
 		}
-		auto prepared = unique_ptr_cast<QuackPreparedBatch, QuackPreparedFetchBatch>(std::move(batch));
-		auto &entry = prepared->entry;
+		auto &entry = static_cast<QuackPreparedFetchBatch &>(*batch).entry;
 		QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset, dense_index);
 		auto bytes = entry.payload_size;
-		stream->buffer.PushBatch(dense_index, std::move(entry), bytes);
+		if (stream->buffer.TryPushBatch(dense_index, entry, bytes, interrupt) == QuackPushStatus::NO_CAPACITY) {
+			return false;
+		}
+		batch.reset();
+		return true;
 	}
 
 	void Finish(ClientContext &context, idx_t total_batches) override {

--- a/src/quack_fetch_collector.cpp
+++ b/src/quack_fetch_collector.cpp
@@ -1,0 +1,199 @@
+#include "quack_fetch_collector.hpp"
+
+#include "duckdb/common/random_engine.hpp"
+#include "duckdb/common/thread.hpp"
+#include "duckdb/execution/operator/helper/physical_result_collector.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+
+#include "quack_message.hpp"
+#include "quack_rebalancer_sink.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Fetch-buffer emitter
+//===--------------------------------------------------------------------===//
+//! A fragment serialized into a FETCH_RESPONSE payload, awaiting its dense index.
+struct QuackPreparedFetchBatch : public QuackPreparedBatch {
+	QuackFetchPayload entry;
+};
+
+//! Streams one fragment straight into a FETCH_RESPONSE payload — the accumulation buffer IS the wire
+//! response, so the FETCH handler replies with patched bytes instead of serializing on the reply thread.
+class QuackFetchFragmentBuilder : public QuackFragmentBuilder {
+public:
+	QuackFetchFragmentBuilder(ClientContext &context, idx_t size_hint)
+	    : writer(make_uniq<FetchResponsePayloadWriter>(context, size_hint)) {
+	}
+
+	void Append(ClientContext &context, DataChunk &chunk) override {
+		rows += chunk.size();
+		stager.Append(chunk, [&](DataChunk &full) { writer->AppendChunk(full); });
+	}
+
+	idx_t SizeBytes() const override {
+		return writer->SizeBytes();
+	}
+
+	idx_t AllocatedBytes() const override {
+		return writer->AllocatedBytes();
+	}
+
+	unique_ptr<QuackPreparedBatch> Seal(ClientContext &context) override {
+		stager.Flush([&](DataChunk &full) { writer->AppendChunk(full); });
+		auto sealed = writer->Seal();
+		auto prepared = make_uniq<QuackPreparedFetchBatch>();
+		prepared->entry.payload = std::move(sealed.payload);
+		prepared->entry.payload_size = sealed.payload_size;
+		prepared->entry.index_offset = sealed.index_offset;
+		prepared->entry.rows = rows;
+		return std::move(prepared);
+	}
+
+private:
+	unique_ptr<FetchResponsePayloadWriter> writer;
+	QuackChunkStager stager;
+	idx_t rows = 0;
+};
+
+// Stamps each dense batch's index into its sealed payload and publishes it into the stream's claim
+// buffer, blocking on the buffer's byte capacity — backpressure straight into the executor.
+class QuackFetchBufferEmitter : public QuackBatchEmitter {
+public:
+	QuackFetchBufferEmitter(shared_ptr<QuackFetchStream> stream_p, idx_t debug_delay_ms_p)
+	    : stream(std::move(stream_p)), debug_delay_ms(debug_delay_ms_p) {
+	}
+
+	unique_ptr<QuackFragmentBuilder> OpenFragment(ClientContext &context, idx_t size_hint) override {
+		return make_uniq<QuackFetchFragmentBuilder>(context, size_hint);
+	}
+
+	void EmitPrepared(ClientContext &context, idx_t dense_index, unique_ptr<QuackPreparedBatch> batch) override {
+		if (debug_delay_ms > 0) {
+			// DEBUG SETTING: randomize publish order to stress head-of-stream admission
+			RandomEngine random;
+			ThreadUtil::SleepMs(random.NextRandomInteger(0, NumericCast<uint32_t>(debug_delay_ms)));
+		}
+		auto prepared = unique_ptr_cast<QuackPreparedBatch, QuackPreparedFetchBatch>(std::move(batch));
+		auto &entry = prepared->entry;
+		QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset, dense_index);
+		auto bytes = entry.payload_size;
+		stream->buffer.PushBatch(dense_index, std::move(entry), bytes);
+	}
+
+	void Finish(ClientContext &context, idx_t total_batches) override {
+		// Deliberately NOT finishing the buffer: the claimed statement can sit mid-way through a
+		// multi-statement query, and the client must not see the stream end while later statements run.
+		// RunFetchQuery closes the stream once the WHOLE query returned, validated against this total.
+		stream->announced_total = total_batches;
+	}
+
+private:
+	shared_ptr<QuackFetchStream> stream;
+	idx_t debug_delay_ms;
+};
+
+//===--------------------------------------------------------------------===//
+// Fetch collector operator
+//===--------------------------------------------------------------------===//
+// Result collector producing the client-facing dense batch stream via the shared rebalancer sink;
+// the statement's own result is empty — the data's real exit is the stream's claim buffer.
+class QuackFetchCollector : public PhysicalResultCollector {
+public:
+	QuackFetchCollector(PhysicalPlan &physical_plan, PreparedStatementData &data, shared_ptr<QuackFetchStream> stream_p,
+	                    AppendOrderMode order_mode_p)
+	    : PhysicalResultCollector(physical_plan, data), stream(std::move(stream_p)), order_mode(order_mode_p) {
+	}
+
+	shared_ptr<QuackFetchStream> stream;
+	AppendOrderMode order_mode;
+
+public:
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override {
+		auto debug_delay_ms = QuackGetUBigintSetting(context, "quack_debug_emit_delay_ms", 0);
+		auto emitter = make_uniq<QuackFetchBufferEmitter>(stream, debug_delay_ms);
+		auto state = MakeQuackRebalancerGlobalState(context, types, order_mode, std::move(emitter));
+		state->client_context = context.shared_from_this();
+		return std::move(state);
+	}
+
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override {
+		return make_uniq<QuackRebalancerLocalState>();
+	}
+
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override {
+		return QuackRebalancerSink(context, chunk, input);
+	}
+
+	SinkNextBatchType NextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) const override {
+		return QuackRebalancerNextBatch(context, input);
+	}
+
+	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override {
+		return QuackRebalancerCombine(context, input);
+	}
+
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          OperatorSinkFinalizeInput &input) const override {
+		return QuackRebalancerFinalize(pipeline, event, context, input.global_state.Cast<QuackRebalancerGlobalState>());
+	}
+
+	unique_ptr<QueryResult> GetResult(GlobalSinkState &state) const override {
+		// the data left through the stream's claim buffer; the statement's own result is empty
+		auto &gstate = state.Cast<QuackRebalancerGlobalState>();
+		auto context = gstate.client_context.lock();
+		if (!context) {
+			throw InternalException("client context expired in QuackFetchCollector::GetResult");
+		}
+		auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), types);
+		return make_uniq<MaterializedQueryResult>(statement_type, properties, IdentifiersToStrings(names),
+		                                          std::move(collection), context->GetClientProperties());
+	}
+
+	bool ParallelSink() const override {
+		return order_mode != AppendOrderMode::SERIAL_ORDERED;
+	}
+
+	//! Request executor batch indices only for PARALLEL_ORDERED, so the executor's assertion never fires
+	//! for sources that don't supply a batch index.
+	OperatorPartitionInfo RequiredPartitionInfo() const override {
+		return order_mode == AppendOrderMode::PARALLEL_ORDERED ? OperatorPartitionInfo(/*batch_index=*/true)
+		                                                       : OperatorPartitionInfo();
+	}
+
+	string GetName() const override {
+		return "QUACK_FETCH_COLLECTOR";
+	}
+};
+
+unique_ptr<PhysicalOperator> MakeQuackFetchCollector(ClientContext &context, PreparedStatementData &data,
+                                                     shared_ptr<QuackFetchStream> stream) {
+	// The stream carries the FIRST result-returning statement of the (possibly multi-statement) query,
+	// matching how core picks the head of a result chain; everything else keeps the default collector.
+	if (data.properties.return_type != StatementReturnType::QUERY_RESULT || stream->Bound()) {
+		return PhysicalResultCollector::GetResultCollector(context, data);
+	}
+	auto &physical_plan = *data.physical_plan;
+	auto &root = physical_plan.Root();
+
+	AppendOrderMode order_mode;
+	if (!PhysicalPlanGenerator::PreserveInsertionOrder(context, root)) {
+		order_mode = AppendOrderMode::UNORDERED;
+	} else if (PhysicalPlanGenerator::UseBatchIndex(context, root)) {
+		order_mode = AppendOrderMode::PARALLEL_ORDERED;
+	} else {
+		order_mode = AppendOrderMode::SERIAL_ORDERED;
+	}
+
+	vector<string> result_names;
+	for (auto &name : data.names) {
+		result_names.push_back(name.GetIdentifierName());
+	}
+	stream->SignalBound(data.types, std::move(result_names));
+	return make_uniq<QuackFetchCollector>(physical_plan, data, std::move(stream), order_mode);
+}
+
+} // namespace duckdb

--- a/src/quack_fetch_collector.cpp
+++ b/src/quack_fetch_collector.cpp
@@ -154,8 +154,8 @@ public:
 			throw InternalException("client context expired in QuackFetchCollector::GetResult");
 		}
 		auto collection = make_uniq<ColumnDataCollection>(Allocator::DefaultAllocator(), types);
-		return make_uniq<MaterializedQueryResult>(statement_type, properties, IdentifiersToStrings(names),
-		                                          std::move(collection), context->GetClientProperties());
+		return make_uniq<MaterializedQueryResult>(statement_type, properties, names, std::move(collection),
+		                                          context->GetClientProperties());
 	}
 
 	bool ParallelSink() const override {

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -231,8 +231,22 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 			return true;
 		});
 		auto response = HandleMessage(stream);
-		response->ToMemoryStream(stream);
-		res.set_content((const char *)stream.GetData(), stream.GetPosition(), "application/vnd.duckdb");
+		auto raw = response->RawPayload();
+		if (raw) {
+			// Pre-serialized response (fetch data batches): hand the payload to httplib without
+			// re-serializing or copying; the shared_ptr keeps the buffer alive until it is written out.
+			auto data = const_char_ptr_cast(raw->GetData());
+			auto size = raw->GetPosition();
+			shared_ptr<QuackMessage> owned(std::move(response));
+			res.set_content_provider(size, "application/vnd.duckdb",
+			                         [owned, data](size_t offset, size_t length, duckdb_httplib::DataSink &sink) {
+				                         sink.write(data + offset, length);
+				                         return true;
+			                         });
+		} else {
+			response->ToMemoryStream(stream);
+			res.set_content((const char *)stream.GetData(), stream.GetPosition(), "application/vnd.duckdb");
+		}
 	});
 
 	if (!server->is_valid()) {

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -233,8 +233,8 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 		auto response = HandleMessage(stream);
 		auto raw = response->RawPayload();
 		if (raw) {
-			// Pre-serialized response (fetch data batches): hand the payload to httplib without
-			// re-serializing or copying; the shared_ptr keeps the buffer alive until it is written out.
+			// The payload is already serialized: give it to httplib with no copy. The shared_ptr
+			// keeps the buffer alive until httplib writes it out.
 			auto data = const_char_ptr_cast(raw->GetData());
 			auto size = raw->GetPosition();
 			shared_ptr<QuackMessage> owned(std::move(response));

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -199,8 +199,8 @@ unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_strea
 //===--------------------------------------------------------------------===//
 // QuackChunkPayloadWriter
 //===--------------------------------------------------------------------===//
-//! Exposes the serializer hooks to write one message incrementally: the binary format is forward-only
-//! (no size backpatching), so a message can span many calls if the field order matches exactly.
+//! Opens the serializer hooks, so one message can be written step by step. The binary format is
+//! forward-only, so this works only if the field order is exactly the same.
 class QuackChunkPayloadWriter::PayloadSerializer : public BinarySerializer {
 public:
 	PayloadSerializer(WriteStream &stream, SerializationOptions options)
@@ -211,7 +211,7 @@ public:
 		OnPropertyBegin(field_id, tag);
 	}
 
-	//! Byte-identical to a chunk-list element written via WriteValue(const DataChunkWrapper *).
+	//! The same bytes as a chunk-list element from WriteValue(const DataChunkWrapper *).
 	void WriteChunkElement(DataChunk &chunk) {
 		OnNullableBegin(true);
 		OnObjectBegin();
@@ -221,8 +221,8 @@ public:
 	}
 };
 
-//! LEB128 zero-padded to CHUNK_COUNT_VARINT_WIDTH bytes: decodes to the same value as the canonical
-//! encoding, but has a fixed width so it can be patched in place once the count is known.
+//! A LEB128 padded with zeros to a fixed width. It decodes to the same value as the short form, and
+//! a patch can write the count into it later.
 static void EncodePaddedChunkCount(uint64_t value, data_ptr_t out) {
 	D_ASSERT(value < (1ULL << (7 * QuackChunkPayloadWriter::CHUNK_COUNT_VARINT_WIDTH)));
 	for (idx_t i = 0; i < QuackChunkPayloadWriter::CHUNK_COUNT_VARINT_WIDTH; i++) {
@@ -246,7 +246,7 @@ void QuackChunkPayloadWriter::OpenMessage(const MessageHeader &header) {
 	serializer->Begin();
 	header.Serialize(*serializer);
 	serializer->End();
-	serializer->Begin(); // body object; closed by Seal
+	serializer->Begin(); // Seal closes this
 }
 
 Serializer &QuackChunkPayloadWriter::Body() {
@@ -262,8 +262,8 @@ void QuackChunkPayloadWriter::BeginChunkList(uint16_t field_id, const char *tag)
 }
 
 void QuackChunkPayloadWriter::WriteBatchIndexField(uint16_t field_id, const char *tag) {
-	// Byte-identical to WritePropertyWithDefault<string>(field_id, tag, <8 bytes>): field header,
-	// varint length 8 (one byte), then the payload — whose offset we record for later patching.
+	// The same bytes as WritePropertyWithDefault<string>(field_id, tag, <8 bytes>): the field header,
+	// the length 8 as a one-byte varint, then the payload. Record where the payload starts.
 	serializer->BeginProperty(field_id, tag);
 	data_t length_byte = 8;
 	stream->WriteData(&length_byte, 1);
@@ -302,9 +302,8 @@ QuackChunkPayloadWriter::SealedPayload QuackChunkPayloadWriter::Seal() {
 	sealed_size = result.payload_size;
 	result.payload = std::move(stream);
 #ifdef DEBUG
-	// Round-trip pin: re-serializing the decoded payload with the generated codec must reproduce the
-	// bytes — except the chunk count, which this writer pads for patchability and the generated
-	// encoder emits minimal-width, so that region is compared by value.
+	// The generated codec must decode and re-encode these bytes without a change. The chunk count is
+	// the one exception: this writer pads it and the generated encoder does not, so compare its value.
 	{
 		MemoryStream copy(result.payload_size == 0 ? 1 : NextPowerOfTwo(result.payload_size));
 		copy.WriteData(result.payload->GetData(), result.payload_size);
@@ -343,19 +342,18 @@ QuackChunkPayloadWriter::SealedPayload QuackChunkPayloadWriter::Seal() {
 //===--------------------------------------------------------------------===//
 FetchResponsePayloadWriter::FetchResponsePayloadWriter(ClientContext &context, idx_t capacity_hint)
     : QuackChunkPayloadWriter(context, capacity_hint) {
-	// Responses carry an empty connection id, matching messages serialized via ToMemoryStream.
+	// A response has an empty connection id, as ToMemoryStream writes it.
 	OpenMessage(MessageHeader(MessageType::FETCH_RESPONSE, string()));
 	BeginChunkList(1, "results");
 }
 
 void FetchResponsePayloadWriter::WriteTail() {
-	// total_batches (field 2) is only ever set on the terminal FINISHED response, which is not
-	// pre-serialized; data payloads omit it exactly like the generated default handling.
+	// Only the terminal response sets total_batches, and that response is not serialized here.
 	WriteBatchIndexField(3, "batch_index_fixed");
 }
 
-// batch_index travels as QuackBatchIndexField — a fixed-width LAST field patchable in already-encoded
-// payloads. These two methods back the generator hooks in quack_message.json.
+// batch_index is a fixed-width last field, so a patch can write it into an encoded payload. The
+// generator hooks in quack_message.json call these two methods.
 string FetchResponseMessage::EncodeBatchIndexFixed() const {
 	string bytes(8, '\0');
 	QuackBatchIndexField::Encode(batch_index.IsValid() ? batch_index.GetIndex() : QuackBatchIndexField::INVALID,

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -196,6 +196,186 @@ unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_strea
 	return DeserializeMessage(deserializer, std::move(header));
 }
 
+//===--------------------------------------------------------------------===//
+// QuackChunkPayloadWriter
+//===--------------------------------------------------------------------===//
+//! Exposes the serializer hooks to write one message incrementally: the binary format is forward-only
+//! (no size backpatching), so a message can span many calls if the field order matches exactly.
+class QuackChunkPayloadWriter::PayloadSerializer : public BinarySerializer {
+public:
+	PayloadSerializer(WriteStream &stream, SerializationOptions options)
+	    : BinarySerializer(stream, std::move(options)) {
+	}
+
+	void BeginProperty(field_id_t field_id, const char *tag) {
+		OnPropertyBegin(field_id, tag);
+	}
+
+	//! Byte-identical to a chunk-list element written via WriteValue(const DataChunkWrapper *).
+	void WriteChunkElement(DataChunk &chunk) {
+		OnNullableBegin(true);
+		OnObjectBegin();
+		WriteObject(300, "chunk", [&](Serializer &object) { chunk.Serialize(object); });
+		OnObjectEnd();
+		OnNullableEnd();
+	}
+};
+
+//! LEB128 zero-padded to CHUNK_COUNT_VARINT_WIDTH bytes: decodes to the same value as the canonical
+//! encoding, but has a fixed width so it can be patched in place once the count is known.
+static void EncodePaddedChunkCount(uint64_t value, data_ptr_t out) {
+	D_ASSERT(value < (1ULL << (7 * QuackChunkPayloadWriter::CHUNK_COUNT_VARINT_WIDTH)));
+	for (idx_t i = 0; i < QuackChunkPayloadWriter::CHUNK_COUNT_VARINT_WIDTH; i++) {
+		auto group = static_cast<data_t>((value >> (7 * i)) & 0x7F);
+		out[i] = i + 1 < QuackChunkPayloadWriter::CHUNK_COUNT_VARINT_WIDTH ? (group | 0x80) : group;
+	}
+}
+
+QuackChunkPayloadWriter::QuackChunkPayloadWriter(ClientContext &context, idx_t capacity_hint) {
+	auto capacity = NextPowerOfTwo(MaxValue<idx_t>(capacity_hint, 65536));
+	stream = make_uniq<MemoryStream>(Allocator::DefaultAllocator(), capacity);
+	SerializationOptions options;
+	options.storage_compatibility = StorageCompatibility::FromIndex(StorageVersion::V2_0_0);
+	serializer = make_uniq<PayloadSerializer>(*stream, std::move(options));
+}
+
+QuackChunkPayloadWriter::~QuackChunkPayloadWriter() {
+}
+
+void QuackChunkPayloadWriter::OpenMessage(const MessageHeader &header) {
+	serializer->Begin();
+	header.Serialize(*serializer);
+	serializer->End();
+	serializer->Begin(); // body object; closed by Seal
+}
+
+Serializer &QuackChunkPayloadWriter::Body() {
+	return *serializer;
+}
+
+void QuackChunkPayloadWriter::BeginChunkList(uint16_t field_id, const char *tag) {
+	serializer->BeginProperty(field_id, tag);
+	chunk_count_offset = stream->GetPosition();
+	data_t padded[CHUNK_COUNT_VARINT_WIDTH];
+	EncodePaddedChunkCount(0, padded);
+	stream->WriteData(padded, CHUNK_COUNT_VARINT_WIDTH);
+}
+
+void QuackChunkPayloadWriter::WriteBatchIndexField(uint16_t field_id, const char *tag) {
+	// Byte-identical to WritePropertyWithDefault<string>(field_id, tag, <8 bytes>): field header,
+	// varint length 8 (one byte), then the payload — whose offset we record for later patching.
+	serializer->BeginProperty(field_id, tag);
+	data_t length_byte = 8;
+	stream->WriteData(&length_byte, 1);
+	index_offset = stream->GetPosition();
+	data_t placeholder[8];
+	QuackBatchIndexField::Encode(QuackBatchIndexField::PLACEHOLDER, placeholder);
+	stream->WriteData(placeholder, 8);
+}
+
+void QuackChunkPayloadWriter::AppendChunk(DataChunk &chunk) {
+	D_ASSERT(chunk.size() > 0);
+	serializer->WriteChunkElement(chunk);
+	chunk_count++;
+}
+
+idx_t QuackChunkPayloadWriter::SizeBytes() const {
+	return stream ? stream->GetPosition() : sealed_size;
+}
+
+idx_t QuackChunkPayloadWriter::AllocatedBytes() const {
+	return stream ? stream->GetCapacity() : sealed_size;
+}
+
+QuackChunkPayloadWriter::SealedPayload QuackChunkPayloadWriter::Seal() {
+	D_ASSERT(stream && chunk_count > 0);
+	data_t padded[CHUNK_COUNT_VARINT_WIDTH];
+	EncodePaddedChunkCount(chunk_count, padded);
+	memcpy(stream->GetData() + chunk_count_offset, padded, CHUNK_COUNT_VARINT_WIDTH);
+
+	WriteTail();
+	serializer->End();
+
+	SealedPayload result;
+	result.payload_size = stream->GetPosition();
+	result.index_offset = index_offset;
+	sealed_size = result.payload_size;
+	result.payload = std::move(stream);
+#ifdef DEBUG
+	// Round-trip pin: re-serializing the decoded payload with the generated codec must reproduce the
+	// bytes — except the chunk count, which this writer pads for patchability and the generated
+	// encoder emits minimal-width, so that region is compared by value.
+	{
+		MemoryStream copy(result.payload_size == 0 ? 1 : NextPowerOfTwo(result.payload_size));
+		copy.WriteData(result.payload->GetData(), result.payload_size);
+		QuackBatchIndexField::Patch(copy.GetData(), result.payload_size, result.index_offset, 1);
+		auto message = QuackMessage::FromMemoryStream(copy);
+		if (message->Type() != WrittenType()) {
+			throw InternalException("Payload writer round-trip: message type mismatch");
+		}
+		MemoryStream reserialized;
+		message->ToMemoryStream(reserialized);
+
+		idx_t minimal_width = 1;
+		for (auto value = chunk_count >> 7; value > 0; value >>= 7) {
+			minimal_width++;
+		}
+		auto tail_offset = chunk_count_offset + CHUNK_COUNT_VARINT_WIDTH;
+		uint64_t reser_count = 0;
+		for (idx_t i = 0; i < minimal_width; i++) {
+			reser_count |= static_cast<uint64_t>(reserialized.GetData()[chunk_count_offset + i] & 0x7F) << (7 * i);
+		}
+		bool matches = reserialized.GetPosition() == result.payload_size - CHUNK_COUNT_VARINT_WIDTH + minimal_width &&
+		               memcmp(reserialized.GetData(), copy.GetData(), chunk_count_offset) == 0 &&
+		               reser_count == chunk_count &&
+		               memcmp(reserialized.GetData() + chunk_count_offset + minimal_width, copy.GetData() + tail_offset,
+		                      result.payload_size - tail_offset) == 0;
+		if (!matches) {
+			throw InternalException("Payload writer round-trip: bytes differ from generated serialization");
+		}
+	}
+#endif
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// FetchResponsePayloadWriter
+//===--------------------------------------------------------------------===//
+FetchResponsePayloadWriter::FetchResponsePayloadWriter(ClientContext &context, idx_t capacity_hint)
+    : QuackChunkPayloadWriter(context, capacity_hint) {
+	// Responses carry an empty connection id, matching messages serialized via ToMemoryStream.
+	OpenMessage(MessageHeader(MessageType::FETCH_RESPONSE, string()));
+	BeginChunkList(1, "results");
+}
+
+void FetchResponsePayloadWriter::WriteTail() {
+	// total_batches (field 2) is only ever set on the terminal FINISHED response, which is not
+	// pre-serialized; data payloads omit it exactly like the generated default handling.
+	WriteBatchIndexField(3, "batch_index_fixed");
+}
+
+// batch_index travels as QuackBatchIndexField — a fixed-width LAST field patchable in already-encoded
+// payloads. These two methods back the generator hooks in quack_message.json.
+string FetchResponseMessage::EncodeBatchIndexFixed() const {
+	string bytes(8, '\0');
+	QuackBatchIndexField::Encode(batch_index.IsValid() ? batch_index.GetIndex() : QuackBatchIndexField::INVALID,
+	                             reinterpret_cast<data_ptr_t>(&bytes[0]));
+	return bytes;
+}
+
+void FetchResponseMessage::ApplyBatchIndexFixed(const string &bytes) {
+	if (bytes.size() != 8) {
+		throw IOException("FetchResponseMessage: malformed batch index field");
+	}
+	auto value = QuackBatchIndexField::Decode(reinterpret_cast<const_data_ptr_t>(bytes.data()));
+	if (value == QuackBatchIndexField::PLACEHOLDER) {
+		throw IOException("FetchResponseMessage: batch arrived unstamped");
+	}
+	if (value != QuackBatchIndexField::INVALID) {
+		batch_index = optional_idx(value);
+	}
+}
+
 void DataChunkWrapper::Serialize(Serializer &serializer) const {
 	serializer.WriteObject(300, "chunk", [&](Serializer &inner) { chunk.Serialize(inner); });
 }

--- a/src/quack_rebalancer_core.cpp
+++ b/src/quack_rebalancer_core.cpp
@@ -10,22 +10,20 @@ QuackRebalancerCore::QuackRebalancerCore(ClientContext &context, idx_t buffer_by
 
 void QuackRebalancerCore::AddPendingFragment(ClientContext &context, idx_t executor_batch, idx_t min_batch_index,
                                              idx_t memory_usage, unique_ptr<QuackPreparedBatch> prepared) {
-	// The fragment arrives already emit-ready (built on the producing thread as chunks arrived) —
-	// settling releases ready bytes, not work.
 	{
 		annotated_lock_guard<annotated_mutex> guard(lock);
 		raw_batches[executor_batch].emplace_back(memory_usage, std::move(prepared));
 	}
-	// The min batch's already-pushed fragments are a settled prefix of the dense stream (future
-	// fragments simply get later indices), so the frontier always includes them — regardless of caller.
+	// The min batch's pushed fragments are a settled prefix: later fragments only get later indices.
+	// The frontier therefore always includes them, whichever thread calls.
 	ReleaseSettled(min_batch_index + 1);
-	// Blocked producers can help emit; also drain here so stamped batches hit the wire immediately.
+	// blocked producers can help to emit
 	{
 		annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
 		memory_manager.UnblockTasks();
 	}
-	// Probe drain (mid-Sink, the chunk is already consumed — cannot yield here): a capacity-parked
-	// batch is shelved and finished by the next interrupt-carrying drain (Sink top, Combine, Finalize).
+	// A probe only: the chunk is already consumed, so this call cannot yield. A parked batch waits
+	// for the next drain that carries an interrupt (the top of Sink, Combine, or Finalize).
 	ExecuteTasks(context);
 }
 
@@ -51,8 +49,8 @@ void QuackRebalancerCore::ReleaseSettled(idx_t min_exclusive) {
 QuackEmitProgress QuackRebalancerCore::ExecuteTasks(ClientContext &context,
                                                     optional_ptr<const InterruptState> interrupt) {
 	while (true) {
-		// Capacity-parked retries first, lowest index first: the head of the stream is always
-		// admitted, so index order guarantees the drain makes progress once capacity frees.
+		// Parked retries first, lowest index first. The head of the stream always gets in, so index
+		// order makes progress certain after capacity frees.
 		unique_ptr<QuackEmitTask> task;
 		{
 			annotated_lock_guard<annotated_mutex> guard(lock);

--- a/src/quack_rebalancer_core.cpp
+++ b/src/quack_rebalancer_core.cpp
@@ -24,11 +24,14 @@ void QuackRebalancerCore::AddPendingFragment(ClientContext &context, idx_t execu
 		annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
 		memory_manager.UnblockTasks();
 	}
+	// Probe drain (mid-Sink, the chunk is already consumed — cannot yield here): a capacity-parked
+	// batch is shelved and finished by the next interrupt-carrying drain (Sink top, Combine, Finalize).
 	ExecuteTasks(context);
 }
 
-void QuackRebalancerCore::AddSettledData(ClientContext &context, unique_ptr<QuackPreparedBatch> prepared) {
-	emitter->EmitPrepared(context, next_dense++, std::move(prepared));
+bool QuackRebalancerCore::TryEmitStamped(ClientContext &context, QuackEmitTask &task,
+                                         optional_ptr<const InterruptState> interrupt) {
+	return emitter->TryEmitPrepared(context, task.dense_index, task.prepared, interrupt);
 }
 
 void QuackRebalancerCore::ReleaseSettled(idx_t min_exclusive) {
@@ -45,23 +48,36 @@ void QuackRebalancerCore::ReleaseSettled(idx_t min_exclusive) {
 	}
 }
 
-bool QuackRebalancerCore::ExecuteTask(ClientContext &context) {
-	auto task = task_manager.GetTask();
-	if (!task) {
-		return false;
-	}
-	auto memory_usage = task->memory_usage;
-	emitter->EmitPrepared(context, task->dense_index, std::move(task->prepared));
-	if (memory_usage > 0) {
-		memory_manager.ReduceUnflushedMemory(memory_usage);
-		annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
-		memory_manager.UnblockTasks();
-	}
-	return true;
-}
-
-void QuackRebalancerCore::ExecuteTasks(ClientContext &context) {
-	while (ExecuteTask(context)) {
+QuackEmitProgress QuackRebalancerCore::ExecuteTasks(ClientContext &context,
+                                                    optional_ptr<const InterruptState> interrupt) {
+	while (true) {
+		// Capacity-parked retries first, lowest index first: the head of the stream is always
+		// admitted, so index order guarantees the drain makes progress once capacity frees.
+		unique_ptr<QuackEmitTask> task;
+		{
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			if (!parked_tasks.empty()) {
+				task = std::move(parked_tasks.begin()->second);
+				parked_tasks.erase(parked_tasks.begin());
+			}
+		}
+		if (!task) {
+			task = task_manager.GetTask();
+		}
+		if (!task) {
+			return QuackEmitProgress::DONE;
+		}
+		if (!TryEmitStamped(context, *task, interrupt)) {
+			annotated_lock_guard<annotated_mutex> guard(lock);
+			parked_tasks.emplace(task->dense_index, std::move(task));
+			return QuackEmitProgress::BLOCKED;
+		}
+		auto memory_usage = task->memory_usage;
+		if (memory_usage > 0) {
+			memory_manager.ReduceUnflushedMemory(memory_usage);
+			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+			memory_manager.UnblockTasks();
+		}
 	}
 }
 
@@ -78,7 +94,7 @@ void QuackRebalancerCore::FinalizeCut(ClientContext &context) {
 }
 
 void QuackRebalancerCore::FinalizeFinish(ClientContext &context) {
-	if (task_manager.TaskCount() != 0) {
+	if (TaskCount() != 0) {
 		throw InternalException("Unemitted batches remain in QuackRebalancerCore::FinalizeFinish");
 	}
 	memory_manager.FinalCheck();

--- a/src/quack_rebalancer_core.cpp
+++ b/src/quack_rebalancer_core.cpp
@@ -1,0 +1,88 @@
+#include "quack_rebalancer_core.hpp"
+
+namespace duckdb {
+
+QuackRebalancerCore::QuackRebalancerCore(ClientContext &context, idx_t buffer_bytes_override_p,
+                                         idx_t initial_memory_request, unique_ptr<QuackBatchEmitter> emitter_p)
+    : memory_manager(context, initial_memory_request), buffer_bytes_override(buffer_bytes_override_p),
+      emitter(std::move(emitter_p)) {
+}
+
+void QuackRebalancerCore::AddPendingFragment(ClientContext &context, idx_t executor_batch, idx_t min_batch_index,
+                                             idx_t memory_usage, unique_ptr<QuackPreparedBatch> prepared) {
+	// The fragment arrives already emit-ready (built on the producing thread as chunks arrived) —
+	// settling releases ready bytes, not work.
+	{
+		annotated_lock_guard<annotated_mutex> guard(lock);
+		raw_batches[executor_batch].emplace_back(memory_usage, std::move(prepared));
+	}
+	// The min batch's already-pushed fragments are a settled prefix of the dense stream (future
+	// fragments simply get later indices), so the frontier always includes them — regardless of caller.
+	ReleaseSettled(min_batch_index + 1);
+	// Blocked producers can help emit; also drain here so stamped batches hit the wire immediately.
+	{
+		annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+		memory_manager.UnblockTasks();
+	}
+	ExecuteTasks(context);
+}
+
+void QuackRebalancerCore::AddSettledData(ClientContext &context, unique_ptr<QuackPreparedBatch> prepared) {
+	emitter->EmitPrepared(context, next_dense++, std::move(prepared));
+}
+
+void QuackRebalancerCore::ReleaseSettled(idx_t min_exclusive) {
+	annotated_lock_guard<annotated_mutex> guard(lock);
+	for (auto entry = raw_batches.begin(); entry != raw_batches.end();) {
+		if (entry->first >= min_exclusive) {
+			break;
+		}
+		for (auto &fragment : entry->second) {
+			task_manager.AddTask(
+			    make_uniq<QuackEmitTask>(next_dense++, fragment.memory_usage, std::move(fragment.prepared)));
+		}
+		entry = raw_batches.erase(entry);
+	}
+}
+
+bool QuackRebalancerCore::ExecuteTask(ClientContext &context) {
+	auto task = task_manager.GetTask();
+	if (!task) {
+		return false;
+	}
+	auto memory_usage = task->memory_usage;
+	emitter->EmitPrepared(context, task->dense_index, std::move(task->prepared));
+	if (memory_usage > 0) {
+		memory_manager.ReduceUnflushedMemory(memory_usage);
+		annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+		memory_manager.UnblockTasks();
+	}
+	return true;
+}
+
+void QuackRebalancerCore::ExecuteTasks(ClientContext &context) {
+	while (ExecuteTask(context)) {
+	}
+}
+
+bool QuackRebalancerCore::OutOfMemory(idx_t batch_index) {
+	if (buffer_bytes_override > 0 && memory_manager.GetUnflushedMemory() > buffer_bytes_override &&
+	    !memory_manager.IsMinimumBatchIndex(batch_index)) {
+		return true;
+	}
+	return memory_manager.OutOfMemory(batch_index);
+}
+
+void QuackRebalancerCore::FinalizeCut(ClientContext &context) {
+	ReleaseSettled(NumericLimits<idx_t>::Maximum());
+}
+
+void QuackRebalancerCore::FinalizeFinish(ClientContext &context) {
+	if (task_manager.TaskCount() != 0) {
+		throw InternalException("Unemitted batches remain in QuackRebalancerCore::FinalizeFinish");
+	}
+	memory_manager.FinalCheck();
+	emitter->Finish(context, TotalBatches());
+}
+
+} // namespace duckdb

--- a/src/quack_rebalancer_sink.cpp
+++ b/src/quack_rebalancer_sink.cpp
@@ -30,7 +30,6 @@ idx_t QuackRebalancerGlobalState::MaxThreads(idx_t source_max_threads) {
 	}
 	auto &memory_manager = core->MemoryManager();
 	memory_manager.SetMemorySize(source_max_threads * minimum_memory_per_thread);
-	// cap the concurrent threads working on this sink by the amount of available memory
 	return MinValue<idx_t>(source_max_threads, memory_manager.AvailableMemory() / minimum_memory_per_thread + 1);
 }
 
@@ -42,7 +41,7 @@ unique_ptr<QuackRebalancerGlobalState> MakeQuackRebalancerGlobalState(ClientCont
 	    1, QuackGetUBigintSetting(context, "quack_target_batch_bytes", QUACK_TARGET_BATCH_BYTES_DEFAULT));
 	auto buffer_bytes_override =
 	    QuackGetUBigintSetting(context, "quack_rebalance_buffer_bytes", QUACK_REBALANCE_BUFFER_BYTES_DEFAULT);
-	// same heuristic as core's batch operators: 4MB of buffer space per column per thread
+	// core's batch operators use the same heuristic: 4MB for each column on each thread
 	auto minimum_memory_per_thread = MaxValue<idx_t>(types.size(), 1) * 4ULL * 1024ULL * 1024ULL;
 
 	auto global_state = make_uniq<QuackRebalancerGlobalState>(order_mode, target_bytes, minimum_memory_per_thread);
@@ -54,7 +53,6 @@ unique_ptr<QuackRebalancerGlobalState> MakeQuackRebalancerGlobalState(ClientCont
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
-// Seal this thread's current builder and shelve it as one fragment of its executor batch.
 static void PushLocalFragment(ClientContext &context, QuackRebalancerGlobalState &gstate,
                               QuackRebalancerLocalState &lstate) {
 	if (!lstate.builder) {
@@ -71,8 +69,7 @@ static void PushLocalFragment(ClientContext &context, QuackRebalancerGlobalState
 	lstate.last_chunk_bytes = 0;
 }
 
-// Seal + stamp this thread's builder into lstate.pending_emit (SERIAL_ORDERED / UNORDERED —
-// everything is settled on arrival). Emission is separate so a capacity-parked batch can be retried.
+// Emission stays separate from the stamp, so a parked batch can be retried without a second stamp.
 static void StampLocalFragment(ClientContext &context, QuackRebalancerGlobalState &gstate,
                                QuackRebalancerLocalState &lstate) {
 	if (!lstate.builder) {
@@ -91,9 +88,8 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 	auto &core = *gstate.core;
 
 	if (gstate.order_mode != AppendOrderMode::PARALLEL_ORDERED) {
-		// SERIAL_ORDERED / UNORDERED: everything is stampable on arrival — cut at the target and emit.
-		// A capacity-parked batch is retried BEFORE the chunk is consumed, so returning BLOCKED here
-		// is safe: the executor re-invokes Sink with the same chunk once the wake fires.
+		// The retry runs BEFORE the chunk is consumed, so BLOCKED is safe here: the executor calls
+		// Sink again with the same chunk after the wake.
 		if (lstate.pending_emit) {
 			if (!core.TryEmitStamped(context.client, *lstate.pending_emit, input.interrupt_state)) {
 				return SinkResultType::BLOCKED;
@@ -109,8 +105,8 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 		lstate.builder->Append(context.client, chunk);
 		lstate.local_count += chunk.size();
 		if (lstate.builder->SizeBytes() >= gstate.target_bytes) {
-			// The chunk is consumed, so we cannot yield anymore: probe the emit (no wake registered);
-			// if the buffer is full the batch stays pending and the NEXT call blocks before its chunk.
+			// The chunk is consumed, so this call cannot yield: probe only. A full buffer leaves the
+			// batch pending, and the next call blocks before it takes its chunk.
 			StampLocalFragment(context.client, gstate, lstate);
 			if (core.TryEmitStamped(context.client, *lstate.pending_emit, nullptr)) {
 				lstate.pending_emit.reset();
@@ -121,8 +117,7 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 
 	auto &memory_manager = core.MemoryManager();
 	auto batch_index = lstate.partition_info.batch_index.GetIndex();
-	// Retry capacity-parked emits first (chunk untouched — yielding is safe): freed client capacity
-	// is used promptly, and a still-full buffer parks this producer instead of growing memory.
+	// Retry parked emits first, while the chunk is untouched and a yield is safe.
 	if (core.HasParkedEmits()) {
 		if (core.ExecuteTasks(context.client, input.interrupt_state) == QuackEmitProgress::BLOCKED) {
 			return SinkResultType::BLOCKED;
@@ -135,7 +130,7 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 		if (!memory_manager.IsMinimumBatchIndex(batch_index) && core.OutOfMemory(batch_index)) {
 			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
 			if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
-				// still over budget and not the minimum batch: park this producer until the prefix drains
+				// still over budget and not the minimum batch: wait for the prefix to drain
 				return memory_manager.BlockSink(input.interrupt_state);
 			}
 		}
@@ -144,7 +139,7 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 	if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
 		memory_manager.UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
 		if (core.OutOfMemory(batch_index)) {
-			// over budget: stop sinking and help emit batches for the minimum batch index instead
+			// over budget: stop sinking and help to emit the minimum batch instead
 			lstate.processing_tasks = true;
 			return QuackRebalancerSink(context, chunk, input);
 		}
@@ -152,8 +147,8 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 	if (chunk.size() == 0) {
 		return SinkResultType::NEED_MORE_INPUT;
 	}
-	// Cut BEFORE the append that would cross the grain, so the settled frontier advances continuously
-	// mid-batch and the min batch's fragments stream out immediately.
+	// Cut BEFORE the append that would cross the grain. The settled frontier then moves forward
+	// inside a batch, and the min batch's fragments go out at once.
 	if (lstate.builder && lstate.fragment_bytes > 0 &&
 	    lstate.fragment_bytes + lstate.last_chunk_bytes > gstate.FragmentGrain()) {
 		PushLocalFragment(context.client, gstate, lstate);
@@ -178,8 +173,7 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 //===--------------------------------------------------------------------===//
 // NextBatch (PARALLEL_ORDERED path)
 //===--------------------------------------------------------------------===//
-// Push the finished batch's remaining fragment, then advance. NextBatch fires BEFORE the new batch's
-// first Sink, so lstate.batch_index is still the OLD batch here.
+// NextBatch runs BEFORE the new batch's first Sink, so lstate.batch_index is still the old batch.
 SinkNextBatchType QuackRebalancerNextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) {
 	auto &gstate = input.global_state.Cast<QuackRebalancerGlobalState>();
 	auto &lstate = input.local_state.Cast<QuackRebalancerLocalState>();
@@ -198,8 +192,8 @@ SinkNextBatchType QuackRebalancerNextBatch(ExecutionContext &context, OperatorSi
 //===--------------------------------------------------------------------===//
 // Combine
 //===--------------------------------------------------------------------===//
-// May return BLOCKED (capacity-parked emit) and be re-invoked; every step below is a no-op on
-// re-entry once its state is consumed (builder reset, pending_emit reset, local_count zeroed).
+// A parked emit makes this return BLOCKED, and the executor calls it again. Each step below does
+// nothing on the second call, because the first call cleared its state.
 SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, OperatorSinkCombineInput &input) {
 	auto &gstate = input.global_state.Cast<QuackRebalancerGlobalState>();
 	auto &lstate = input.local_state.Cast<QuackRebalancerLocalState>();
@@ -207,7 +201,7 @@ SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, Operator
 
 	if (gstate.order_mode == AppendOrderMode::PARALLEL_ORDERED) {
 		if (lstate.batch_index.IsValid()) {
-			PushLocalFragment(context.client, gstate, lstate); // no-op once the builder is consumed
+			PushLocalFragment(context.client, gstate, lstate);
 		}
 		core.MemoryManager().UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
 		if (core.ExecuteTasks(context.client, input.interrupt_state) == QuackEmitProgress::BLOCKED) {
@@ -236,8 +230,8 @@ SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, Operator
 //===--------------------------------------------------------------------===//
 // Finalize
 //===--------------------------------------------------------------------===//
-// The final cut can leave several stamped batches queued (every producer's tail settles at once);
-// drain them across threads instead of on the one Finalize thread, then FinishEvent closes the stream.
+// The final cut can leave several stamped batches queued, because every producer's tail settles at
+// the same time. These tasks drain them in parallel, then FinishEvent closes the stream.
 class QuackEmitRemainingTask : public ExecutorTask {
 public:
 	QuackEmitRemainingTask(Executor &executor, shared_ptr<Event> event_p, QuackRebalancerGlobalState &gstate_p,
@@ -246,8 +240,8 @@ public:
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
-		// The client may be slow to drain the buffer: yield on capacity instead of parking a
-		// scheduler thread; the buffer's capacity wake reschedules this task and we re-enter here.
+		// A slow client must not stop a scheduler thread: yield instead. The buffer's wake puts this
+		// task back on the queue.
 		InterruptState interrupt(shared_from_this());
 		if (gstate.core->ExecuteTasks(context, interrupt) == QuackEmitProgress::BLOCKED) {
 			return TaskExecutionResult::TASK_BLOCKED;

--- a/src/quack_rebalancer_sink.cpp
+++ b/src/quack_rebalancer_sink.cpp
@@ -1,0 +1,262 @@
+#include "quack_rebalancer_sink.hpp"
+
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/parallel/base_pipeline_event.hpp"
+#include "duckdb/parallel/executor_task.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+namespace duckdb {
+
+idx_t QuackGetUBigintSetting(ClientContext &context, const char *name, idx_t default_value) {
+	Value val;
+	if (context.TryGetCurrentSetting(name, val) && !val.IsNull()) {
+		return val.GetValue<uint64_t>();
+	}
+	return default_value;
+}
+
+idx_t QuackGetUBigintSetting(DatabaseInstance &db, const char *name, idx_t default_value) {
+	Value val;
+	if (DBConfig::GetConfig(db).TryGetCurrentSetting(name, val) && !val.IsNull()) {
+		return val.GetValue<uint64_t>();
+	}
+	return default_value;
+}
+
+idx_t QuackRebalancerGlobalState::MaxThreads(idx_t source_max_threads) {
+	if (order_mode != AppendOrderMode::PARALLEL_ORDERED) {
+		return source_max_threads;
+	}
+	auto &memory_manager = core->MemoryManager();
+	memory_manager.SetMemorySize(source_max_threads * minimum_memory_per_thread);
+	// cap the concurrent threads working on this sink by the amount of available memory
+	return MinValue<idx_t>(source_max_threads, memory_manager.AvailableMemory() / minimum_memory_per_thread + 1);
+}
+
+unique_ptr<QuackRebalancerGlobalState> MakeQuackRebalancerGlobalState(ClientContext &context,
+                                                                      const vector<LogicalType> &types,
+                                                                      AppendOrderMode order_mode,
+                                                                      unique_ptr<QuackBatchEmitter> emitter) {
+	auto target_bytes = MaxValue<idx_t>(
+	    1, QuackGetUBigintSetting(context, "quack_target_batch_bytes", QUACK_TARGET_BATCH_BYTES_DEFAULT));
+	auto buffer_bytes_override =
+	    QuackGetUBigintSetting(context, "quack_rebalance_buffer_bytes", QUACK_REBALANCE_BUFFER_BYTES_DEFAULT);
+	// same heuristic as core's batch operators: 4MB of buffer space per column per thread
+	auto minimum_memory_per_thread = MaxValue<idx_t>(types.size(), 1) * 4ULL * 1024ULL * 1024ULL;
+
+	auto global_state = make_uniq<QuackRebalancerGlobalState>(order_mode, target_bytes, minimum_memory_per_thread);
+	global_state->core =
+	    make_uniq<QuackRebalancerCore>(context, buffer_bytes_override, minimum_memory_per_thread, std::move(emitter));
+	return global_state;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+// Seal this thread's current builder and shelve it as one fragment of its executor batch.
+static void PushLocalFragment(ClientContext &context, QuackRebalancerGlobalState &gstate,
+                              QuackRebalancerLocalState &lstate) {
+	if (!lstate.builder) {
+		return;
+	}
+	auto min_batch_index = lstate.partition_info.min_batch_index.GetIndex();
+	auto prepared = lstate.builder->Seal(context);
+	lstate.size_hint = lstate.builder->SizeBytes();
+	lstate.builder.reset();
+	gstate.core->AddPendingFragment(context, lstate.batch_index.GetIndex(), min_batch_index, lstate.local_memory_usage,
+	                                std::move(prepared));
+	lstate.local_memory_usage = 0;
+	lstate.fragment_bytes = 0;
+	lstate.last_chunk_bytes = 0;
+}
+
+// Seal and emit immediately (SERIAL_ORDERED / UNORDERED — everything is settled on arrival).
+static void EmitLocalFragment(ClientContext &context, QuackRebalancerGlobalState &gstate,
+                              QuackRebalancerLocalState &lstate) {
+	if (!lstate.builder) {
+		return;
+	}
+	auto prepared = lstate.builder->Seal(context);
+	lstate.size_hint = lstate.builder->SizeBytes();
+	lstate.builder.reset();
+	gstate.core->AddSettledData(context, std::move(prepared));
+}
+
+SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) {
+	auto &gstate = input.global_state.Cast<QuackRebalancerGlobalState>();
+	auto &lstate = input.local_state.Cast<QuackRebalancerLocalState>();
+	auto &core = *gstate.core;
+
+	if (gstate.order_mode != AppendOrderMode::PARALLEL_ORDERED) {
+		// SERIAL_ORDERED / UNORDERED: everything is stampable on arrival — cut at the target and emit.
+		if (chunk.size() == 0) {
+			return SinkResultType::NEED_MORE_INPUT;
+		}
+		if (!lstate.builder) {
+			lstate.builder = core.OpenFragment(context.client, lstate.size_hint);
+		}
+		lstate.builder->Append(context.client, chunk);
+		lstate.local_count += chunk.size();
+		if (lstate.builder->SizeBytes() >= gstate.target_bytes) {
+			EmitLocalFragment(context.client, gstate, lstate);
+		}
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	auto &memory_manager = core.MemoryManager();
+	auto batch_index = lstate.partition_info.batch_index.GetIndex();
+	if (lstate.processing_tasks) {
+		core.ExecuteTasks(context.client);
+		if (!memory_manager.IsMinimumBatchIndex(batch_index) && core.OutOfMemory(batch_index)) {
+			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
+			if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
+				// still over budget and not the minimum batch: park this producer until the prefix drains
+				return memory_manager.BlockSink(input.interrupt_state);
+			}
+		}
+		lstate.processing_tasks = false;
+	}
+	if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
+		memory_manager.UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
+		if (core.OutOfMemory(batch_index)) {
+			// over budget: stop sinking and help emit batches for the minimum batch index instead
+			lstate.processing_tasks = true;
+			return QuackRebalancerSink(context, chunk, input);
+		}
+	}
+	if (chunk.size() == 0) {
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+	// Cut BEFORE the append that would cross the grain, so the settled frontier advances continuously
+	// mid-batch and the min batch's fragments stream out immediately.
+	if (lstate.builder && lstate.fragment_bytes > 0 &&
+	    lstate.fragment_bytes + lstate.last_chunk_bytes > gstate.FragmentGrain()) {
+		PushLocalFragment(context.client, gstate, lstate);
+	}
+	if (!lstate.builder) {
+		lstate.builder = core.OpenFragment(context.client, lstate.size_hint);
+		lstate.batch_index = batch_index;
+	}
+	lstate.builder->Append(context.client, chunk);
+	lstate.local_count += chunk.size();
+	auto new_bytes = lstate.builder->SizeBytes();
+	lstate.last_chunk_bytes = new_bytes - lstate.fragment_bytes;
+	lstate.fragment_bytes = new_bytes;
+	auto new_memory_usage = lstate.builder->AllocatedBytes();
+	if (new_memory_usage > lstate.local_memory_usage) {
+		memory_manager.IncreaseUnflushedMemory(new_memory_usage - lstate.local_memory_usage);
+		lstate.local_memory_usage = new_memory_usage;
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// NextBatch (PARALLEL_ORDERED path)
+//===--------------------------------------------------------------------===//
+// Push the finished batch's remaining fragment, then advance. NextBatch fires BEFORE the new batch's
+// first Sink, so lstate.batch_index is still the OLD batch here.
+SinkNextBatchType QuackRebalancerNextBatch(ExecutionContext &context, OperatorSinkNextBatchInput &input) {
+	auto &gstate = input.global_state.Cast<QuackRebalancerGlobalState>();
+	auto &lstate = input.local_state.Cast<QuackRebalancerLocalState>();
+	if (gstate.order_mode != AppendOrderMode::PARALLEL_ORDERED) {
+		return SinkNextBatchType::READY;
+	}
+
+	if (lstate.batch_index.IsValid()) {
+		PushLocalFragment(context.client, gstate, lstate);
+	}
+	gstate.core->MemoryManager().UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
+	lstate.batch_index = lstate.partition_info.batch_index;
+	return SinkNextBatchType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, OperatorSinkCombineInput &input) {
+	auto &gstate = input.global_state.Cast<QuackRebalancerGlobalState>();
+	auto &lstate = input.local_state.Cast<QuackRebalancerLocalState>();
+	auto &core = *gstate.core;
+
+	if (gstate.order_mode == AppendOrderMode::PARALLEL_ORDERED) {
+		if (lstate.batch_index.IsValid()) {
+			PushLocalFragment(context.client, gstate, lstate);
+		}
+		core.MemoryManager().UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
+		core.ExecuteTasks(context.client);
+	} else {
+		EmitLocalFragment(context.client, gstate, lstate);
+	}
+	gstate.row_count += lstate.local_count;
+	return SinkCombineResultType::FINISHED;
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+// The final cut can leave several stamped batches queued (every producer's tail settles at once);
+// drain them across threads instead of on the one Finalize thread, then FinishEvent closes the stream.
+class QuackEmitRemainingTask : public ExecutorTask {
+public:
+	QuackEmitRemainingTask(Executor &executor, shared_ptr<Event> event_p, QuackRebalancerGlobalState &gstate_p,
+	                       ClientContext &context_p)
+	    : ExecutorTask(executor, std::move(event_p)), gstate(gstate_p), context(context_p) {
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		gstate.core->ExecuteTasks(context);
+		event->FinishTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+	string TaskType() const override {
+		return "QuackEmitRemainingTask";
+	}
+
+private:
+	QuackRebalancerGlobalState &gstate;
+	ClientContext &context;
+};
+
+class QuackEmitRemainingEvent : public BasePipelineEvent {
+public:
+	QuackEmitRemainingEvent(QuackRebalancerGlobalState &gstate_p, Pipeline &pipeline_p, ClientContext &context_p)
+	    : BasePipelineEvent(pipeline_p), gstate(gstate_p), context(context_p) {
+	}
+
+	void Schedule() override {
+		vector<shared_ptr<Task>> tasks;
+		auto num_threads =
+		    MinValue<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads(), gstate.core->TaskCount());
+		for (idx_t i = 0; i < num_threads; i++) {
+			tasks.push_back(make_uniq<QuackEmitRemainingTask>(pipeline->executor, shared_from_this(), gstate, context));
+		}
+		D_ASSERT(!tasks.empty());
+		SetTasks(std::move(tasks));
+	}
+
+	void FinishEvent() override {
+		gstate.core->FinalizeFinish(context);
+	}
+
+private:
+	QuackRebalancerGlobalState &gstate;
+	ClientContext &context;
+};
+
+SinkFinalizeType QuackRebalancerFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                         QuackRebalancerGlobalState &gstate) {
+	auto &core = *gstate.core;
+	core.FinalizeCut(context);
+	if (core.TaskCount() <= 1) {
+		core.ExecuteTasks(context);
+		core.FinalizeFinish(context);
+	} else {
+		// several stamped batches remain: emit them in parallel before closing the stream
+		event.InsertEvent(make_shared_ptr<QuackEmitRemainingEvent>(gstate, pipeline, context));
+	}
+	return SinkFinalizeType::READY;
+}
+
+} // namespace duckdb

--- a/src/quack_rebalancer_sink.cpp
+++ b/src/quack_rebalancer_sink.cpp
@@ -71,16 +71,18 @@ static void PushLocalFragment(ClientContext &context, QuackRebalancerGlobalState
 	lstate.last_chunk_bytes = 0;
 }
 
-// Seal and emit immediately (SERIAL_ORDERED / UNORDERED — everything is settled on arrival).
-static void EmitLocalFragment(ClientContext &context, QuackRebalancerGlobalState &gstate,
-                              QuackRebalancerLocalState &lstate) {
+// Seal + stamp this thread's builder into lstate.pending_emit (SERIAL_ORDERED / UNORDERED —
+// everything is settled on arrival). Emission is separate so a capacity-parked batch can be retried.
+static void StampLocalFragment(ClientContext &context, QuackRebalancerGlobalState &gstate,
+                               QuackRebalancerLocalState &lstate) {
 	if (!lstate.builder) {
 		return;
 	}
+	D_ASSERT(!lstate.pending_emit);
 	auto prepared = lstate.builder->Seal(context);
 	lstate.size_hint = lstate.builder->SizeBytes();
 	lstate.builder.reset();
-	gstate.core->AddSettledData(context, std::move(prepared));
+	lstate.pending_emit = gstate.core->StampSettled(std::move(prepared));
 }
 
 SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) {
@@ -90,6 +92,14 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 
 	if (gstate.order_mode != AppendOrderMode::PARALLEL_ORDERED) {
 		// SERIAL_ORDERED / UNORDERED: everything is stampable on arrival — cut at the target and emit.
+		// A capacity-parked batch is retried BEFORE the chunk is consumed, so returning BLOCKED here
+		// is safe: the executor re-invokes Sink with the same chunk once the wake fires.
+		if (lstate.pending_emit) {
+			if (!core.TryEmitStamped(context.client, *lstate.pending_emit, input.interrupt_state)) {
+				return SinkResultType::BLOCKED;
+			}
+			lstate.pending_emit.reset();
+		}
 		if (chunk.size() == 0) {
 			return SinkResultType::NEED_MORE_INPUT;
 		}
@@ -99,15 +109,29 @@ SinkResultType QuackRebalancerSink(ExecutionContext &context, DataChunk &chunk, 
 		lstate.builder->Append(context.client, chunk);
 		lstate.local_count += chunk.size();
 		if (lstate.builder->SizeBytes() >= gstate.target_bytes) {
-			EmitLocalFragment(context.client, gstate, lstate);
+			// The chunk is consumed, so we cannot yield anymore: probe the emit (no wake registered);
+			// if the buffer is full the batch stays pending and the NEXT call blocks before its chunk.
+			StampLocalFragment(context.client, gstate, lstate);
+			if (core.TryEmitStamped(context.client, *lstate.pending_emit, nullptr)) {
+				lstate.pending_emit.reset();
+			}
 		}
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
 	auto &memory_manager = core.MemoryManager();
 	auto batch_index = lstate.partition_info.batch_index.GetIndex();
+	// Retry capacity-parked emits first (chunk untouched — yielding is safe): freed client capacity
+	// is used promptly, and a still-full buffer parks this producer instead of growing memory.
+	if (core.HasParkedEmits()) {
+		if (core.ExecuteTasks(context.client, input.interrupt_state) == QuackEmitProgress::BLOCKED) {
+			return SinkResultType::BLOCKED;
+		}
+	}
 	if (lstate.processing_tasks) {
-		core.ExecuteTasks(context.client);
+		if (core.ExecuteTasks(context.client, input.interrupt_state) == QuackEmitProgress::BLOCKED) {
+			return SinkResultType::BLOCKED;
+		}
 		if (!memory_manager.IsMinimumBatchIndex(batch_index) && core.OutOfMemory(batch_index)) {
 			annotated_lock_guard<annotated_mutex> guard(memory_manager.lock);
 			if (!memory_manager.IsMinimumBatchIndex(batch_index)) {
@@ -174,6 +198,8 @@ SinkNextBatchType QuackRebalancerNextBatch(ExecutionContext &context, OperatorSi
 //===--------------------------------------------------------------------===//
 // Combine
 //===--------------------------------------------------------------------===//
+// May return BLOCKED (capacity-parked emit) and be re-invoked; every step below is a no-op on
+// re-entry once its state is consumed (builder reset, pending_emit reset, local_count zeroed).
 SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, OperatorSinkCombineInput &input) {
 	auto &gstate = input.global_state.Cast<QuackRebalancerGlobalState>();
 	auto &lstate = input.local_state.Cast<QuackRebalancerLocalState>();
@@ -181,14 +207,29 @@ SinkCombineResultType QuackRebalancerCombine(ExecutionContext &context, Operator
 
 	if (gstate.order_mode == AppendOrderMode::PARALLEL_ORDERED) {
 		if (lstate.batch_index.IsValid()) {
-			PushLocalFragment(context.client, gstate, lstate);
+			PushLocalFragment(context.client, gstate, lstate); // no-op once the builder is consumed
 		}
 		core.MemoryManager().UpdateMinBatchIndex(lstate.partition_info.min_batch_index.GetIndex());
-		core.ExecuteTasks(context.client);
+		if (core.ExecuteTasks(context.client, input.interrupt_state) == QuackEmitProgress::BLOCKED) {
+			return SinkCombineResultType::BLOCKED;
+		}
 	} else {
-		EmitLocalFragment(context.client, gstate, lstate);
+		if (lstate.pending_emit) {
+			if (!core.TryEmitStamped(context.client, *lstate.pending_emit, input.interrupt_state)) {
+				return SinkCombineResultType::BLOCKED;
+			}
+			lstate.pending_emit.reset();
+		}
+		if (lstate.builder) {
+			StampLocalFragment(context.client, gstate, lstate);
+			if (!core.TryEmitStamped(context.client, *lstate.pending_emit, input.interrupt_state)) {
+				return SinkCombineResultType::BLOCKED;
+			}
+			lstate.pending_emit.reset();
+		}
 	}
 	gstate.row_count += lstate.local_count;
+	lstate.local_count = 0;
 	return SinkCombineResultType::FINISHED;
 }
 
@@ -205,7 +246,12 @@ public:
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
-		gstate.core->ExecuteTasks(context);
+		// The client may be slow to drain the buffer: yield on capacity instead of parking a
+		// scheduler thread; the buffer's capacity wake reschedules this task and we re-enter here.
+		InterruptState interrupt(shared_from_this());
+		if (gstate.core->ExecuteTasks(context, interrupt) == QuackEmitProgress::BLOCKED) {
+			return TaskExecutionResult::TASK_BLOCKED;
+		}
 		event->FinishTask();
 		return TaskExecutionResult::TASK_FINISHED;
 	}
@@ -249,11 +295,11 @@ SinkFinalizeType QuackRebalancerFinalize(Pipeline &pipeline, Event &event, Clien
                                          QuackRebalancerGlobalState &gstate) {
 	auto &core = *gstate.core;
 	core.FinalizeCut(context);
-	if (core.TaskCount() <= 1) {
-		core.ExecuteTasks(context);
+	// A single batch emits here. Several batches, or one that parks on capacity, go to the event
+	// tasks: those emit in parallel, and they can yield when the delivery buffer is full.
+	if (core.TaskCount() <= 1 && core.ExecuteTasks(context) == QuackEmitProgress::DONE) {
 		core.FinalizeFinish(context);
 	} else {
-		// several stamped batches remain: emit them in parallel before closing the stream
 		event.InsertEvent(make_shared_ptr<QuackEmitRemainingEvent>(gstate, pipeline, context));
 	}
 	return SinkFinalizeType::READY;

--- a/src/quack_result_cache.cpp
+++ b/src/quack_result_cache.cpp
@@ -3,41 +3,16 @@
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/main/query_result.hpp"
-#include "duckdb/main/stream_query_result.hpp"
 
-#include "quack_message.hpp"
+#include "quack_fetch_collector.hpp"
 #include "quack_server.hpp"
 
 namespace duckdb {
 
-static vector<unique_ptr<DataChunkWrapper>> CreateBatch(unique_ptr<QueryResult> &query_result, idx_t max_rows) {
-	vector<unique_ptr<DataChunkWrapper>> results;
-	idx_t rows = 0;
-	while (rows < max_rows) {
-		auto result_chunk = query_result->Fetch();
-		if (!result_chunk && query_result->HasError()) {
-			results.clear();
-			return results;
-		}
-		if (!result_chunk || result_chunk->size() == 0) {
-			query_result.reset();
-			break;
-		}
-		rows += result_chunk->size();
-		results.push_back(make_uniq<DataChunkWrapper>(*result_chunk));
-	}
-	return results;
-}
-
 QuackResultCache::~QuackResultCache() {
-	if (tail && tail->GetResultType() == QueryResultType::STREAM_RESULT) {
-		try {
-			// If it's a stream we gotta close it
-			tail->Cast<StreamQueryResult>().Close();
-		} catch (...) {
-		}
-	}
+	// Dropping the reference only releases the retained payloads. The query behind the stream is
+	// owned by the connection's fetch state, so whoever drops a cache that is still serving must
+	// abort that stream as well -- see ExpireCacheIfStale's `still_serving`.
 	(*live_caches)--;
 }
 
@@ -70,7 +45,9 @@ int64_t ResultTtlMicros(DatabaseInstance &db) {
 	return NumericCast<int64_t>(ttl_seconds) * Interval::MICROS_PER_SEC;
 }
 
-unique_ptr<QuackResultCache> ExpireCacheIfStale(QuackConnection &connection, timestamp_t now, int64_t ttl_micros) {
+unique_ptr<QuackResultCache> ExpireCacheIfStale(QuackConnection &connection, timestamp_t now, int64_t ttl_micros,
+                                                bool &still_serving) {
+	still_serving = false;
 	auto &cache = connection.result_cache;
 	if (!cache || ttl_micros == 0) {
 		return nullptr;
@@ -79,53 +56,13 @@ unique_ptr<QuackResultCache> ExpireCacheIfStale(QuackConnection &connection, tim
 		return nullptr;
 	}
 	// an expired unfinished stream must fail loudly on later fetches instead of silently truncating
-	if (cache->query_uuid == connection.query_uuid && cache->tail) {
+	if (cache->query_uuid == connection.query_uuid && cache->stream && !cache->stream->buffer.Exhausted()) {
 		connection.query_state = QuackQueryState::CANCELLED;
+		still_serving = true;
 	}
 	auto doomed = std::move(connection.result_cache);
 	connection.ClearResultCache();
 	return doomed;
-}
-
-bool HasMoreResults(QuackConnection &connection) {
-	auto &cache = connection.result_cache;
-	if (cache && cache->query_uuid == connection.query_uuid) {
-		return cache->tail != nullptr;
-	}
-	return connection.duckdb_query_result != nullptr;
-}
-
-vector<unique_ptr<DataChunkWrapper>> ServeBatch(QuackConnection &connection, idx_t max_rows, idx_t max_cache_rows) {
-	auto cache = connection.result_cache.get();
-	if (!cache || cache->query_uuid != connection.query_uuid) {
-		return CreateBatch(connection.duckdb_query_result, max_rows);
-	}
-	cache->last_served_at = Timestamp::GetCurrentTimestamp();
-	vector<unique_ptr<DataChunkWrapper>> results;
-	idx_t rows = 0;
-	while (rows < max_rows && cache->tail) {
-		auto result_chunk = cache->tail->Fetch();
-		if (!result_chunk && cache->tail->HasError()) {
-			connection.duckdb_query_result = std::move(cache->tail);
-			connection.ClearResultCache();
-			return vector<unique_ptr<DataChunkWrapper>>();
-		}
-		if (!result_chunk || result_chunk->size() == 0) {
-			cache->tail.reset();
-			break;
-		}
-		rows += result_chunk->size();
-		// the single-argument Append keeps no append state between batches: a retained state pins the
-		// current 256KB block in the buffer manager for the whole life of the cache
-		cache->retained.Append(*result_chunk);
-		results.push_back(make_uniq<DataChunkWrapper>(*result_chunk));
-	}
-	if (max_cache_rows != 0 && cache->retained.Count() > max_cache_rows) {
-		// Too large to replay, hand the tail back to plain streaming and drop the cache
-		connection.duckdb_query_result = std::move(cache->tail);
-		connection.ClearResultCache();
-	}
-	return results;
 }
 
 } // namespace duckdb

--- a/src/quack_result_cache.cpp
+++ b/src/quack_result_cache.cpp
@@ -10,9 +10,8 @@
 namespace duckdb {
 
 QuackResultCache::~QuackResultCache() {
-	// Dropping the reference only releases the retained payloads. The query behind the stream is
-	// owned by the connection's fetch state, so whoever drops a cache that is still serving must
-	// abort that stream as well -- see ExpireCacheIfStale's `still_serving`.
+	// This releases the retained payloads only. The connection's fetch state owns the query, so a
+	// caller that drops a cache which still serves must abort that stream as well.
 	(*live_caches)--;
 }
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -102,14 +102,14 @@ shared_ptr<QuackDataStream> QuackInsertState::StreamForDeadRangeOrBuffer(const s
 	return nullptr;
 }
 
-//! A fetch stream + its producer thread, taken off the connection so aborting can run unlocked.
+//! A fetch stream and its producer thread, taken off the connection so an abort can run unlocked.
 struct DetachedFetchStream {
 	shared_ptr<QuackFetchStream> stream;
 	std::thread thread;
 };
 
-//! Error the buffer so consumers and capacity-blocked producers wake, interrupt the query if it is
-//! still running, join the producer. Call WITHOUT the connection lock.
+//! Error the buffer, so consumers and parked producers wake. Interrupt the query if it still runs,
+//! then join the producer. Call this WITHOUT the connection lock.
 static void AbortDetachedFetch(QuackConnection &connection, DetachedFetchStream detached, const string &reason) {
 	if (detached.stream) {
 		auto was_finished = detached.stream->buffer.Finished();
@@ -123,7 +123,7 @@ static void AbortDetachedFetch(QuackConnection &connection, DetachedFetchStream 
 	}
 }
 
-//! Stop + join the connection's fetch collector. Call WITHOUT the connection lock.
+//! Stop and join the connection's fetch collector. Call this WITHOUT the connection lock.
 static void AbortFetchStream(QuackConnection &connection, const string &reason) {
 	DetachedFetchStream detached;
 	{
@@ -131,7 +131,7 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 		detached.stream = std::move(connection.fetch.stream);
 		detached.thread = std::move(connection.fetch.thread);
 		if (detached.stream) {
-			// the abort reason must never mask a real failure: prefer the stream's own error
+			// the abort reason must not hide a real failure
 			connection.fetch.abort_error = detached.stream->buffer.HasError()
 			                                   ? detached.stream->buffer.GetError()
 			                                   : ErrorData(ExceptionType::INTERRUPT, reason);
@@ -140,15 +140,15 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 	AbortDetachedFetch(connection, std::move(detached), reason);
 }
 
-//! Background thread: runs the client's query with the fetch collector plugged in, holding the
-//! connection lock for its duration; the query executes in parallel into the stream's claim buffer.
+//! Runs the client's query with the fetch collector installed, and holds the connection lock for
+//! the full duration. The query fills the stream's claim buffer in parallel.
 static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStream> stream, string sql) {
 	try {
 		unique_lock<mutex> guard(connection.lock);
 		auto &context = *connection.duckdb_connection->context;
 
-		// MakeQuackFetchCollector routes the FIRST result-returning statement into the stream (the
-		// protocol's historical multi-statement semantics); other statements keep the default collector.
+		// MakeQuackFetchCollector sends the FIRST statement that returns a result into the stream.
+		// Every other statement keeps the default collector.
 		auto &config = ClientConfig::GetConfig(context);
 		config.get_result_collector = [stream](ClientContext &ctx, PreparedStatementData &data) {
 			return MakeQuackFetchCollector(ctx, data, stream);
@@ -157,7 +157,7 @@ static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStre
 		try {
 			result = connection.duckdb_connection->Query(sql);
 		} catch (...) {
-			// leave no dangling collector hook on the connection's config
+			// leave no collector hook on the connection's config
 			config.get_result_collector = nullptr;
 			throw;
 		}
@@ -165,8 +165,8 @@ static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStre
 		if (result->HasError()) {
 			stream->buffer.SetError(result->GetErrorObject());
 		} else if (!stream->Bound()) {
-			// No collector claimed the stream (no statement returned a query result): route the last
-			// statement's Success/Count result through, as the protocol always has. Columnless = error.
+			// No collector claimed the stream, because no statement returned a result. Send the last
+			// statement's Success/Count result, as the protocol always has. No columns is an error.
 			if (result->names.empty()) {
 				stream->buffer.SetError(ErrorData(ExceptionType::INVALID_INPUT, "Query did not return any columns"));
 				stream->buffer.Finish();
@@ -203,12 +203,12 @@ static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStre
 	} catch (std::exception &ex) {
 		stream->buffer.SetError(ErrorData(ex));
 	}
-	// Close against the collector's announced total: a short stream errors instead of truncating.
+	// Close against the announced total, so a short stream errors instead of truncating.
 	stream->buffer.Finish(stream->announced_total);
 }
 
 QuackConnection::~QuackConnection() {
-	// Abort + join any in-flight INSERT and fetch collector before members are destroyed.
+	// Abort and join the INSERT and the fetch collector before the members go away.
 	insert.Detach().AbortAndJoin("connection closed during insert");
 	AbortFetchStream(*this, "connection closed during fetch");
 }
@@ -534,7 +534,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto effective_sql = (auth_result.type().id() == LogicalTypeId::VARCHAR) ? auth_result.GetValue<string>()
 		                                                                         : prepare_request_message.Query();
 
-		// stop any previous producer before touching connection state (joins its thread → lock is free)
+		// Stop the previous producer first. This joins its thread, so it frees the connection lock.
 		AbortFetchStream(connection, "superseded by a new query");
 		{
 			std::unique_lock<std::mutex> lock(connection.lock);
@@ -549,8 +549,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		    QuackGetUBigintSetting(db, "quack_fetch_producer_buffer_bytes", QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT));
 		DetachedFetchStream superseded;
 		{
-			// Swap-install atomically: a concurrent PREPARE may have installed a producer since the
-			// abort above, and assigning over a joinable std::thread would terminate the process.
+			// Install under one lock. A concurrent PREPARE can install a producer after the abort
+			// above, and an assignment over a joinable std::thread would stop the process.
 			lock_guard<mutex> guard(connection.fetch.lock);
 			superseded.stream = std::move(connection.fetch.stream);
 			superseded.thread = std::move(connection.fetch.thread);
@@ -562,7 +562,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		AbortDetachedFetch(connection, std::move(superseded), "superseded by a new query");
 
 		if (!stream->WaitBound()) {
-			// planning failed before a collector existed — surface the error and clean up
+			// planning failed before a collector existed
 			auto error = stream->buffer.GetError();
 			AbortFetchStream(connection, "query failed");
 			std::unique_lock<std::mutex> lock(connection.lock);
@@ -571,8 +571,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>(error);
 		}
 
-		// Inline the leading batches into the PREPARE response so small results arrive in one round
-		// trip (catalog enumeration never FETCHes); FETCH indices are remapped by the consumed count.
+		// Put the leading batches in the PREPARE response, so a small result needs one round trip
+		// only. The FETCH indices then move down by the count this drain consumed.
 		idx_t max_inline_rows =
 		    QuackGetUBigintSetting(db, "quack_prepare_inline_rows", QUACK_PREPARE_INLINE_ROWS_DEFAULT);
 		vector<unique_ptr<DataChunkWrapper>> results;
@@ -584,7 +584,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			if (status == QuackClaimPopStatus::BATCH) {
 				consumed++;
 				inline_rows += entry.rows;
-				// Batches are stored pre-serialized; only this inline drain decodes them back to chunks.
+				// Batches are stored serialized. This drain is the only place that decodes them.
 				MemoryStream payload_stream(entry.payload->GetData(), entry.payload_size);
 				auto inline_message = QuackMessage::FromMemoryStream(payload_stream);
 				for (auto &wrapper : inline_message->Cast<FetchResponseMessage>().MutableResults()) {
@@ -606,8 +606,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			stream->buffer.WaitForBatch(consumed + 1);
 		}
 		stream->prepare_batches = consumed;
-		// If the drain did not observe a CLEAN stream end, optimistically report more: a spurious true
-		// costs one terminal FETCH; false on an errored buffer would report a truncated result complete.
+		// Report more unless the drain saw a CLEAN end. A wrong true costs one more FETCH. A wrong
+		// false on an errored buffer would report a truncated result as complete.
 		auto needs_more_fetch = !stream->buffer.Exhausted() || stream->buffer.HasError();
 		if (!needs_more_fetch) {
 			connection.query_state = QuackQueryState::FINISHED;
@@ -620,8 +620,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
 		auto &connection = *connection_p;
 
-		// no connection.lock here: the producer thread holds it for the query's duration; FETCH only
-		// touches the stream's buffer
+		// No connection.lock here: the producer thread holds it, and FETCH touches only the buffer.
 		shared_ptr<QuackFetchStream> stream;
 		hugeint_t stream_uuid;
 		ErrorData abort_error;
@@ -641,13 +640,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>("FETCH_REQUEST is missing its batch index");
 		}
 
-		// The request names its batch (client-visible; add back the batches PREPARE consumed inline).
-		// Served payloads are retained until acked so a transport retry re-serves the SAME batch.
+		// The request names its batch, so add back the batches PREPARE consumed inline. Served
+		// payloads stay until the client acks them, so a transport retry gets the SAME batch.
 		auto dense_index = fetch_request_message.batch_index + stream->prepare_batches;
 		auto dense_ack = fetch_request_message.ack_index + stream->prepare_batches;
 		{
 			lock_guard<mutex> guard(stream->serve_lock);
-			// everything <= the ack was received by the client and can never be re-requested
+			// the client has everything up to the ack, and cannot ask for it again
 			stream->served.erase(stream->served.begin(), stream->served.upper_bound(dense_ack));
 		}
 
@@ -655,17 +654,17 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			QuackClaimPopStatus status;
 			QuackFetchPayload entry;
 			{
-				// One critical section for retained-check + pop + retain: a concurrent retry of the same
-				// index can never fall through to FINISHED while the original is mid-serve.
+				// One critical section for the check, the pop and the retain. A concurrent retry of the
+				// same index cannot reach FINISHED while the first serve runs.
 				lock_guard<mutex> guard(stream->serve_lock);
 				auto retained = stream->served.find(dense_index);
 				if (retained != stream->served.end()) {
-					// re-serve (already patched with the client-visible index)
+					// already patched with the client-visible index
 					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, retained->second);
 				}
 				status = stream->buffer.TryPopClaimed(dense_index, entry);
 				if (status == QuackClaimPopStatus::BATCH) {
-					// re-stamp the sealed payload with the client-visible index; retain it for retries
+					// stamp the client-visible index, then keep the payload for a retry
 					QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset,
 					                            fetch_request_message.batch_index);
 					shared_ptr<MemoryStream> payload(std::move(entry.payload));
@@ -673,13 +672,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, std::move(payload));
 				}
 			}
-			// BATCH returned under the lock above
 			if (status == QuackClaimPopStatus::ERRORED) {
 				return make_uniq<ErrorResponse>(stream->buffer.GetError());
 			}
 			if (status == QuackClaimPopStatus::FINISHED) {
-				// the stream ended below the requested index: terminal response, announcing the
-				// client-visible total so the client can validate it received the whole stream
+				// The stream ended below this index. The terminal response carries the total, so the
+				// client can check that it got every batch.
 				if (connection.query_state == QuackQueryState::ACTIVE) {
 					connection.query_state = QuackQueryState::FINISHED;
 				}
@@ -811,8 +809,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>("Attempted to cancel a different query with id '%s' instead of '%s'",
 			                                cancel_request_message.query_uuid, connection.query_uuid);
 		}
-		// Interrupt() alone cannot wake a producer parked on the claim buffer's capacity wait — the
-		// abort's SetError is what releases it. Clients recognize cancellation by the "Interrupt" text.
+		// Interrupt() cannot wake a producer parked on the buffer's capacity. The abort's SetError
+		// releases it. A client finds a cancel by the "Interrupt" text.
 		AbortFetchStream(connection, "Interrupted: query was cancelled");
 		connection.duckdb_connection->Interrupt();
 		connection.query_state = QuackQueryState::CANCELLED;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -302,6 +302,10 @@ void QuackServer::CleanupExpiredConnection(QuackConnection &connection) {
 		connection.duckdb_connection->Interrupt();
 	}
 	connection.insert.Detach().AbortAndJoin("connection heartbeat lease expired");
+	// Interrupt() alone cannot wake a producer parked on the buffer's capacity, and it holds the
+	// connection lock until it does. Abort and join it here, not in ~QuackConnection, so the
+	// connection is fully quiet before the handler that expired it moves on.
+	AbortFetchStream(connection, "connection heartbeat lease expired");
 }
 
 bool QuackServer::RenewConnectionLease(const string &connection_id, const shared_ptr<QuackConnection> &connection) {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -388,29 +388,42 @@ void QuackServer::SweepExpiredCaches(DatabaseInstance &db) {
 	}
 	vector<CacheExpiryEntry> requeue;
 	vector<unique_ptr<QuackResultCache>> doomed;
+	//! Connections whose expired cache was still serving: their producer has to be aborted, which
+	//! joins a thread, so it happens after the state lock is released.
+	vector<shared_ptr<QuackConnection>> abandoned;
 	for (auto &entry : candidates) {
 		auto connection = GetConnection(entry.session_id);
 		if (!connection) {
 			// disconnected, the cache died with the connection and the slot dies here
 			continue;
 		}
-		std::unique_lock<std::mutex> lock(connection->lock, std::try_to_lock);
-		if (!lock.owns_lock()) {
-			// busy serving a request right now, by definition not idle; retry on the next sweep
-			requeue.push_back(std::move(entry));
-			continue;
+		{
+			std::unique_lock<std::mutex> lock(connection->lock, std::try_to_lock);
+			if (!lock.owns_lock()) {
+				// another handler is mutating the session state; retry on the next sweep
+				requeue.push_back(std::move(entry));
+				continue;
+			}
+			bool still_serving = false;
+			auto expired = ExpireCacheIfStale(*connection, now, ttl_micros, still_serving);
+			if (expired) {
+				doomed.push_back(std::move(expired));
+				if (still_serving) {
+					abandoned.push_back(connection);
+				}
+			}
+			if (connection->result_cache) {
+				// served (or replaced) since the snapshot was queued, keep the slot under the fresh timestamp
+				entry.served_at = connection->result_cache->last_served_at;
+				requeue.push_back(std::move(entry));
+			} else {
+				connection->cache_in_expiry_queue = false;
+			}
 		}
-		auto expired = ExpireCacheIfStale(*connection, now, ttl_micros);
-		if (expired) {
-			doomed.push_back(std::move(expired));
-		}
-		if (connection->result_cache) {
-			// served (or replaced) since the snapshot was queued, keep the slot under the fresh timestamp
-			entry.served_at = connection->result_cache->last_served_at;
-			requeue.push_back(std::move(entry));
-		} else {
-			connection->cache_in_expiry_queue = false;
-		}
+	}
+	for (auto &connection : abandoned) {
+		// Releases the query the client walked away from. A later FETCH finds this error.
+		AbortFetchStream(*connection, "Query was interrupted");
 	}
 	if (!requeue.empty()) {
 		std::lock_guard<std::mutex> lock(cache_expiry_mutex);

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -171,8 +171,8 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 	AbortDetachedFetch(connection, std::move(detached), reason);
 }
 
-//! Bring the connection's result cache up to date with what its stream is holding. Drops the cache
-//! once the result outgrows quack_cache_max_rows: too big to keep for a reconnect that may never come.
+//! Update the cache with what its stream holds. Drops the cache when the result grows past
+//! quack_cache_max_rows, because it is then too large to keep for a reconnect.
 static void SyncFetchCache(QuackConnection &connection, QuackFetchStream &stream, DatabaseInstance &db) {
 	std::unique_lock<std::mutex> lock(connection.lock);
 	auto &cache = connection.result_cache;
@@ -183,7 +183,7 @@ static void SyncFetchCache(QuackConnection &connection, QuackFetchStream &stream
 	cache->retained_rows = stream.RetainedRows();
 	auto max_cache_rows = CacheMaxRows(db);
 	if (max_cache_rows != 0 && cache->retained_rows > max_cache_rows) {
-		// back to plain streaming: the acks release payloads again
+		// the acks release the payloads again
 		stream.DropRetention();
 		connection.ClearResultCache();
 		return;
@@ -223,7 +223,7 @@ static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStre
 				stream->buffer.Finish();
 				return;
 			}
-			// BaseQueryResult::names is a vector<Identifier>; the stream carries plain strings.
+			// BaseQueryResult::names is a vector<Identifier>. The stream carries plain strings.
 			vector<string> result_names;
 			result_names.reserve(result->GetNames().size());
 			for (auto &col_name : result->GetNames()) {
@@ -322,9 +322,8 @@ void QuackServer::CleanupExpiredConnection(QuackConnection &connection) {
 		connection.duckdb_connection->Interrupt();
 	}
 	connection.insert.Detach().AbortAndJoin("connection heartbeat lease expired");
-	// Interrupt() alone cannot wake a producer parked on the buffer's capacity, and it holds the
-	// statement lock until it does. Abort and join it here, not in ~QuackConnection, so the
-	// connection is fully quiet before the handler that expired it moves on.
+	// Interrupt() cannot wake a producer that is parked on the buffer capacity. Abort and join it
+	// here, not in ~QuackConnection, so the connection is quiet before the handler continues.
 	AbortFetchStream(connection, "connection heartbeat lease expired");
 }
 
@@ -408,8 +407,7 @@ void QuackServer::SweepExpiredCaches(DatabaseInstance &db) {
 	}
 	vector<CacheExpiryEntry> requeue;
 	vector<unique_ptr<QuackResultCache>> doomed;
-	//! Connections whose expired cache was still serving: their producer has to be aborted, which
-	//! joins a thread, so it happens after the state lock is released.
+	// Their producer must be aborted, which joins a thread. Do that after the lock is released.
 	vector<shared_ptr<QuackConnection>> abandoned;
 	for (auto &entry : candidates) {
 		auto connection = GetConnection(entry.session_id);
@@ -745,9 +743,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		}
 
 		auto stream = make_shared_ptr<QuackFetchStream>();
-		// One read-ahead buffer exists for each connection, so a fixed 256 MB does not suit every server.
-		// Core sizes optional operator buffers at a quarter of the memory limit, as
-		// BatchMemoryManager::SetMemorySize does. A setting of 0 still means "no limit".
+		// One buffer exists for each connection, so a fixed size does not suit every server. Core
+		// also sizes an optional buffer at a quarter of the memory limit. 0 still means no limit.
 		auto producer_bytes =
 		    QuackGetUBigintSetting(db, "quack_fetch_producer_buffer_bytes", QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT);
 		auto memory_cap = BufferManager::GetBufferManager(db).GetOperatorMemoryLimit() / 4;
@@ -806,8 +803,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 					results.push_back(std::move(wrapper));
 				}
 				if (retain_result) {
-					// These rows leave in the PREPARE response and never reach the FETCH handler, so
-					// this is the only chance to count them towards the cache.
+					// These rows leave in the PREPARE response. The FETCH handler never sees them.
 					stream->Retain(consumed, std::move(entry.payload), entry.rows);
 				}
 				continue;
@@ -827,8 +823,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		}
 		stream->prepare_batches = consumed;
 		if (retain_result) {
-			// Created for every cached client query, including one that returns no rows at all: an
-			// empty result is still a retained result, and reports 0 rather than "nothing cached".
+			// Created for every cached client query, also one with no rows. An empty result then
+			// reports 0, and not "nothing cached".
 			{
 				std::unique_lock<std::mutex> lock(connection.lock);
 				connection.result_cache =
@@ -878,8 +874,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto dense_ack = fetch_request_message.ack_index + stream->prepare_batches;
 		{
 			lock_guard<mutex> guard(stream->serve_lock);
-			// The client has everything up to the ack and cannot ask for it again -- unless a result
-			// cache is holding the whole result open for a reconnect.
+			// The client has everything up to the ack and cannot ask for it again. A result cache
+			// keeps the payloads for longer.
 			if (!stream->retain_all) {
 				auto last = stream->served.upper_bound(dense_ack);
 				for (auto it = stream->served.begin(); it != last; ++it) {
@@ -915,7 +911,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				}
 			}
 			if (served_batch) {
-				// outside serve_lock: the cache is guarded by the connection's state lock
+				// outside serve_lock, because the connection's state lock guards the cache
 				SyncFetchCache(connection, *stream, db);
 				return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, std::move(served_batch));
 			}
@@ -1060,8 +1056,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		// releases it. A client finds a cancel by the "Interrupt" text.
 		AbortFetchStream(connection, "Interrupted: query was cancelled");
 		connection.duckdb_connection->Interrupt();
-		// The interrupt aborts any statement currently running under the statement lock; take the
-		// lock so the state change cannot race that statement's handler.
+		// The interrupt stops the statement that runs now. Take the state lock, so the change of
+		// state cannot race that statement's handler.
 		std::unique_lock<std::mutex> lock(connection.lock);
 		connection.query_state = QuackQueryState::CANCELLED;
 		connection.ClearResultCache();

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -9,11 +9,16 @@
 #include "duckdb/storage/temporary_file_manager.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 
+#include "duckdb/main/client_config.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+
 #include "quack_server.hpp"
 #include "quack_message.hpp"
 #include "quack_log.hpp"
 #include "quack_storage.hpp"
 #include "quack_data_stream.hpp"
+#include "quack_fetch_collector.hpp"
+#include "quack_rebalancer_sink.hpp"
 
 #include "mbedtls_wrapper.hpp"
 
@@ -97,10 +102,115 @@ shared_ptr<QuackDataStream> QuackInsertState::StreamForDeadRangeOrBuffer(const s
 	return nullptr;
 }
 
+//! A fetch stream + its producer thread, taken off the connection so aborting can run unlocked.
+struct DetachedFetchStream {
+	shared_ptr<QuackFetchStream> stream;
+	std::thread thread;
+};
+
+//! Error the buffer so consumers and capacity-blocked producers wake, interrupt the query if it is
+//! still running, join the producer. Call WITHOUT the connection lock.
+static void AbortDetachedFetch(QuackConnection &connection, DetachedFetchStream detached, const string &reason) {
+	if (detached.stream) {
+		auto was_finished = detached.stream->buffer.Finished();
+		detached.stream->buffer.SetError(ErrorData(ExceptionType::INTERRUPT, reason));
+		if (!was_finished && connection.duckdb_connection) {
+			connection.duckdb_connection->Interrupt();
+		}
+	}
+	if (detached.thread.joinable()) {
+		detached.thread.join();
+	}
+}
+
+//! Stop + join the connection's fetch collector. Call WITHOUT the connection lock.
+static void AbortFetchStream(QuackConnection &connection, const string &reason) {
+	DetachedFetchStream detached;
+	{
+		lock_guard<mutex> guard(connection.fetch.lock);
+		detached.stream = std::move(connection.fetch.stream);
+		detached.thread = std::move(connection.fetch.thread);
+		if (detached.stream) {
+			// the abort reason must never mask a real failure: prefer the stream's own error
+			connection.fetch.abort_error = detached.stream->buffer.HasError()
+			                                   ? detached.stream->buffer.GetError()
+			                                   : ErrorData(ExceptionType::INTERRUPT, reason);
+		}
+	}
+	AbortDetachedFetch(connection, std::move(detached), reason);
+}
+
+//! Background thread: runs the client's query with the fetch collector plugged in, holding the
+//! connection lock for its duration; the query executes in parallel into the stream's claim buffer.
+static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStream> stream, string sql) {
+	try {
+		unique_lock<mutex> guard(connection.lock);
+		auto &context = *connection.duckdb_connection->context;
+
+		// MakeQuackFetchCollector routes the FIRST result-returning statement into the stream (the
+		// protocol's historical multi-statement semantics); other statements keep the default collector.
+		auto &config = ClientConfig::GetConfig(context);
+		config.get_result_collector = [stream](ClientContext &ctx, PreparedStatementData &data) {
+			return MakeQuackFetchCollector(ctx, data, stream);
+		};
+		unique_ptr<QueryResult> result;
+		try {
+			result = connection.duckdb_connection->Query(sql);
+		} catch (...) {
+			// leave no dangling collector hook on the connection's config
+			config.get_result_collector = nullptr;
+			throw;
+		}
+		config.get_result_collector = nullptr;
+		if (result->HasError()) {
+			stream->buffer.SetError(result->GetErrorObject());
+		} else if (!stream->Bound()) {
+			// No collector claimed the stream (no statement returned a query result): route the last
+			// statement's Success/Count result through, as the protocol always has. Columnless = error.
+			if (result->names.empty()) {
+				stream->buffer.SetError(ErrorData(ExceptionType::INVALID_INPUT, "Query did not return any columns"));
+				stream->buffer.Finish();
+				return;
+			}
+			stream->SignalBound(result->types, result->names);
+			unique_ptr<FetchResponsePayloadWriter> writer;
+			idx_t rows = 0;
+			while (auto chunk = result->Fetch()) {
+				if (chunk->size() == 0) {
+					continue;
+				}
+				if (!writer) {
+					writer = make_uniq<FetchResponsePayloadWriter>(context, 0);
+				}
+				writer->AppendChunk(*chunk);
+				rows += chunk->size();
+			}
+			if (writer) {
+				auto sealed = writer->Seal();
+				QuackFetchPayload entry;
+				entry.payload = std::move(sealed.payload);
+				entry.payload_size = sealed.payload_size;
+				entry.index_offset = sealed.index_offset;
+				entry.rows = rows;
+				QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset, 1);
+				auto bytes = entry.payload_size;
+				stream->buffer.PushBatch(1, std::move(entry), bytes);
+				stream->announced_total = 1;
+			} else {
+				stream->announced_total = 0;
+			}
+		}
+	} catch (std::exception &ex) {
+		stream->buffer.SetError(ErrorData(ex));
+	}
+	// Close against the collector's announced total: a short stream errors instead of truncating.
+	stream->buffer.Finish(stream->announced_total);
+}
+
 QuackConnection::~QuackConnection() {
-	// Abort + join any in-flight INSERT before members are destroyed.
+	// Abort + join any in-flight INSERT and fetch collector before members are destroyed.
 	insert.Detach().AbortAndJoin("connection closed during insert");
-	duckdb_query_result.reset();
+	AbortFetchStream(*this, "connection closed during fetch");
 }
 
 //! Background thread: runs the INSERT that drains `stream` via scan_data_from_quack_client, holding
@@ -370,31 +480,6 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	return response;
 }
 
-// Accumulate whole chunks until `max_rows` is reached (row-based like the send path, so sparse
-// filtered chunks don't shrink the batch). Resets query_result once the cursor is exhausted.
-static vector<unique_ptr<DataChunkWrapper>> CreateBatch(Allocator &allocator, unique_ptr<QueryResult> &query_result,
-                                                        idx_t max_rows) {
-	vector<unique_ptr<DataChunkWrapper>> results;
-
-	idx_t rows = 0;
-	while (rows < max_rows) {
-		auto result_chunk = query_result->Fetch();
-		// error case
-		if (!result_chunk && query_result->HasError()) {
-			results.clear();
-			return results;
-		}
-		// we are done case
-		if (!result_chunk || result_chunk->size() == 0) {
-			query_result.reset();
-			break;
-		}
-		rows += result_chunk->size();
-		results.push_back(make_uniq<DataChunkWrapper>(*result_chunk));
-	}
-	return results;
-}
-
 unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db, QuackMessage &received_message,
                                                             optional_ptr<QuackConnection> connection_p) {
 	if (connection_p) {
@@ -449,94 +534,163 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto effective_sql = (auth_result.type().id() == LogicalTypeId::VARCHAR) ? auth_result.GetValue<string>()
 		                                                                         : prepare_request_message.Query();
 
-		std::unique_lock<std::mutex> lock(connection.lock);
-		connection.duckdb_query_result.reset();
-		connection.sql_query = prepare_request_message.Query();
-		connection.query_state = QuackQueryState::ACTIVE;
-		connection.query_started_at = Timestamp::GetCurrentTimestamp();
-
+		// stop any previous producer before touching connection state (joins its thread → lock is free)
+		AbortFetchStream(connection, "superseded by a new query");
 		{
-			auto query_result = connection.duckdb_connection->SendQuery(effective_sql);
-			if (query_result->HasError()) {
+			std::unique_lock<std::mutex> lock(connection.lock);
+			connection.sql_query = prepare_request_message.Query();
+			connection.query_state = QuackQueryState::ACTIVE;
+			connection.query_started_at = Timestamp::GetCurrentTimestamp();
+			connection.query_uuid = prepare_request_message.QueryUUID();
+		}
+
+		auto stream = make_shared_ptr<QuackFetchStream>();
+		stream->buffer.SetCapacity(
+		    QuackGetUBigintSetting(db, "quack_fetch_producer_buffer_bytes", QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT));
+		DetachedFetchStream superseded;
+		{
+			// Swap-install atomically: a concurrent PREPARE may have installed a producer since the
+			// abort above, and assigning over a joinable std::thread would terminate the process.
+			lock_guard<mutex> guard(connection.fetch.lock);
+			superseded.stream = std::move(connection.fetch.stream);
+			superseded.thread = std::move(connection.fetch.thread);
+			connection.fetch.stream = stream;
+			connection.fetch.uuid = prepare_request_message.QueryUUID();
+			connection.fetch.abort_error = ErrorData();
+			connection.fetch.thread = std::thread(RunFetchQuery, std::ref(connection), stream, effective_sql);
+		}
+		AbortDetachedFetch(connection, std::move(superseded), "superseded by a new query");
+
+		if (!stream->WaitBound()) {
+			// planning failed before a collector existed — surface the error and clean up
+			auto error = stream->buffer.GetError();
+			AbortFetchStream(connection, "query failed");
+			std::unique_lock<std::mutex> lock(connection.lock);
+			connection.sql_query = "";
+			connection.query_state = QuackQueryState::CANCELLED;
+			return make_uniq<ErrorResponse>(error);
+		}
+
+		// Inline the leading batches into the PREPARE response so small results arrive in one round
+		// trip (catalog enumeration never FETCHes); FETCH indices are remapped by the consumed count.
+		idx_t max_inline_rows =
+		    QuackGetUBigintSetting(db, "quack_prepare_inline_rows", QUACK_PREPARE_INLINE_ROWS_DEFAULT);
+		vector<unique_ptr<DataChunkWrapper>> results;
+		idx_t inline_rows = 0;
+		idx_t consumed = 0;
+		while (inline_rows < max_inline_rows) {
+			QuackFetchPayload entry;
+			auto status = stream->buffer.TryPopClaimed(consumed + 1, entry);
+			if (status == QuackClaimPopStatus::BATCH) {
+				consumed++;
+				inline_rows += entry.rows;
+				// Batches are stored pre-serialized; only this inline drain decodes them back to chunks.
+				MemoryStream payload_stream(entry.payload->GetData(), entry.payload_size);
+				auto inline_message = QuackMessage::FromMemoryStream(payload_stream);
+				for (auto &wrapper : inline_message->Cast<FetchResponseMessage>().MutableResults()) {
+					results.push_back(std::move(wrapper));
+				}
+				continue;
+			}
+			if (status == QuackClaimPopStatus::FINISHED) {
+				break;
+			}
+			if (status == QuackClaimPopStatus::ERRORED) {
+				auto error = stream->buffer.GetError();
+				AbortFetchStream(connection, "query failed");
+				std::unique_lock<std::mutex> lock(connection.lock);
 				connection.sql_query = "";
-				auto response = make_uniq<ErrorResponse>(query_result->GetErrorObject());
-				connection.duckdb_query_result.reset();
 				connection.query_state = QuackQueryState::CANCELLED;
-				return response;
+				return make_uniq<ErrorResponse>(error);
 			}
-			if (query_result->names.empty()) {
-				connection.sql_query = "";
-				auto response = make_uniq<ErrorResponse>(query_result->GetErrorObject());
-				connection.duckdb_query_result.reset();
-				connection.query_state = QuackQueryState::QUACK_ERROR;
-				return make_uniq<ErrorResponse>("Query did not return any columns");
-			}
-
-			connection.duckdb_query_result = std::move(query_result);
+			stream->buffer.WaitForBatch(consumed + 1);
 		}
-		// Fresh query → restart batch numbering. Clients' local state is re-initialized on
-		// a new PREPARE, so indices start at 0 again.
-		connection.next_batch_index = 1;
-		connection.query_uuid = prepare_request_message.QueryUUID();
-
-		Value max_rows_val;
-		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_rows", max_rows_val);
-		auto max_rows_per_batch = max_rows_val.GetValue<uint64_t>();
-
-		auto names = connection.duckdb_query_result->names;
-		auto types = connection.duckdb_query_result->types;
-
-		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_rows_per_batch);
-		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) {
-			D_ASSERT(results.empty());
-
-			auto error_message = connection.duckdb_query_result->GetErrorObject();
-			connection.duckdb_query_result.reset();
-			return make_uniq<ErrorResponse>(std::move(error_message));
-		}
-		// CreateBatch resets the cursor on exhaustion; a live cursor means more batches remain.
-		auto needs_more_fetch = connection.duckdb_query_result != nullptr;
-		if (!needs_more_fetch && connection.query_state == QuackQueryState::ACTIVE) {
+		stream->prepare_batches = consumed;
+		// If the drain did not observe a CLEAN stream end, optimistically report more: a spurious true
+		// costs one terminal FETCH; false on an errored buffer would report a truncated result complete.
+		auto needs_more_fetch = !stream->buffer.Exhausted() || stream->buffer.HasError();
+		if (!needs_more_fetch) {
 			connection.query_state = QuackQueryState::FINISHED;
 		}
-		return make_uniq<PrepareResponseMessage>(types, names, std::move(results), needs_more_fetch,
-		                                         connection.query_uuid);
+		return make_uniq<PrepareResponseMessage>(stream->types, stream->names, std::move(results), needs_more_fetch,
+		                                         prepare_request_message.QueryUUID());
 	}
 
 	case MessageType::FETCH_REQUEST: {
 		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
 		auto &connection = *connection_p;
-		std::unique_lock<std::mutex> lock(connection.lock);
 
-		if (connection.query_uuid != fetch_request_message.uuid) {
+		// no connection.lock here: the producer thread holds it for the query's duration; FETCH only
+		// touches the stream's buffer
+		shared_ptr<QuackFetchStream> stream;
+		hugeint_t stream_uuid;
+		ErrorData abort_error;
+		{
+			lock_guard<mutex> guard(connection.fetch.lock);
+			stream = connection.fetch.stream;
+			stream_uuid = connection.fetch.uuid;
+			abort_error = connection.fetch.abort_error;
+		}
+		if (!stream && stream_uuid == fetch_request_message.uuid && abort_error.HasError()) {
+			return make_uniq<ErrorResponse>(abort_error);
+		}
+		if (!stream || stream_uuid != fetch_request_message.uuid) {
 			return make_uniq<ErrorResponse>("Result has been closed");
 		}
-		if (connection.query_state == QuackQueryState::CANCELLED) {
-			return make_uniq<ErrorResponse>("Query was interrupted");
-		}
-		if (!connection.duckdb_query_result) {
-			return make_uniq<FetchResponseMessage>();
-		}
-		if (connection.duckdb_query_result->HasError()) {
-			return make_uniq<ErrorResponse>(connection.duckdb_query_result->GetErrorObject());
+		if (fetch_request_message.batch_index == 0) {
+			return make_uniq<ErrorResponse>("FETCH_REQUEST is missing its batch index");
 		}
 
-		Value max_rows_val;
-		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_rows", max_rows_val);
-		auto max_rows_per_batch = max_rows_val.GetValue<uint64_t>();
+		// The request names its batch (client-visible; add back the batches PREPARE consumed inline).
+		// Served payloads are retained until acked so a transport retry re-serves the SAME batch.
+		auto dense_index = fetch_request_message.batch_index + stream->prepare_batches;
+		auto dense_ack = fetch_request_message.ack_index + stream->prepare_batches;
+		{
+			lock_guard<mutex> guard(stream->serve_lock);
+			// everything <= the ack was received by the client and can never be re-requested
+			stream->served.erase(stream->served.begin(), stream->served.upper_bound(dense_ack));
+		}
 
-		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_rows_per_batch);
-		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) { // TODO this is duplicated
-			D_ASSERT(results.empty());
-			auto error_message = connection.duckdb_query_result->GetErrorObject();
-			connection.duckdb_query_result.reset();
-			return make_uniq<ErrorResponse>(std::move(error_message));
+		while (true) {
+			QuackClaimPopStatus status;
+			QuackFetchPayload entry;
+			{
+				// One critical section for retained-check + pop + retain: a concurrent retry of the same
+				// index can never fall through to FINISHED while the original is mid-serve.
+				lock_guard<mutex> guard(stream->serve_lock);
+				auto retained = stream->served.find(dense_index);
+				if (retained != stream->served.end()) {
+					// re-serve (already patched with the client-visible index)
+					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, retained->second);
+				}
+				status = stream->buffer.TryPopClaimed(dense_index, entry);
+				if (status == QuackClaimPopStatus::BATCH) {
+					// re-stamp the sealed payload with the client-visible index; retain it for retries
+					QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset,
+					                            fetch_request_message.batch_index);
+					shared_ptr<MemoryStream> payload(std::move(entry.payload));
+					stream->served.emplace(dense_index, payload);
+					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, std::move(payload));
+				}
+			}
+			// BATCH returned under the lock above
+			if (status == QuackClaimPopStatus::ERRORED) {
+				return make_uniq<ErrorResponse>(stream->buffer.GetError());
+			}
+			if (status == QuackClaimPopStatus::FINISHED) {
+				// the stream ended below the requested index: terminal response, announcing the
+				// client-visible total so the client can validate it received the whole stream
+				if (connection.query_state == QuackQueryState::ACTIVE) {
+					connection.query_state = QuackQueryState::FINISHED;
+				}
+				auto response = make_uniq<FetchResponseMessage>();
+				if (stream->announced_total.IsValid()) {
+					response->SetTotalBatches(stream->announced_total.GetIndex() - stream->prepare_batches);
+				}
+				return std::move(response);
+			}
+			stream->buffer.WaitForBatch(dense_index);
 		}
-		auto assigned_batch_index = connection.next_batch_index++;
-		if (!connection.duckdb_query_result && connection.query_state == QuackQueryState::ACTIVE) {
-			connection.query_state = QuackQueryState::FINISHED;
-		}
-		return make_uniq<FetchResponseMessage>(std::move(results), optional_idx(assigned_batch_index));
 	}
 
 	case MessageType::SEND_DATA_REQUEST: {
@@ -657,9 +811,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			return make_uniq<ErrorResponse>("Attempted to cancel a different query with id '%s' instead of '%s'",
 			                                cancel_request_message.query_uuid, connection.query_uuid);
 		}
+		// Interrupt() alone cannot wake a producer parked on the claim buffer's capacity wait — the
+		// abort's SetError is what releases it. Clients recognize cancellation by the "Interrupt" text.
+		AbortFetchStream(connection, "Interrupted: query was cancelled");
 		connection.duckdb_connection->Interrupt();
 		connection.query_state = QuackQueryState::CANCELLED;
-		connection.duckdb_query_result.reset();
 		return make_uniq<SuccessResponse>();
 	}
 	case MessageType::ACKNOWLEDGEMENT: {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -140,7 +140,7 @@ struct DetachedFetchStream {
 };
 
 //! Error the buffer, so consumers and parked producers wake. Interrupt the query if it still runs,
-//! then join the producer. Call this WITHOUT the connection lock.
+//! then join the producer. Call this WITHOUT the statement lock.
 static void AbortDetachedFetch(QuackConnection &connection, DetachedFetchStream detached, const string &reason) {
 	if (detached.stream) {
 		auto was_finished = detached.stream->buffer.Finished();
@@ -154,7 +154,7 @@ static void AbortDetachedFetch(QuackConnection &connection, DetachedFetchStream 
 	}
 }
 
-//! Stop and join the connection's fetch collector. Call this WITHOUT the connection lock.
+//! Stop and join the connection's fetch collector. Call this WITHOUT the statement lock.
 static void AbortFetchStream(QuackConnection &connection, const string &reason) {
 	DetachedFetchStream detached;
 	{
@@ -171,11 +171,11 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 	AbortDetachedFetch(connection, std::move(detached), reason);
 }
 
-//! Runs the client's query with the fetch collector installed, and holds the connection lock for
+//! Runs the client's query with the fetch collector installed, and holds the statement lock for
 //! the full duration. The query fills the stream's claim buffer in parallel.
 static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStream> stream, string sql) {
 	try {
-		unique_lock<mutex> guard(connection.lock);
+		unique_lock<mutex> guard(connection.statement_lock);
 		auto &context = *connection.duckdb_connection->context;
 
 		// MakeQuackFetchCollector sends the FIRST statement that returns a result into the stream.
@@ -251,11 +251,11 @@ QuackConnection::~QuackConnection() {
 }
 
 //! Background thread: runs the INSERT that drains `stream` via scan_data_from_quack_client, holding
-//! the connection lock for the statement's duration (one transactional statement -> atomic).
+//! the statement lock for the statement's duration (one transactional statement -> atomic).
 static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackDataStream> stream, string stream_id,
                                string schema_name, string table_name) {
 	try {
-		unique_lock<mutex> lock(connection.lock);
+		unique_lock<mutex> lock(connection.statement_lock);
 		auto sql = StringUtil::Format("INSERT INTO %s.%s SELECT * FROM scan_data_from_quack_client(%s)",
 		                              SQLIdentifier(schema_name), SQLIdentifier(table_name), SQLString(stream_id));
 		auto result = connection.duckdb_connection->Query(sql);
@@ -303,7 +303,7 @@ void QuackServer::CleanupExpiredConnection(QuackConnection &connection) {
 	}
 	connection.insert.Detach().AbortAndJoin("connection heartbeat lease expired");
 	// Interrupt() alone cannot wake a producer parked on the buffer's capacity, and it holds the
-	// connection lock until it does. Abort and join it here, not in ~QuackConnection, so the
+	// statement lock until it does. Abort and join it here, not in ~QuackConnection, so the
 	// connection is fully quiet before the handler that expired it moves on.
 	AbortFetchStream(connection, "connection heartbeat lease expired");
 }
@@ -641,7 +641,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
                                                             optional_ptr<QuackConnection> connection_p) {
 	if (connection_p && received_message.Type() != MessageType::HEARTBEAT_REQUEST) {
 		// A message unrelated to the active insert stream means it was abandoned (client source failed, no
-		// FINALIZE) — abort it so it rolls back and releases the connection lock.
+		// FINALIZE) — abort it so it rolls back and releases the statement lock.
 		connection_p->insert.DetachIfUnrelated(StreamIdForMessage(received_message))
 		    .AbortAndJoin("insert stream abandoned");
 	}
@@ -697,7 +697,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto effective_sql = (auth_result.type().id() == LogicalTypeId::VARCHAR) ? auth_result.GetValue<string>()
 		                                                                         : prepare_request_message.Query();
 
-		// Stop the previous producer first. This joins its thread, so it frees the connection lock.
+		// Stop the previous producer first. This joins its thread, so it frees the statement lock.
 		AbortFetchStream(connection, "superseded by a new query");
 		{
 			std::unique_lock<std::mutex> lock(connection.lock);
@@ -783,7 +783,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &fetch_request_message = received_message.Cast<FetchRequestMessage>();
 		auto &connection = *connection_p;
 
-		// No connection.lock here: the producer thread holds it, and FETCH touches only the buffer.
+		// FETCH touches only the buffer and the served map, so it needs neither lock on the way in.
 		shared_ptr<QuackFetchStream> stream;
 		hugeint_t stream_uuid;
 		ErrorData abort_error;
@@ -976,7 +976,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		// releases it. A client finds a cancel by the "Interrupt" text.
 		AbortFetchStream(connection, "Interrupted: query was cancelled");
 		connection.duckdb_connection->Interrupt();
-		// The interrupt aborts any statement currently running under the session lock; take the
+		// The interrupt aborts any statement currently running under the statement lock; take the
 		// lock so the state change cannot race that statement's handler.
 		std::unique_lock<std::mutex> lock(connection.lock);
 		connection.query_state = QuackQueryState::CANCELLED;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -745,8 +745,16 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		}
 
 		auto stream = make_shared_ptr<QuackFetchStream>();
-		stream->buffer.SetCapacity(
-		    QuackGetUBigintSetting(db, "quack_fetch_producer_buffer_bytes", QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT));
+		// One read-ahead buffer exists for each connection, so a fixed 256 MB does not suit every server.
+		// Core sizes optional operator buffers at a quarter of the memory limit, as
+		// BatchMemoryManager::SetMemorySize does. A setting of 0 still means "no limit".
+		auto producer_bytes =
+		    QuackGetUBigintSetting(db, "quack_fetch_producer_buffer_bytes", QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT);
+		auto memory_cap = BufferManager::GetBufferManager(db).GetOperatorMemoryLimit() / 4;
+		if (producer_bytes > 0 && memory_cap > 0) {
+			producer_bytes = MinValue<idx_t>(producer_bytes, memory_cap);
+		}
+		stream->buffer.SetCapacity(producer_bytes);
 		// Internal catalog traffic carries uuid 0. It must never displace the client's retained result.
 		bool client_query = prepare_request_message.QueryUUID() != hugeint_t {0, 0};
 		bool retain_result = client_query && ServerCachingEnabled(db);

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -723,6 +723,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto stream = make_shared_ptr<QuackFetchStream>();
 		stream->buffer.SetCapacity(
 		    QuackGetUBigintSetting(db, "quack_fetch_producer_buffer_bytes", QUACK_FETCH_PRODUCER_BUFFER_BYTES_DEFAULT));
+		// Internal catalog traffic carries uuid 0. It must never displace the client's retained result.
+		bool client_query = prepare_request_message.QueryUUID() != hugeint_t {0, 0};
+		bool retain_result = client_query && ServerCachingEnabled(db);
+		if (retain_result) {
+			// hold every served payload, instead of releasing it once the client acks
+			stream->RetainAll();
+		}
 		DetachedFetchStream superseded;
 		{
 			// Install under one lock. A concurrent PREPARE can install a producer after the abort
@@ -765,6 +772,11 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				auto inline_message = QuackMessage::FromMemoryStream(payload_stream);
 				for (auto &wrapper : inline_message->Cast<FetchResponseMessage>().MutableResults()) {
 					results.push_back(std::move(wrapper));
+				}
+				if (retain_result) {
+					// These rows leave in the PREPARE response and never reach the FETCH handler, so
+					// this is the only chance to count them towards the cache.
+					stream->Retain(consumed, std::move(entry.payload), entry.rows);
 				}
 				continue;
 			}
@@ -822,8 +834,15 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto dense_ack = fetch_request_message.ack_index + stream->prepare_batches;
 		{
 			lock_guard<mutex> guard(stream->serve_lock);
-			// the client has everything up to the ack, and cannot ask for it again
-			stream->served.erase(stream->served.begin(), stream->served.upper_bound(dense_ack));
+			// The client has everything up to the ack and cannot ask for it again -- unless a result
+			// cache is holding the whole result open for a reconnect.
+			if (!stream->retain_all) {
+				auto last = stream->served.upper_bound(dense_ack);
+				for (auto it = stream->served.begin(); it != last; ++it) {
+					stream->retained_rows -= it->second.rows;
+				}
+				stream->served.erase(stream->served.begin(), last);
+			}
 		}
 
 		while (true) {
@@ -836,7 +855,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				auto retained = stream->served.find(dense_index);
 				if (retained != stream->served.end()) {
 					// already patched with the client-visible index
-					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, retained->second);
+					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, retained->second.payload);
 				}
 				status = stream->buffer.TryPopClaimed(dense_index, entry);
 				if (status == QuackClaimPopStatus::BATCH) {
@@ -844,7 +863,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 					QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset,
 					                            fetch_request_message.batch_index);
 					shared_ptr<MemoryStream> payload(std::move(entry.payload));
-					stream->served.emplace(dense_index, payload);
+					stream->served.emplace(dense_index,
+					                       QuackFetchStream::RetainedPayload {payload, entry.rows});
+					stream->retained_rows += entry.rows;
 					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, std::move(payload));
 				}
 			}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -171,6 +171,26 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 	AbortDetachedFetch(connection, std::move(detached), reason);
 }
 
+//! Bring the connection's result cache up to date with what its stream is holding. Drops the cache
+//! once the result outgrows quack_cache_max_rows: too big to keep for a reconnect that may never come.
+static void SyncFetchCache(QuackConnection &connection, QuackFetchStream &stream, DatabaseInstance &db) {
+	std::unique_lock<std::mutex> lock(connection.lock);
+	auto &cache = connection.result_cache;
+	if (!cache || cache->stream.get() != &stream) {
+		return;
+	}
+	cache->last_served_at = Timestamp::GetCurrentTimestamp();
+	cache->retained_rows = stream.RetainedRows();
+	auto max_cache_rows = CacheMaxRows(db);
+	if (max_cache_rows != 0 && cache->retained_rows > max_cache_rows) {
+		// back to plain streaming: the acks release payloads again
+		stream.DropRetention();
+		connection.ClearResultCache();
+		return;
+	}
+	connection.SyncCachedRows();
+}
+
 //! Runs the client's query with the fetch collector installed, and holds the statement lock for
 //! the full duration. The query fills the stream's claim buffer in parallel.
 static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStream> stream, string sql) {
@@ -714,6 +734,10 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		AbortFetchStream(connection, "superseded by a new query");
 		{
 			std::unique_lock<std::mutex> lock(connection.lock);
+			if (prepare_request_message.QueryUUID() != hugeint_t {0, 0}) {
+				// a new client query displaces the retained one, even if caching is now off
+				connection.ClearResultCache();
+			}
 			connection.sql_query = prepare_request_message.Query();
 			connection.query_state = QuackQueryState::ACTIVE;
 			connection.query_started_at = Timestamp::GetCurrentTimestamp();
@@ -794,6 +818,18 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			stream->buffer.WaitForBatch(consumed + 1);
 		}
 		stream->prepare_batches = consumed;
+		if (retain_result) {
+			// Created for every cached client query, including one that returns no rows at all: an
+			// empty result is still a retained result, and reports 0 rather than "nothing cached".
+			{
+				std::unique_lock<std::mutex> lock(connection.lock);
+				connection.result_cache =
+				    make_uniq<QuackResultCache>(prepare_request_message.Query(), prepare_request_message.QueryUUID(),
+				                                stream, connection.live_caches);
+				RegisterCacheForExpiry(connection);
+			}
+			SyncFetchCache(connection, *stream, db);
+		}
 		// Report more unless the drain saw a CLEAN end. A wrong true costs one more FETCH. A wrong
 		// false on an errored buffer would report a truncated result as complete.
 		auto needs_more_fetch = !stream->buffer.Exhausted() || stream->buffer.HasError();
@@ -848,6 +884,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		while (true) {
 			QuackClaimPopStatus status;
 			QuackFetchPayload entry;
+			shared_ptr<MemoryStream> served_batch;
 			{
 				// One critical section for the check, the pop and the retain. A concurrent retry of the
 				// same index cannot reach FINISHED while the first serve runs.
@@ -855,19 +892,24 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				auto retained = stream->served.find(dense_index);
 				if (retained != stream->served.end()) {
 					// already patched with the client-visible index
-					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, retained->second.payload);
+					served_batch = retained->second.payload;
+				} else {
+					status = stream->buffer.TryPopClaimed(dense_index, entry);
+					if (status == QuackClaimPopStatus::BATCH) {
+						// stamp the client-visible index, then keep the payload for a retry
+						QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset,
+						                            fetch_request_message.batch_index);
+						shared_ptr<MemoryStream> payload(std::move(entry.payload));
+						stream->served.emplace(dense_index, QuackFetchStream::RetainedPayload {payload, entry.rows});
+						stream->retained_rows += entry.rows;
+						served_batch = std::move(payload);
+					}
 				}
-				status = stream->buffer.TryPopClaimed(dense_index, entry);
-				if (status == QuackClaimPopStatus::BATCH) {
-					// stamp the client-visible index, then keep the payload for a retry
-					QuackBatchIndexField::Patch(entry.payload->GetData(), entry.payload_size, entry.index_offset,
-					                            fetch_request_message.batch_index);
-					shared_ptr<MemoryStream> payload(std::move(entry.payload));
-					stream->served.emplace(dense_index,
-					                       QuackFetchStream::RetainedPayload {payload, entry.rows});
-					stream->retained_rows += entry.rows;
-					return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, std::move(payload));
-				}
+			}
+			if (served_batch) {
+				// outside serve_lock: the cache is guarded by the connection's state lock
+				SyncFetchCache(connection, *stream, db);
+				return make_uniq<QuackRawPayloadResponse>(MessageType::FETCH_RESPONSE, std::move(served_batch));
 			}
 			if (status == QuackClaimPopStatus::ERRORED) {
 				return make_uniq<ErrorResponse>(stream->buffer.GetError());
@@ -1014,6 +1056,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		// lock so the state change cannot race that statement's handler.
 		std::unique_lock<std::mutex> lock(connection.lock);
 		connection.query_state = QuackQueryState::CANCELLED;
+		connection.ClearResultCache();
 		return make_uniq<SuccessResponse>();
 	}
 	case MessageType::ACKNOWLEDGEMENT: {
@@ -1029,6 +1072,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			                                acknowledgement_message.QueryUUID(), cache->query_uuid);
 		}
 		// The client confirmed it received the full result, the replay cache has served its purpose
+		if (cache->stream) {
+			cache->stream->DropRetention();
+		}
 		connection.ClearResultCache();
 		return make_uniq<SuccessResponse>();
 	}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -198,12 +198,18 @@ static void RunFetchQuery(QuackConnection &connection, shared_ptr<QuackFetchStre
 		} else if (!stream->Bound()) {
 			// No collector claimed the stream, because no statement returned a result. Send the last
 			// statement's Success/Count result, as the protocol always has. No columns is an error.
-			if (result->names.empty()) {
+			if (result->GetNames().empty()) {
 				stream->buffer.SetError(ErrorData(ExceptionType::INVALID_INPUT, "Query did not return any columns"));
 				stream->buffer.Finish();
 				return;
 			}
-			stream->SignalBound(result->types, result->names);
+			// BaseQueryResult::names is a vector<Identifier>; the stream carries plain strings.
+			vector<string> result_names;
+			result_names.reserve(result->GetNames().size());
+			for (auto &col_name : result->GetNames()) {
+				result_names.push_back(col_name.GetIdentifierName());
+			}
+			stream->SignalBound(result->GetTypes(), std::move(result_names));
 			unique_ptr<FetchResponsePayloadWriter> writer;
 			idx_t rows = 0;
 			while (auto chunk = result->Fetch()) {

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -9,6 +9,14 @@
 
 namespace duckdb {
 
+void AcknowledgementMessage::Serialize(Serializer &serializer) const {
+}
+
+unique_ptr<AcknowledgementMessage> AcknowledgementMessage::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<AcknowledgementMessage>(new AcknowledgementMessage());
+	return result;
+}
+
 void CancelRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<hugeint_t>(1, "query_uuid", query_uuid);
 }
@@ -73,23 +81,31 @@ unique_ptr<ErrorResponse> ErrorResponse::Deserialize(Deserializer &deserializer)
 
 void FetchRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<hugeint_t>(1, "uuid", uuid);
+	serializer.WritePropertyWithDefault<idx_t>(2, "batch_index", batch_index, 0);
+	serializer.WritePropertyWithDefault<idx_t>(3, "ack_index", ack_index, 0);
 }
 
 unique_ptr<FetchRequestMessage> FetchRequestMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FetchRequestMessage>(new FetchRequestMessage());
 	deserializer.ReadProperty<hugeint_t>(1, "uuid", result->uuid);
+	deserializer.ReadPropertyWithExplicitDefault<idx_t>(2, "batch_index", result->batch_index, 0);
+	deserializer.ReadPropertyWithExplicitDefault<idx_t>(3, "ack_index", result->ack_index, 0);
 	return result;
 }
 
 void FetchResponseMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(1, "results", results);
-	serializer.WriteProperty<optional_idx>(2, "batch_index", batch_index);
+	serializer.WritePropertyWithDefault<optional_idx>(2, "total_batches", total_batches, optional_idx());
+	serializer.WritePropertyWithDefault<string>(3, "batch_index_fixed", EncodeBatchIndexFixed());
 }
 
 unique_ptr<FetchResponseMessage> FetchResponseMessage::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<FetchResponseMessage>(new FetchResponseMessage());
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<DataChunkWrapper>>>(1, "results", result->results);
-	deserializer.ReadProperty<optional_idx>(2, "batch_index", result->batch_index);
+	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(2, "total_batches", result->total_batches,
+	                                                           optional_idx());
+	auto batch_index_fixed = deserializer.ReadPropertyWithDefault<string>(3, "batch_index_fixed");
+	result->ApplyBatchIndexFixed(std::move(batch_index_fixed));
 	return result;
 }
 
@@ -194,15 +210,6 @@ void SuccessResponse::Serialize(Serializer &serializer) const {
 
 unique_ptr<SuccessResponse> SuccessResponse::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<SuccessResponse>(new SuccessResponse());
-	return result;
-}
-
-
-void AcknowledgementMessage::Serialize(Serializer &serializer) const {
-}
-
-unique_ptr<AcknowledgementMessage> AcknowledgementMessage::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<AcknowledgementMessage>(new AcknowledgementMessage());
 	return result;
 }
 

--- a/test/sql/fetch_async.test
+++ b/test/sql/fetch_async.test
@@ -6,8 +6,8 @@ require parquet
 
 include test/template/quack_setup.test_template
 
-# hash() pads the rows with incompressible bytes: batches are cut on SERIALIZED size, and plain
-# sequential integers would fit one batch that is fully inlined into PREPARE — no FETCH at all
+# hash() makes the rows hard to compress. Batches are cut on SERIALIZED size, so plain integers
+# would fit one batch, PREPARE would inline it, and no FETCH would run.
 statement ok quack_db:quack_server_con
 create table big as select range i, hash(range) pad from range(100000);
 
@@ -25,7 +25,7 @@ create view big_pq as select i, pad from '{TEST_DIR}/fetch_ord.parquet';
 statement ok
 attach {server} as rpc (token 'asdf')
 
-# small batches + a one-batch PREPARE drain => many FETCH round-trips through the read-ahead pipeline.
+# small batches and a one-batch PREPARE drain give many FETCH round trips
 # Set AFTER the attach: the catalog enumeration itself is otherwise truncated to one chunk and
 # loses the views (pre-existing ExecuteCommandInternal FIXME).
 statement ok quack_db:quack_server_con
@@ -34,7 +34,7 @@ set global quack_prepare_inline_rows=1;
 statement ok quack_db:quack_server_con
 set global quack_target_batch_bytes=65536;
 
-# sanity: this shape really produces multiple FETCHes (guards the batching config against drift)
+# make sure this shape really produces more than one FETCH
 statement ok
 CALL enable_logging('Quack');
 

--- a/test/sql/fetch_async.test
+++ b/test/sql/fetch_async.test
@@ -6,28 +6,50 @@ require parquet
 
 include test/template/quack_setup.test_template
 
+# hash() pads the rows with incompressible bytes: batches are cut on SERIALIZED size, and plain
+# sequential integers would fit one batch that is fully inlined into PREPARE — no FETCH at all
 statement ok quack_db:quack_server_con
-create table big as select range i from range(100000);
+create table big as select range i, hash(range) pad from range(100000);
 
 statement ok quack_db:quack_server_con
-create table big500 as select range i from range(500000);
+create table big500 as select range i, hash(range) pad from range(500000);
 
 # remote parquet source: the server-side scan is parallel/multi-row-group, but FETCH batch
 # indices are minted by the quack server, so client-side ordering must be unaffected
 statement ok quack_db:quack_server_con
-copy (select range i from range(500000)) to '{TEST_DIR}/fetch_ord.parquet' (row_group_size 50000);
+copy (select range i, hash(range) pad from range(500000)) to '{TEST_DIR}/fetch_ord.parquet' (row_group_size 50000);
 
 statement ok quack_db:quack_server_con
-create view big_pq as select i from '{TEST_DIR}/fetch_ord.parquet';
+create view big_pq as select i, pad from '{TEST_DIR}/fetch_ord.parquet';
 
 statement ok
 attach {server} as rpc (token 'asdf')
 
-# one DataChunk per FETCH response => many FETCH round-trips, exercising the read-ahead pipeline.
+# small batches + a one-batch PREPARE drain => many FETCH round-trips through the read-ahead pipeline.
 # Set AFTER the attach: the catalog enumeration itself is otherwise truncated to one chunk and
 # loses the views (pre-existing ExecuteCommandInternal FIXME).
 statement ok quack_db:quack_server_con
-set global quack_fetch_batch_rows=1;
+set global quack_prepare_inline_rows=1;
+
+statement ok quack_db:quack_server_con
+set global quack_target_batch_bytes=65536;
+
+# sanity: this shape really produces multiple FETCHes (guards the batching config against drift)
+statement ok
+CALL enable_logging('Quack');
+
+query II
+select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
+----
+100000	4999950000
+
+query I
+select count(*) > 1 from duckdb_logs_parsed('Quack') where message_type = 'FETCH_REQUEST'
+----
+true
+
+statement ok
+CALL disable_logging();
 
 # the scan must behave the same whether fetches run on the ASYNC pool or inline (async_threads=0)
 foreach at 0 1 8
@@ -47,7 +69,7 @@ select count(*), sum(i) from quack_query_by_name('rpc', 'from big')
 
 # order preservation: server-assigned batch indices flow into an order-preserving CTAS
 statement ok
-create or replace table local_ctas as from quack_query({server}, 'select i from big order by i', token='asdf');
+create or replace table local_ctas as from quack_query({server}, 'select i, pad from big order by i', token='asdf');
 
 query I
 select count(*) from (select i, row_number() over () - 1 rn from local_ctas) where i != rn
@@ -57,7 +79,7 @@ select count(*) from (select i, row_number() over () - 1 rn from local_ctas) whe
 # larger ordered CTAS through the attached catalog: fetches complete out of order, but scan
 # threads must observe monotonically increasing batch indices (order-preserving plan asserts it)
 statement ok
-create or replace table ordered_ctas as select i from rpc.big500;
+create or replace table ordered_ctas as select i, pad from rpc.big500;
 
 query I
 select count(*) from (select i, row_number() over () - 1 rn from ordered_ctas) where i != rn
@@ -66,7 +88,7 @@ select count(*) from (select i, row_number() over () - 1 rn from ordered_ctas) w
 
 # same, sourced from a remote parquet view (parallel multi-row-group scan on the server)
 statement ok
-create or replace table ordered_ctas_pq as select i from rpc.big_pq;
+create or replace table ordered_ctas_pq as select i, pad from rpc.big_pq;
 
 query I
 select count(*) from (select i, row_number() over () - 1 rn from ordered_ctas_pq) where i != rn
@@ -118,7 +140,7 @@ statement ok
 SET quack_debug_fetch_delay_ms=15;
 
 statement ok
-create or replace table delayed_ctas as select i from rpc.big500;
+create or replace table delayed_ctas as select i, pad from rpc.big500;
 
 query I
 select count(*) from (select i, row_number() over () - 1 rn from delayed_ctas) where i != rn
@@ -147,5 +169,11 @@ query II
 select count(*), sum(i) from quack_query({server}, 'from big', token='asdf')
 ----
 100000	4999950000
+
+statement ok quack_db:quack_server_con
+reset global quack_target_batch_bytes;
+
+statement ok quack_db:quack_server_con
+reset global quack_prepare_inline_rows;
 
 include test/template/quack_teardown.test_template

--- a/test/sql/fetch_cancel_insert.test
+++ b/test/sql/fetch_cancel_insert.test
@@ -4,8 +4,8 @@
 
 include test/template/quack_setup.test_template
 
-# After the client abandons the scan, the producer fills the tiny buffer and parks on its capacity
-# wait holding the connection lock; CANCEL must abort the stream or later statements hang.
+# The client stops the scan. The producer then fills the small buffer and parks, and it holds the
+# connection lock. CANCEL must abort the stream, or the next statement waits for ever.
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_fetch_producer_buffer_bytes = 262144;
 
@@ -27,13 +27,12 @@ ATTACH {server} AS remote (TOKEN 'asdf');
 statement ok
 ATTACH {server} AS remote2 (TOKEN 'asdf');
 
-# abandon a large scan after one row: fetching stops, the producer keeps going until it parks
+# stop a large scan after one row: the producer continues until it parks
 query I
 SELECT count(*) FROM (SELECT * FROM quack_query_by_name('remote', 'SELECT i, pad FROM big') LIMIT 1);
 ----
 1
 
-# give the producer time to fill the buffer and park
 statement ok
 SELECT sleep_ms(200);
 
@@ -49,7 +48,7 @@ SET VARIABLE conn_id = (
 statement ok
 FROM quack_cancel('remote2', getvariable('conn_id'));
 
-# without the abort in CANCEL, this INSERT blocks forever on the connection lock
+# without the abort in CANCEL, this INSERT waits for ever on the connection lock
 statement ok
 INSERT INTO remote.sink_t VALUES (1);
 

--- a/test/sql/fetch_cancel_insert.test
+++ b/test/sql/fetch_cancel_insert.test
@@ -1,0 +1,70 @@
+# name: test/sql/fetch_cancel_insert.test
+# description: cancelling a scan whose producer is parked on the fetch buffer frees the connection for later INSERTs
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+# After the client abandons the scan, the producer fills the tiny buffer and parks on its capacity
+# wait holding the connection lock; CANCEL must abort the stream or later statements hang.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_fetch_producer_buffer_bytes = 262144;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_target_batch_bytes = 65536;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_prepare_inline_rows = 1;
+
+statement ok quack_db:quack_server_con
+CREATE TABLE big AS SELECT range AS i, hash(range) AS pad FROM range(1000000);
+
+statement ok quack_db:quack_server_con
+CREATE TABLE sink_t(i BIGINT);
+
+statement ok
+ATTACH {server} AS remote (TOKEN 'asdf');
+
+statement ok
+ATTACH {server} AS remote2 (TOKEN 'asdf');
+
+# abandon a large scan after one row: fetching stops, the producer keeps going until it parks
+query I
+SELECT count(*) FROM (SELECT * FROM quack_query_by_name('remote', 'SELECT i, pad FROM big') LIMIT 1);
+----
+1
+
+# give the producer time to fill the buffer and park
+statement ok
+SELECT sleep_ms(200);
+
+statement ok
+SET VARIABLE conn_id = (
+  SELECT connection_id
+  FROM quack_query_by_name('remote2',
+    'SELECT connection_id FROM quack_active_connections()
+     WHERE state = ''active'' AND query LIKE ''%FROM big%''
+     LIMIT 1')
+);
+
+statement ok
+FROM quack_cancel('remote2', getvariable('conn_id'));
+
+# without the abort in CANCEL, this INSERT blocks forever on the connection lock
+statement ok
+INSERT INTO remote.sink_t VALUES (1);
+
+query I
+SELECT count(*) FROM remote.sink_t;
+----
+1
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_fetch_producer_buffer_bytes;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_prepare_inline_rows;
+
+include test/template/quack_teardown.test_template

--- a/test/sql/fetch_error.test
+++ b/test/sql/fetch_error.test
@@ -1,0 +1,34 @@
+# name: test/sql/fetch_error.test
+# description: a server-side execution error reaches the client with its own message
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+# the query fails before it seals a batch
+statement error
+SELECT * FROM quack_query({server}, 'SELECT CASE WHEN i >= 100 THEN error(''small boom'') ELSE i END FROM range(200) t(i)', token='asdf');
+----
+small boom
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_target_batch_bytes = 65536;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_prepare_inline_rows = 1;
+
+statement ok quack_db:quack_server_con
+CREATE TABLE big AS SELECT range AS i, hash(range) AS pad FROM range(200000);
+
+# the query fails after PREPARE inlined a batch and the client fetched more
+statement error
+SELECT * FROM quack_query({server}, 'SELECT CASE WHEN i >= 150000 THEN error(''late boom'') ELSE i END AS i, pad FROM big', token='asdf');
+----
+late boom
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_prepare_inline_rows;
+
+include test/template/quack_teardown.test_template

--- a/test/sql/fetch_head_of_line.test
+++ b/test/sql/fetch_head_of_line.test
@@ -4,9 +4,9 @@
 
 include test/template/quack_setup.test_template
 
-# The stall shape: jittered emitters fill the small (8-batch) buffer with LATER batches while the
-# head batch's emitter lags; the head then blocks on capacity while the client waits for exactly it.
-# Head-of-stream admission must let it through — without it this test hangs.
+# The emitters run at different speeds. The slow ones fill the small buffer with LATER batches, and
+# the head batch then finds no capacity while the client waits for it. Head-of-stream admission must
+# let the head in. Without it, this test waits for ever.
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_fetch_producer_buffer_bytes = 524288;
 
@@ -22,7 +22,7 @@ SET GLOBAL quack_debug_emit_delay_ms = 5;
 statement ok quack_db:quack_server_con
 CREATE TABLE big AS SELECT range AS i, hash(range) AS pad FROM range(200000);
 
-# single consuming scan thread + a read-ahead window of 1: the client only ever waits on one index
+# one scan thread and a read-ahead window of 1: the client waits on one index only
 statement ok
 SET threads = 1;
 

--- a/test/sql/fetch_head_of_line.test
+++ b/test/sql/fetch_head_of_line.test
@@ -1,0 +1,55 @@
+# name: test/sql/fetch_head_of_line.test
+# description: a full producer buffer of later batches must not starve the head batch (single-threaded client)
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+# The stall shape: jittered emitters fill the small (8-batch) buffer with LATER batches while the
+# head batch's emitter lags; the head then blocks on capacity while the client waits for exactly it.
+# Head-of-stream admission must let it through — without it this test hangs.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_fetch_producer_buffer_bytes = 524288;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_target_batch_bytes = 65536;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_prepare_inline_rows = 1;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_debug_emit_delay_ms = 5;
+
+statement ok quack_db:quack_server_con
+CREATE TABLE big AS SELECT range AS i, hash(range) AS pad FROM range(200000);
+
+# single consuming scan thread + a read-ahead window of 1: the client only ever waits on one index
+statement ok
+SET threads = 1;
+
+statement ok
+SET quack_fetch_read_ahead = 1;
+
+query II
+SELECT count(*), sum(i) FROM quack_query({server}, 'SELECT i, pad FROM big', token='asdf')
+----
+200000	19999900000
+
+statement ok
+RESET threads;
+
+statement ok
+RESET quack_fetch_read_ahead;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_fetch_producer_buffer_bytes;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_prepare_inline_rows;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_debug_emit_delay_ms;
+
+include test/template/quack_teardown.test_template

--- a/test/sql/fetch_projection.test
+++ b/test/sql/fetch_projection.test
@@ -4,10 +4,19 @@
 
 include test/template/quack_setup.test_template
 
-# 30000 rows x 2 cols => ~15 DataChunks of 2048 => exceeds quack_fetch_batch_rows (24576),
-# forcing at least one FETCH round-trip after the initial PREPARE batch.
+# A small batch target + an incompressible hash() column force the result to span multiple FETCH
+# batches (batches are cut on SERIALIZED size; plain sequential data would fit one inlined batch).
 statement ok quack_db:quack_server_con
-create table big as select range as a, range * 2 as b from range(30000);
+set global quack_target_batch_bytes=65536;
+
+statement ok quack_db:quack_server_con
+set global quack_prepare_inline_rows=1;
+
+statement ok quack_db:quack_server_con
+create table big as select range as a, range * 2 as b, hash(range) as pad from range(30000);
+
+statement ok
+CALL enable_logging('Quack');
 
 # Inner query returns 2 columns; the outer aggregate only needs column a, so DuckDB
 # prunes the scan output to width 1. Fetched chunks are still full-width and must be
@@ -17,10 +26,25 @@ select count(*), min(a), max(a) from quack_query({server}, 'SELECT * FROM big', 
 ----
 30000	0	29999
 
+# sanity: the result really spans multiple FETCHes (guards the batching config against drift)
+query I
+select count(*) > 1 from duckdb_logs_parsed('Quack') where message_type = 'FETCH_REQUEST'
+----
+true
+
 # Projecting the second column verifies the local projection picks the right column index.
 query III
 select count(*), min(b), max(b) from quack_query({server}, 'SELECT * FROM big', token='asdf')
 ----
 30000	0	59998
+
+statement ok
+CALL disable_logging();
+
+statement ok quack_db:quack_server_con
+reset global quack_target_batch_bytes;
+
+statement ok quack_db:quack_server_con
+reset global quack_prepare_inline_rows;
 
 include test/template/quack_teardown.test_template

--- a/test/sql/fetch_projection.test
+++ b/test/sql/fetch_projection.test
@@ -4,8 +4,8 @@
 
 include test/template/quack_setup.test_template
 
-# A small batch target + an incompressible hash() column force the result to span multiple FETCH
-# batches (batches are cut on SERIALIZED size; plain sequential data would fit one inlined batch).
+# A small batch target and a hash() column that is hard to compress make the result span more than
+# one FETCH batch. Batches are cut on SERIALIZED size, so plain data would fit one inlined batch.
 statement ok quack_db:quack_server_con
 set global quack_target_batch_bytes=65536;
 
@@ -26,7 +26,7 @@ select count(*), min(a), max(a) from quack_query({server}, 'SELECT * FROM big', 
 ----
 30000	0	29999
 
-# sanity: the result really spans multiple FETCHes (guards the batching config against drift)
+# make sure the result really spans more than one FETCH
 query I
 select count(*) > 1 from duckdb_logs_parsed('Quack') where message_type = 'FETCH_REQUEST'
 ----

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -207,8 +207,7 @@ SET preserve_insertion_order=true;
 # Async FETCH POSTs run on ASYNC-pool threads via PostRaw(nullptr, ...); the logger stamped at
 # client checkout must make them visible in the HTTP transport log, not just the Quack log.
 
-# small fetch batches so one scan makes many async FETCH round-trips: the producer cuts small
-# dense batches, and the PREPARE response inlines only the first ones
+# small batches, so one scan makes many async FETCH round trips
 statement ok quack_db:quack_server_con
 set global quack_prepare_inline_rows=2048;
 
@@ -218,8 +217,8 @@ set global quack_target_batch_bytes=65536;
 statement ok
 CALL truncate_duckdb_logs();
 
-# hash() keeps the batches incompressible — they are cut on SERIALIZED bytes, and plain range()
-# would compress into a single batch that gets fully inlined into the PREPARE response (no FETCHes)
+# hash() makes the batches hard to compress. They are cut on SERIALIZED bytes, so a plain range()
+# would give one batch, PREPARE would inline it, and no FETCH would run.
 query I
 select count(*) from quack_query({server}, 'select hash(range) h from range(50000)')
 ----

--- a/test/sql/logging.test
+++ b/test/sql/logging.test
@@ -207,15 +207,21 @@ SET preserve_insertion_order=true;
 # Async FETCH POSTs run on ASYNC-pool threads via PostRaw(nullptr, ...); the logger stamped at
 # client checkout must make them visible in the HTTP transport log, not just the Quack log.
 
-# small fetch batches so one scan makes many async FETCH round-trips
+# small fetch batches so one scan makes many async FETCH round-trips: the producer cuts small
+# dense batches, and the PREPARE response inlines only the first ones
 statement ok quack_db:quack_server_con
-set global quack_fetch_batch_rows=2048;
+set global quack_prepare_inline_rows=2048;
+
+statement ok quack_db:quack_server_con
+set global quack_target_batch_bytes=65536;
 
 statement ok
 CALL truncate_duckdb_logs();
 
+# hash() keeps the batches incompressible — they are cut on SERIALIZED bytes, and plain range()
+# would compress into a single batch that gets fully inlined into the PREPARE response (no FETCHes)
 query I
-select count(*) from quack_query({server}, 'from range(50000)')
+select count(*) from quack_query({server}, 'select hash(range) h from range(50000)')
 ----
 50000
 
@@ -236,7 +242,10 @@ select
 true
 
 statement ok quack_db:quack_server_con
-reset global quack_fetch_batch_rows;
+reset global quack_prepare_inline_rows;
+
+statement ok quack_db:quack_server_con
+reset global quack_target_batch_bytes;
 
 # --- HTTP logging (context-less teardown scope) ---
 # A pooled client's DISCONNECT POST is context-less and must not be logged under the

--- a/test/sql/reconnects_parallel.test
+++ b/test/sql/reconnects_parallel.test
@@ -4,8 +4,8 @@
 
 include test/template/quack_setup.test_template
 
-# One-batch PREPARE drain + small batches of a scrambled (incompressible but deterministic) column
-# force a genuinely multi-FETCH parallel scan, engaging the exactly-once ACK machinery.
+# A one-batch PREPARE drain and small batches of a scrambled column make a parallel scan that needs
+# many FETCHes. This is what puts the exactly-once ACK machinery to work.
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_prepare_inline_rows = 1;
 
@@ -28,7 +28,7 @@ statement ok
 CALL enable_logging('Quack');
 
 # --- reconnects disabled: full parallel consumption completes and NO ACK is sent ---
-# CTAS forces a full transfer: aggregates would be pushed down whole (one-row result, no FETCH)
+# CTAS moves all the data. An aggregate would be pushed down and give one row, with no FETCH.
 statement ok
 CREATE OR REPLACE TABLE local_1 AS SELECT i, r FROM remote.big;
 
@@ -37,7 +37,7 @@ SELECT count(*), sum(r) FROM local_1;
 ----
 300000	147413745176582
 
-# sanity: the scan above really was multi-FETCH (guards the batching config against drift)
+# make sure the scan above really used more than one FETCH
 query I
 SELECT count(*) > 1 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'FETCH_REQUEST';
 ----

--- a/test/sql/reconnects_parallel.test
+++ b/test/sql/reconnects_parallel.test
@@ -4,12 +4,16 @@
 
 include test/template/quack_setup.test_template
 
-# One chunk per FETCH batch forces ack_sent machinery is engaged.
+# One-batch PREPARE drain + small batches of a scrambled (incompressible but deterministic) column
+# force a genuinely multi-FETCH parallel scan, engaging the exactly-once ACK machinery.
 statement ok quack_db:quack_server_con
-SET GLOBAL quack_fetch_batch_rows = 1;
+SET GLOBAL quack_prepare_inline_rows = 1;
 
 statement ok quack_db:quack_server_con
-CREATE TABLE big AS SELECT range AS i FROM range(300000);
+SET GLOBAL quack_target_batch_bytes = 65536;
+
+statement ok quack_db:quack_server_con
+CREATE TABLE big AS SELECT range AS i, (range * 48271) % 1000000007 AS r FROM range(300000);
 
 statement ok
 CREATE SECRET (TYPE quack, TOKEN 'asdf');
@@ -24,10 +28,20 @@ statement ok
 CALL enable_logging('Quack');
 
 # --- reconnects disabled: full parallel consumption completes and NO ACK is sent ---
-query I
-SELECT count(*) FROM remote.big;
+# CTAS forces a full transfer: aggregates would be pushed down whole (one-row result, no FETCH)
+statement ok
+CREATE OR REPLACE TABLE local_1 AS SELECT i, r FROM remote.big;
+
+query II
+SELECT count(*), sum(r) FROM local_1;
 ----
-300000
+300000	147413745176582
+
+# sanity: the scan above really was multi-FETCH (guards the batching config against drift)
+query I
+SELECT count(*) > 1 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'FETCH_REQUEST';
+----
+true
 
 query I
 SELECT count(*) FROM duckdb_logs_parsed('Quack') WHERE message_type = 'ACKNOWLEDGEMENT';
@@ -38,10 +52,13 @@ statement ok
 SET quack_enable_reconnects = true;
 
 # --- reconnects enabled: full parallel consumption sends EXACTLY ONE ACK ---
-query I
-SELECT count(*) FROM remote.big;
+statement ok
+CREATE OR REPLACE TABLE local_2 AS SELECT i, r FROM remote.big;
+
+query II
+SELECT count(*), sum(r) FROM local_2;
 ----
-300000
+300000	147413745176582
 
 query I
 SELECT count(*) FROM duckdb_logs_parsed('Quack')
@@ -50,10 +67,13 @@ WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE';
 1
 
 # A second query sends its own single ACK: exactly one per completed query, never zero, never two.
+statement ok
+CREATE OR REPLACE TABLE local_3 AS SELECT i, r FROM remote.big;
+
 query I
-SELECT sum(i) FROM remote.big;
+SELECT sum(r) FROM local_3;
 ----
-44999850000
+147413745176582
 
 query I
 SELECT count(*) FROM duckdb_logs_parsed('Quack')
@@ -62,7 +82,10 @@ WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE';
 2
 
 statement ok quack_db:quack_server_con
-RESET GLOBAL quack_fetch_batch_rows;
+RESET GLOBAL quack_prepare_inline_rows;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
 
 statement ok
 DETACH remote;

--- a/test/sql/result_cache_read_ahead.test
+++ b/test/sql/result_cache_read_ahead.test
@@ -1,5 +1,5 @@
 # name: test/sql/result_cache_read_ahead.test
-# description: result cache over a multi-batch read-ahead result: retention flows through FETCH, survives internal catalog traffic, and is released by the client's ACK
+# description: result cache over a multi-batch read-ahead result: retention through FETCH, survival of internal catalog traffic, release by the client ACK
 # group: [sql]
 
 include test/template/quack_setup.test_template
@@ -16,8 +16,8 @@ SET GLOBAL quack_cache_max_rows = 0;
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_result_ttl = 0;
 
-# The other cache tests use results small enough that PREPARE inlines them whole, so they only cover
-# retention from the inline drain. Small batches force real FETCH round trips instead.
+# The other cache tests use a result that PREPARE inlines whole. They cover the inline drain only.
+# Small batches force real FETCH round trips.
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_prepare_inline_rows = 1;
 
@@ -43,7 +43,7 @@ SELECT count(*), sum(r) FROM local_copy;
 ----
 200000	97656166825687
 
-# the scan really did go over many FETCHes, so the rows below came through the FETCH handler
+# the scan used many FETCHes, so the rows above came through the FETCH handler
 query I
 SELECT count(*) > 1 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'FETCH_REQUEST';
 ----
@@ -55,8 +55,8 @@ SELECT max(cached_rows) FROM quack_active_connections();
 200000
 
 # --- internal catalog traffic must not displace it ---
-# quack_clear_cache re-binds the catalog over the same connection with query uuid 0. The retained
-# payloads belong to the cache, not to whatever stream the connection is serving now.
+# quack_clear_cache binds the catalog again on the same connection, with query uuid 0. The
+# payloads belong to the cache, and not to the stream the connection serves now.
 
 statement ok
 CALL quack_clear_cache();

--- a/test/sql/result_cache_read_ahead.test
+++ b/test/sql/result_cache_read_ahead.test
@@ -1,0 +1,102 @@
+# name: test/sql/result_cache_read_ahead.test
+# description: result cache over a multi-batch read-ahead result: retention flows through FETCH, survives internal catalog traffic, and is released by the client's ACK
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+CREATE TABLE big AS SELECT range AS i, (range * 48271) % 1000000007 AS r FROM range(200000);
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_enable_reconnects = true;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_cache_max_rows = 0;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_result_ttl = 0;
+
+# The other cache tests use results small enough that PREPARE inlines them whole, so they only cover
+# retention from the inline drain. Small batches force real FETCH round trips instead.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_prepare_inline_rows = 1;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_target_batch_bytes = 65536;
+
+statement ok
+CREATE SECRET (TYPE quack, TOKEN 'asdf');
+
+statement ok
+ATTACH {server} AS remote;
+
+statement ok
+CALL enable_logging('Quack');
+
+# --- a fully consumed multi-batch result is retained in full ---
+
+statement ok
+CREATE OR REPLACE TABLE local_copy AS SELECT i, r FROM remote.big;
+
+query II
+SELECT count(*), sum(r) FROM local_copy;
+----
+200000	97656166825687
+
+# the scan really did go over many FETCHes, so the rows below came through the FETCH handler
+query I
+SELECT count(*) > 1 FROM duckdb_logs_parsed('Quack') WHERE message_type = 'FETCH_REQUEST';
+----
+true
+
+query I quack_db:quack_server_con
+SELECT max(cached_rows) FROM quack_active_connections();
+----
+200000
+
+# --- internal catalog traffic must not displace it ---
+# quack_clear_cache re-binds the catalog over the same connection with query uuid 0. The retained
+# payloads belong to the cache, not to whatever stream the connection is serving now.
+
+statement ok
+CALL quack_clear_cache();
+
+query I quack_db:quack_server_con
+SELECT max(cached_rows) FROM quack_active_connections();
+----
+200000
+
+# --- the client's ACK releases it ---
+
+statement ok
+SET quack_enable_reconnects = true;
+
+statement ok
+CREATE OR REPLACE TABLE local_copy_2 AS SELECT i, r FROM remote.big;
+
+query II
+SELECT count(*), sum(r) FROM local_copy_2;
+----
+200000	97656166825687
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('Quack')
+WHERE message_type = 'ACKNOWLEDGEMENT' AND response_type = 'SUCCESS_RESPONSE';
+----
+1
+
+query I quack_db:quack_server_con
+SELECT count(cached_rows) FROM quack_active_connections();
+----
+0
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_prepare_inline_rows;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
+
+statement ok
+DETACH remote;
+
+include test/template/quack_teardown.test_template

--- a/test/sql/result_ttl.test
+++ b/test/sql/result_ttl.test
@@ -106,8 +106,8 @@ SELECT count(cached_rows) FROM quack_active_connections();
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_result_ttl = 1;
 
-# Small batches, or the whole result is one batch that PREPARE inlines: the client would then never
-# FETCH, and an expired stream it never resumes proves nothing.
+# Small batches. At the default size the result is one batch, PREPARE inlines it, and the client
+# never sends a FETCH. An expired stream that nobody resumes proves nothing.
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_target_batch_bytes = 65536;
 

--- a/test/sql/result_ttl.test
+++ b/test/sql/result_ttl.test
@@ -106,6 +106,11 @@ SELECT count(cached_rows) FROM quack_active_connections();
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_result_ttl = 1;
 
+# Small batches, or the whole result is one batch that PREPARE inlines: the client would then never
+# FETCH, and an expired stream it never resumes proves nothing.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_target_batch_bytes = 65536;
+
 # Bind-time PREPARE serves the first batch and leaves the tail in the cache; the client then idles.
 statement ok
 PREPARE p AS SELECT sum(i) FROM quack_query({server}, 'FROM big', token=>'asdf');
@@ -120,6 +125,9 @@ Query was interrupted
 
 statement ok
 DEALLOCATE p;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
 
 statement ok
 DETACH remote;

--- a/test/sql/result_ttl_releases_query.test
+++ b/test/sql/result_ttl_releases_query.test
@@ -16,9 +16,9 @@ SET GLOBAL quack_cache_max_rows = 0;
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_result_ttl = 1;
 
-# Small batches and a small producer buffer, so the read-ahead producer parks on capacity while the
-# sort is still live. Left at their defaults the whole result fits in the buffer, the query runs to
-# completion during PREPARE, and there is no abandoned query left to release.
+# Small batches and a small producer buffer, so the producer parks while the sort is still live.
+# At the default sizes the whole result fits in the buffer. The query then completes during
+# PREPARE, and no abandoned query remains to release.
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_target_batch_bytes = 65536;
 

--- a/test/sql/result_ttl_releases_query.test
+++ b/test/sql/result_ttl_releases_query.test
@@ -16,6 +16,15 @@ SET GLOBAL quack_cache_max_rows = 0;
 statement ok quack_db:quack_server_con
 SET GLOBAL quack_result_ttl = 1;
 
+# Small batches and a small producer buffer, so the read-ahead producer parks on capacity while the
+# sort is still live. Left at their defaults the whole result fits in the buffer, the query runs to
+# completion during PREPARE, and there is no abandoned query left to release.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_target_batch_bytes = 65536;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_fetch_producer_buffer_bytes = 262144;
+
 statement ok
 CREATE SECRET (TYPE quack, TOKEN 'asdf');
 
@@ -52,5 +61,11 @@ DETACH sweeper;
 
 statement ok
 DEALLOCATE p;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_target_batch_bytes;
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_fetch_producer_buffer_bytes;
 
 include test/template/quack_teardown.test_template


### PR DESCRIPTION
Builds on #208. That PR made the client fetch ahead, but the server side was still a single lazily driven cursor behind a mutex: one thread pulling chunks out of a `StreamingQueryResult`, serializing them on the reply thread, and handing out "the next batch" to whoever asked. That design has three problems: production is serial no matter how parallel the query is, every FETCH pays serialization latency on the critical path, and "give me the next batch" is unsafe to retry (a lost response means a lost batch).

This PR replaces that with a parallel, pre-serialized, retry-safe read path. The query now runs into a result collector that produces wire-ready batches on the executor threads, and FETCH becomes an addressed, idempotent request: the client asks for batch N and the server can answer that exact question any number of times.

> A follow up PR will move the send data path into the same machinery

## The core: claim buffer and rebalancer

Two components carry the design, and both are deliberately generic because the send path will reuse them:

**`QuackClaimBuffer`** is the delivery primitive: a buffer of densely numbered batches (1, 2, 3, ...) where each consumer claims the next index and waits for exactly that batch. Producers can push out of order; consumers still see a monotone sequence per thread. It also carries the safety features: push dedupe (a retried delivery of the same index is dropped), byte-capacity backpressure into the producer, head of stream admission (the batch the consumer needs next is always admitted so a full buffer of later batches cannot starve it), and `Finish(expected_total)` which errors if the stream closed short instead of silently truncating.  The claiming model is borrowed from core's multi-file read-ahead (consumers claim the next ticket and wait for exactly that one), and waiting reuses its `ReadAheadJobCompletion` directly, so a scan thread whose batch is not there yet parks and returns `BLOCKED` to the executor, and publishing that batch wakes exactly that task. The buffer itself is hand-rolled: core's machinery is a prefetch task runner, not an addressable batch buffer. Converging the two in core someday would be nice. The same template backs the client fetch buffer and the server fetch stream, and later the insert stream.

**`QuackRebalancerCore/Sink`** solves the shape mismatch between what the executor produces and what we want on the wire. Executor batches are sparse and uneven (a filtered scan can produce 1kb fragments); wire messages want to be dense and evenly sized. The rebalancer accumulates fragments per thread up to `quack_target_batch_bytes` (default 32MB), maps them onto dense indices while preserving source order when required, and emits them out of order (receivers reassemble by index). The key property is that fragments are accumulated directly in their final serialized form, so cutting a batch costs no extra copy or serialization pass. On this PR the rebalancer feeds the server fetch collector; on the next one the same sink feeds the client INSERT.

A note on that last point, since the obvious alternative is buffering chunks in a `ColumnDataCollection` and serializing at send time (as I suggested in #191). Serializing into a `MemoryStream` as chunks arrive wins on three counts: the data is copied exactly once (chunk to wire bytes, on the producer thread, instead of chunk to CDC to wire bytes with the serialization pass landing on whichever thread cuts the batch), batches get cut on their actual serialized size rather than a columnar in-memory estimate, and the server can hand the exact same buffer to httplib for the response and retain it for retries with zero further work. The trade-off is losing the buffer manager backing a CDC would give us; the claim buffer's byte cap and the rebalancer's memory budget bound it instead.

## Life a chunk in the fetch path

Diagram by Claude et al.

```txt
             SERVER               |               CLIENT
                                  |
  query starts on a background <--+---  PREPARE(sql)
  thread with the fetch           |
  collector plugged in            |
      |                           |
      | DataChunks (parallel      |
      | executor threads)         |
      v                           |
  fragment builder: chunks        |
  serialize straight into a       |
  FETCH_RESPONSE payload as       |
  they arrive                     |
      |                           |
      | seal at the byte target   |
      v                           |
  rebalancer: sparse executor     |
  batches become dense 1,2,3,...  |
  stamped into the serialized     |
  payload (8-byte patch)          |
      |                           |
      v                           |
  claim buffer (byte-capped,      |
  blocks the executor if the      |
  client falls behind)            |
      |                           |
      | leading batches inlined --+-->  scan starts on the
      | into the PREPARE response |     inline chunks
      |                           |         |
      |                           |         v
      |                           |     QuackFetcher keeps up
      |                           |     to K FETCHes in flight
      |                           |     on the async pool
      |                           |         |
      | <-------------------------+---  FETCH(batch=N, ack=M)
      v                           |
  pop batch N, patch the          |
  client-visible index, retain    |
  the payload until acked         |
      |                           |
      | raw bytes, zero copy,   --+-->  decode off the pipeline
        nothing serialized on     |     threads, publish into
        the reply thread          |     the claim buffer
                                  |         |
                                  |         v
                                  |     scan threads claim the
                                  |     next index and wait for
                                  |     exactly that batch
                                  |         |
                                  |         v
                                  |     DataChunks flow into
                                  |     the local pipeline
```

Note the reply thread does no serialization work at all: it pops a finished payload, patches 8 bytes, and hands the buffer to httplib via a content provider (no copy either).

## Retry safety

Every FETCH names its batch and carries an ack watermark ("I have everything up to M"). The server retains served payloads until acked, so an HTTP-level retry of a lost response re-serves the same batch instead of popping the next one and losing it. On top of that, both ends validate the total batch count at end of stream, so a lost batch fails loudly. Duplicate deliveries are dropped by the buffer's dedupe.

> Small reads pay a PREPARE latency cost because the response has to wait for the first batch to seal. The fix (sealing the first batch early / opportunistically) is designed and queued as a follow-up PR.

## Follow-ups

- Send path on the same rebalancer + claim buffer (next PR in the stack).
- Early seal for PREPARE latency on large batches.
- Upstream reserved/backpatchable field support in DuckDB's serializer, which would replace the hand-mirrored payload writer and its debug pin entirely (see annex).
- Evicting the retained tail at end of stream. The last ~depth payloads currently stay retained until the next PREPARE or disconnect because nothing acks them. Plan is a best-effort FINALIZE from the client at scan end, which also tears down abandoned scans; needs a quick alignment with #224's ACKNOWLEDGEMENT since they overlap.

## Annex: design notes

I think you will see some interesting/questionable decissions and I wanted to get ahead by providing some explanations. This doesn't make the decisions unquestionable but hopefully it saves a conversation round trip (as we like to optimize round trips here).

**Why batches are stamped after serialization, and the weird serializer that enables it.** The rebalancer only knows a batch's dense index at release time, after the batch is fully serialized, and the FETCH handler renumbers it a second time at serve time (the client-visible index subtracts whatever PREPARE consumed inline). Patching a normal serialized integer is impossible because the encoding is variable width, so the index travels as `QuackBatchIndexField`: a fixed 8-byte field, serialized last, overwritten in place. The chunk count has the same problem in reverse (written before the chunks, known after), solved by zero-padding its LEB128 to a fixed 5 bytes; padded LEB128 decodes to the same value, so standard readers are unaffected.

**`QuackChunkPayloadWriter` and the debug round-trip pin.** Streaming chunks into a payload means hand-writing an incremental encoder that must stay byte-identical to the generated codec the receiver uses. That mirror is convention, not compiler-checked, so `Seal()` in debug builds decodes its own bytes with the generated codec, re-encodes, and requires equality (count region compared by value because of the padding). Any drift between the two encoders fails the first debug test instead of surfacing as a wire error weeks later. To be clear, this whole construction (the hand-mirrored writer, the placeholder tricks, the pin that guards them) exists because DuckDB's serializer has no notion of reserved or backpatchable fields. The proper fix is to add that support in core: let a serializer reserve a fixed-width slot and patch it after the fact, and the writer collapses into the generated code path with no drift to guard against.

**`FetchResponseMessage` codec stays generated.** The fixed-width field needs custom encode/decode logic, but instead of hand-maintaining the codec we use the generator's own hooks (`serialize_property`, `deserialize_skip_assign`, `methods`), so `quack_message.json` remains the wire truth and `generate_serialization.py` is safe to run.

**PREPARE still inlines leading rows.** Small results (catalog enumeration in particular) complete in one round trip. Since batches are stored pre-serialized, the inline drain is the one place that decodes them back into chunks, and FETCH indices are remapped by the consumed count. The old `quack_fetch_batch_rows` setting only governed this drain anymore, so it is renamed to `quack_prepare_inline_rows`.

**Head of stream admission.** Emission is parallel and out of order, but the server only ever pops the exact index the client asked for. Without an exception, a full buffer of later batches can block the one batch the client is waiting on (deadlock-shaped stall, reachable with a single-threaded client). The claim buffer therefore always admits the head of the stream, overshooting the cap by at most one batch. `quack_debug_emit_delay_ms` exists to make tests hit this shape reliably.

**Coexistence with #224.** The ACKNOWLEDGEMENT message and reconnect tests are preserved. Note there are now two unrelated "ack" concepts: #224's query-completion ACK (reconnect support, opt-in) and this PR's per-FETCH `ack_index` watermark (served-payload GC). This may create some confusion, so we should consider a clearer naming convention for either of the two.

## Important EDIT --> we should add backpatching in core first

I think that to make this PR clean we should make backpatching possible via extending the binary serializer in core and the `WriteStream`. Propposal:

### For `WriteStream`

```cpp
class WriteStream {
public:
      virtual void WriteData(const_data_ptr_t buffer, idx_t write_size) = 0;
      // Backpatching: streams that keep written bytes reachable can patch them in place.
      virtual bool SupportsBackpatching() const {
              return false;
      }
      virtual idx_t GetStreamPosition() const;             // throws if unsupported
      virtual void PatchData(idx_t offset, const_data_ptr_t buffer, idx_t size); // throws if unsupported
};
```
Which then `MemoryStream` implements.

### For the `Serializer`

```cpp
class Serializer {
public:
      // A handle to a fixed-width slot: plain offset + width, so the payload owner
      // can re-patch the raw retained bytes later without a live serializer.
      struct ReservedSlot {
              idx_t offset = DConstants::INVALID_INDEX;
              idx_t width = 0;
      };

      // Writes the field header plus a padded-varint placeholder of 'width' bytes.
      virtual ReservedSlot WriteReservedProperty(field_id_t field_id, const char *tag, idx_t width);
      virtual void PatchReserved(const ReservedSlot &slot, uint64_t value);

      // A list whose count is unknown until the elements have been written.
      virtual ReservedSlot BeginDeferredList(field_id_t field_id, const char *tag, idx_t count_width);
      template <class T>
      void WriteDeferredListElement(const T &value); // same element encoding as WriteList's body
      virtual void EndDeferredList(const ReservedSlot &slot, idx_t count);
};
```

And then implemented by the `BinarySerializer`:

```cpp
Serializer::ReservedSlot BinarySerializer::WriteReservedProperty(field_id_t field_id, const char *tag, idx_t width) {
      OnPropertyBegin(field_id, tag);
      ReservedSlot slot {stream.GetStreamPosition(), width};
      data_t padded[MAX_RESERVED_WIDTH];
      EncodePaddedLEB128(0, padded, width); // redundant continuation bits, ProtoZero-style
      stream.WriteData(padded, width);
      OnPropertyEnd();
      return slot;
}

void BinarySerializer::PatchReserved(const ReservedSlot &slot, uint64_t value) {
      D_ASSERT(value < (1ULL << (7 * slot.width))); // must fit the reserved width
      data_t padded[MAX_RESERVED_WIDTH];
      EncodePaddedLEB128(value, padded, slot.width);
      stream.PatchData(slot.offset, padded, slot.width);
}
```

Which is what we basically rolled out in Quack now (and the reason we have basically two potentially divergent serializers)