### PR TITLE
Fix ATTACH when remote tables have computed DEFAULTs (#132)

### DIFF
--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -3,6 +3,7 @@
 #include "quack_scan.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "storage/quack_view.hpp"
@@ -14,11 +15,27 @@ unique_ptr<CreateInfo> ParseCreateTable(const string &sql) {
 	parser.ParseQuery(sql);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::CREATE_STATEMENT) {
 		throw BinderException(
-		    "Failed to create view from SQL string - \"%s\" - statement did not contain a single SELECT statement",
+		    "Failed to parse CREATE TABLE from remote catalog SQL - \"%s\" - expected a single CREATE statement",
 		    sql);
 	}
 	auto &create = parser.statements[0]->Cast<CreateStatement>();
 	return std::move(create.info);
+}
+
+//! Client-side catalog entries for attached quack tables only need name + type for
+//! local planning. Computed DEFAULTs (e.g. `1+0`, `current_timestamp`) fail
+//! BindCreateTableInfo on the client and abort the entire ATTACH with a misleading
+//! "Catalog \"…\" does not exist" (https://github.com/duckdb/duckdb-quack/issues/132).
+//! Postgres/Snowflake attaches similarly expose remote columns without rebinding
+//! server-side DEFAULT expressions into the client catalog. Real DEFAULTs remain
+//! on the server; INSERT DEFAULT VALUES is executed remotely.
+static void StripColumnDefaultsForClientCatalog(CreateTableInfo &info) {
+	for (idx_t i = 0; i < info.columns.LogicalColumnCount(); i++) {
+		auto &col = info.columns.GetColumnMutable(LogicalIndex(i));
+		if (col.HasDefaultValue()) {
+			col.SetDefaultValue(nullptr);
+		}
+	}
 }
 
 QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &parent,
@@ -39,9 +56,18 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			if (info->type != CatalogType::TABLE_ENTRY) {
 				throw InternalException("Expected a CREATE TABLE");
 			}
+			auto &create_table = info->Cast<CreateTableInfo>();
+			StripColumnDefaultsForClientCatalog(create_table);
 			// bind to resolve the types
 			auto binder = Binder::CreateBinder(context);
-			auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
+			unique_ptr<BoundCreateTableInfo> bound_info;
+			try {
+				bound_info = binder->BindCreateTableInfo(std::move(info), schema);
+			} catch (std::exception &ex) {
+				throw BinderException(
+				    "Failed to bind remote table while attaching quack catalog \"%s\" (schema \"%s\"): %s\nSQL: %s",
+				    catalog.GetName(), schema.name, ex.what(), sql);
+			}
 			auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());
 			entry = std::move(table);
 		} else {

--- a/test/sql/attach_computed_default.test
+++ b/test/sql/attach_computed_default.test
@@ -1,0 +1,66 @@
+# name: test/sql/attach_computed_default.test
+# description: ATTACH must not fail when remote tables have computed DEFAULT expressions (issue #132)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# constant default (always worked)
+statement ok con1
+create table t_const (x integer not null default 1);
+
+# computed defaults — previously aborted client ATTACH with "Catalog does not exist"
+statement ok con1
+create table t_expr (x integer not null default 1 + 0);
+
+statement ok con1
+create table t_ts (ts timestamptz default current_timestamp, v integer);
+
+statement ok con1
+insert into t_const default values;
+insert into t_expr default values;
+insert into t_ts (v) values (42);
+
+statement ok con2
+attach {server} as r (token 'asdf')
+
+# catalog must expose all three tables
+query I con2
+select count(*) from r.t_const
+----
+1
+
+query I con2
+select count(*) from r.t_expr
+----
+1
+
+query I con2
+select v from r.t_ts
+----
+42
+
+# remote INSERT DEFAULT still runs server-side
+statement ok con2
+insert into r.t_expr default values
+
+query I con2
+select count(*) from r.t_expr
+----
+2
+
+statement ok con2
+detach r
+
+statement ok con1
+call quack_stop({server})
+
+endloop


### PR DESCRIPTION
## What happened

On **client ATTACH**, quack loads the remote catalog by:

1. Running `duckdb_tables()` on the server (gets each table’s `CREATE TABLE` SQL)
2. Parsing that SQL on the **client**
3. Calling `BindCreateTableInfo` — which **rebinds every column DEFAULT on the client**

**Computed** DEFAULTs (`1+0`, `current_timestamp`, `now()`, …) fail that client-side bind.  
The attach alias is never registered, so the only error the user sees is the misleading:

```text
Binder Error: Catalog "r" does not exist!
```

**Constant** DEFAULTs (`DEFAULT 1`) already worked.  
`quack_query` still works in the broken case (it never rebuilds a full client catalog), which made this easy to misdiagnose.

Postgres/Snowflake attaches do not rebind server DEFAULT expressions into the client catalog the same way — they expose names/types for planning. Quack should behave like that for catalog load.

Closes / fixes #132.

## How to repro

**Server** (`duckdb -init server.sql`):

```sql
INSTALL quack FROM core_nightly; LOAD quack;
-- works with ATTACH:
-- CREATE TABLE t (x INTEGER NOT NULL DEFAULT 1);
-- breaks ATTACH:
CREATE TABLE t (x INTEGER NOT NULL DEFAULT 1 + 0);
INSERT INTO t DEFAULT VALUES;
CALL quack_serve('quack:localhost', token => 'tok1234');
```

**Client**:

```sql
INSTALL quack FROM core_nightly; LOAD quack;
-- still works:
FROM quack_query('quack:localhost', 'FROM t', token => 'tok1234');
-- fails with Catalog "r" does not exist:
ATTACH 'quack:localhost' AS r (TYPE quack, TOKEN 'tok1234');
FROM r.t;
```

Same pattern with `DEFAULT current_timestamp` (e.g. live lookdown tables).

## Fix

In `QuackTableSet` (client catalog load), **strip column DEFAULTs after parse and before `BindCreateTableInfo`**.

- Client catalog only needs **names/types** for planning (same idea as other remote attaches).
- Real DEFAULTs stay on the **server**.
- `INSERT DEFAULT VALUES` still executes **remotely**.
- If bind still fails for another reason, the error now includes catalog name, schema, and the CREATE SQL (instead of only “catalog does not exist”).

## Test

`test/sql/attach_computed_default.test` — ATTACH with:

- constant `DEFAULT 1`
- computed `DEFAULT 1 + 0`
- `DEFAULT current_timestamp`

then scan + remote `INSERT DEFAULT VALUES`.

## Local confirmation

On a live quack server with lookdown tables using `DEFAULT current_timestamp` / `now()`:

- ATTACH failed with `Catalog "q" does not exist`
- Dropping those DEFAULTs unblocked ATTACH (workaround)
- This fix is the proper client-side solution so DEFAULTs can stay on the server