### PR TITLE
Bump httpfs: stalled S3/HTTP transfers time out instead of hanging forever

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -11,6 +11,9 @@ duckdb_extension_load(autocomplete)
 
 duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    GIT_TAG 53c5b032f6c368cfcc1a1ac3819118e86d3286a6
-    APPLY_PATCHES
+    # Includes the curl per-read timeout fix (duckdb-httpfs#336): stalled transfers abort via
+    # CURLOPT_LOW_SPEED_* instead of hanging forever / requiring a huge total-transfer timeout.
+    # Newest commit before the 2026-07-30 directory restructure. No APPLY_PATCHES: the carried
+    # patches (prefetch network cost model etc.) were absorbed upstream on 2026-07-03.
+    GIT_TAG a6352ca0a4bec678008133cd41edb13e6465fa88
 )


### PR DESCRIPTION
Bump `httpfs` since relevant changes were made wrt timeouts