### PR TITLE
Server: keep result teardown and session-id RNG race-free

### DIFF
--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -261,6 +261,7 @@ string QuackServer::GenerateRandomToken(DatabaseInstance &db) {
 }
 
 string QuackServer::GenerateSessionId() {
+	data_t bytes[kTokenBytes];
 	{
 		std::lock_guard<std::mutex> lock(session_id_rng_mutex);
 		if (!session_id_rng) {
@@ -273,10 +274,9 @@ string QuackServer::GenerateSessionId() {
 			                                                   EncryptionTypes::EncryptionVersion::NONE);
 			session_id_rng = encryption_util->CreateEncryptionState(std::move(metadata));
 		}
+		// Generate under the mutex: the RNG state is shared across concurrent CONNECTION_REQUESTs.
+		session_id_rng->GenerateRandomData(bytes, kTokenBytes);
 	}
-
-	data_t bytes[kTokenBytes];
-	session_id_rng->GenerateRandomData(bytes, kTokenBytes);
 	return HexEncode(bytes, kTokenBytes);
 }
 
@@ -449,8 +449,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto effective_sql = (auth_result.type().id() == LogicalTypeId::VARCHAR) ? auth_result.GetValue<string>()
 		                                                                         : prepare_request_message.Query();
 
+		// Declared before `lock` so it is destroyed after the lock releases: tearing down the
+		// previous query's streaming result can block on its in-flight I/O, and must not do so
+		// while holding the session lock.
+		unique_ptr<QueryResult> stale_result;
 		std::unique_lock<std::mutex> lock(connection.lock);
-		connection.duckdb_query_result.reset();
+		stale_result = std::move(connection.duckdb_query_result);
 		connection.sql_query = prepare_request_message.Query();
 		connection.query_state = QuackQueryState::ACTIVE;
 		connection.query_started_at = Timestamp::GetCurrentTimestamp();
@@ -658,8 +662,14 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			                                cancel_request_message.query_uuid, connection.query_uuid);
 		}
 		connection.duckdb_connection->Interrupt();
+		// The interrupt aborts any statement currently running under the session lock; take the
+		// lock so the state change and result handoff cannot race that statement's handler.
+		// `stale_result` is declared before `lock` so the result's (potentially blocking)
+		// teardown runs after the lock is released.
+		unique_ptr<QueryResult> stale_result;
+		std::unique_lock<std::mutex> lock(connection.lock);
 		connection.query_state = QuackQueryState::CANCELLED;
-		connection.duckdb_query_result.reset();
+		stale_result = std::move(connection.duckdb_query_result);
 		return make_uniq<SuccessResponse>();
 	}
 	case MessageType::ACKNOWLEDGEMENT: {


### PR DESCRIPTION
Minimal server-side hardening for the wedged-server failure mode diagnosed alongside #235
(long-running servers with many connections/queries eventually stop responding to initial
requests). Three fixes in `quack_server.cpp`:

## Result teardown must not run under the session lock

Destroying a streaming `QueryResult` tears down the query's pipelines, which can block on
in-flight I/O (on the wedged deployment: read-ahead waiting on a stalled remote read). Both
PREPARE (discarding the previous query's result) and CANCEL did this while holding
`connection.lock`, so a single stuck teardown wedged the whole session — every subsequent
request for that session (and each client retry) then parked an HTTP worker on the lock
forever. The stale result is now moved into a local declared *before* the lock guard, so its
destructor runs after the lock releases, on every return path.

## CANCEL raced concurrent handlers on the query result

CANCEL mutated `query_state` and destroyed `duckdb_query_result` without holding
`connection.lock`, racing a concurrent PREPARE/FETCH mid-`CreateBatch` on the same result — a
use-after-free. It now interrupts first (which aborts whatever statement is running under the
lock), then takes the lock for the state change and result handoff.

## Session-id RNG used outside its mutex

`GenerateSessionId` created the shared RNG under `session_id_rng_mutex` but called
`GenerateRandomData` on it after dropping the lock; concurrent CONNECTION_REQUESTs raced on the
RNG state. Generation now happens under the mutex.

## Related

- #235 bumped httpfs so stalled transfers time out instead of hanging forever (the root
  trigger).
- duckdb/duckdb branch `readahead-waiters-drain-inline` fixes the core-side read-ahead
  teardown spin that turns a stalled read into a permanently wedged worker thread.

All quack sqllogic tests pass.
