### PR TITLE
Clear socket options in HttpQuackServer unsetting SO_REUSEPORT

### DIFF
--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -208,6 +208,7 @@ HttpQuackServer::HttpQuackServer(ClientContext &context_p, const QuackUri &uri_p
 	server->set_keep_alive_max_count(1 << 20);
 	server->set_keep_alive_timeout(NumericCast<time_t>(keep_alive_timeout));
 	server->set_tcp_nodelay(true);
+	server->set_socket_options([](socket_t sock) {});
 
 	server->Get("/", [=](const duckdb_httplib::Request &, duckdb_httplib::Response &res) {
 		res.set_content("This is a DuckDB Quack RPC endpoint. Use ATTACH 'quack:...' to connect here.\n", "text/plain");

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -23,15 +23,19 @@ QuackStorageExtensionInfo &QuackStorageExtensionInfo::GetState(const DatabaseIns
 
 QuackServer &QuackStorageExtensionInfo::CreateServer(ClientContext &context, const QuackUri &listen_uri,
                                                      const string &token) {
-	auto server = make_uniq<HttpQuackServer>(context, listen_uri, token);
-
-	auto &actual_uri = server->ListenUri();
-	auto key = actual_uri.CanonicalUri();
 	std::lock_guard<std::mutex> lock(servers_mutex);
-	auto it = servers.find(key);
-	if (it != servers.end()) {
-		throw InvalidInputException("Server already exists for %s", key);
+	auto CheckKey = [this](auto key) {
+		auto it = servers.find(key);
+		if (it != servers.end()) {
+			throw InvalidInputException("Server already exists for %s", key);
+		}
+	};
+	if (listen_uri.Port() != 0) {
+		CheckKey(listen_uri.CanonicalUri());
 	}
+	auto server = make_uniq<HttpQuackServer>(context, listen_uri, token);
+	auto key = server->ListenUri().CanonicalUri();
+	CheckKey(key);
 	servers.emplace(key, std::move(server));
 	return *servers[key];
 }


### PR DESCRIPTION
The default httplib socket options has SO_REUSEPORT. This makes it very easy to bind two separate Quack servers to the same port which is not desirable/useful and quickly results in breakage in practice.

You can reproduce the problem by opening the `duckdb` CLI in two terminals and then running e.g.:

```
CALL quack_serve(
 'quack:localhost:9494',
 token = 'token'
 );
```

in both windows. You will notice both succeed unlike running it twice in a single DuckDB session. Trying to attach after this causes various problems, I'm guessing a TCP session is opened per-message and so things get interleaved and cause problems. At any rate, this is probably not what is intended so this patch just clears the default socket options.