### PR TITLE
Bump httpfs to post-restructure main; bundled duckdb to current main

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -11,9 +11,7 @@ duckdb_extension_load(autocomplete)
 
 duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    # Includes the curl per-read timeout fix (duckdb-httpfs#336): stalled transfers abort via
-    # CURLOPT_LOW_SPEED_* instead of hanging forever / requiring a huge total-transfer timeout.
-    # Newest commit before the 2026-07-30 directory restructure. No APPLY_PATCHES: the carried
-    # patches (prefetch network cost model etc.) were absorbed upstream on 2026-07-03.
-    GIT_TAG a6352ca0a4bec678008133cd41edb13e6465fa88
+    # httpfs main as of 2026-07-31, including the large 2026-07-30 restructure/reimplementation
+    # and the curl per-read timeout fix (duckdb-httpfs#336).
+    GIT_TAG fafb14f2c899ddfd1998f8adf2e07fbbfd28b3fd
 )


### PR DESCRIPTION
Follows up on #235: moves the httpfs pin from the last pre-restructure commit to current main
(`fafb14f2c899`, 2026-07-31), picking up the large 2026-07-30 restructure/reimplementation
(duckdb-httpfs#385 and friends) while keeping the curl per-read timeout semantics from
duckdb-httpfs#336.

The new httpfs requires duckdb APIs newer than the bundled July 14 snapshot (it fails to
compile on `SecretPersistType::TRANSACTION`), so the duckdb submodule advances
`26063e4ca7` → `5cb1335d60` (current main, 2026-07-31).

Verified locally: clean release build, all quack sqllogic tests pass (one pre-existing
env-gated skip). A partial run of the bundled duckdb core sqllogic suite (~78%) against the
new pins also showed no failures.