### PR TITLE
Stabilize remote catalog sessions

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -86,7 +86,7 @@ private:
 class QuackClientConnection : public enable_shared_from_this<QuackClientConnection> {
 public:
 	explicit QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
-	                               idx_t max_connections_cached = 1);
+	                               idx_t max_connections_cached = 1, string remote_catalog_p = {});
 	~QuackClientConnection();
 
 	void CancelQuery(hugeint_t query_uuid);
@@ -97,6 +97,9 @@ public:
 	const QuackUri &ServerURI() const {
 		return uri;
 	}
+	const string &RemoteCatalog() const {
+		return remote_catalog;
+	}
 
 	//! Get a client (either a cached one, or open a new one if required)
 	unique_ptr<QuackClientWrapper> GetClient(ClientContext &context) const;
@@ -106,6 +109,7 @@ public:
 private:
 	QuackUri uri;
 	string connection_id;
+	string remote_catalog;
 	mutable mutex lock;
 	//! Bounds cached_clients: each cached client holds a persistent socket that pins a server
 	//! connection slot, so an unbounded cache would let one attach starve the server's budget.

--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -59,7 +59,7 @@ public:
 	static unique_ptr<QuackClient> GetClient(ClientContext &context, const QuackUri &uri);
 
 	static shared_ptr<QuackClientConnection> ConnectToServer(ClientContext &context, const QuackUri &uri, string token,
-	                                                         string client_id = {});
+	                                                         string client_id = {}, string remote_catalog = {});
 
 	//! Resolve the effective client_id for a new connection
 	static string ResolveClientId(ClientContext &context, optional_ptr<const Value> explicit_value);

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -257,7 +257,7 @@ class ConnectionResponseMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_RESPONSE;
 
-	explicit ConnectionResponseMessage(string connection_id_p);
+	explicit ConnectionResponseMessage(string connection_id_p, string remote_catalog_p = {});
 
 protected:
 	ConnectionResponseMessage() : QuackMessage(TYPE) {
@@ -273,6 +273,9 @@ public:
 	idx_t QuackVersion() const {
 		return quack_version;
 	}
+	const string &RemoteCatalog() const {
+		return remote_catalog;
+	}
 
 	void Serialize(Serializer &serializer) const override;
 	static unique_ptr<ConnectionResponseMessage> Deserialize(Deserializer &deserializer);
@@ -281,6 +284,7 @@ private:
 	string server_duckdb_version;
 	string server_platform;
 	idx_t quack_version;
+	string remote_catalog;
 };
 
 class FetchRequestMessage : public QuackMessage {

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -335,12 +335,10 @@ class SendDataRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::SEND_DATA_REQUEST;
 
-	explicit SendDataRequestMessage(string connection_id_p, string catalog_name_p, string schema_name_p,
-	                                string table_name_p, vector<unique_ptr<DataChunkWrapper>> chunks_p,
-	                                hugeint_t query_uuid_p)
-	    : QuackMessage(TYPE, std::move(connection_id_p)), catalog_name(std::move(catalog_name_p)),
-	      schema_name(std::move(schema_name_p)), table_name(std::move(table_name_p)), chunks(std::move(chunks_p)),
-	      query_uuid(query_uuid_p) {
+	explicit SendDataRequestMessage(string connection_id_p, string schema_name_p, string table_name_p,
+	                                vector<unique_ptr<DataChunkWrapper>> chunks_p, hugeint_t query_uuid_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)),
+	      table_name(std::move(table_name_p)), chunks(std::move(chunks_p)), query_uuid(query_uuid_p) {
 	}
 
 	void Serialize(Serializer &serializer) const override;
@@ -375,9 +373,6 @@ public:
 	const string &SchemaName() const {
 		return schema_name;
 	}
-	const string &CatalogName() const {
-		return catalog_name;
-	}
 	const string &TableName() const {
 		return table_name;
 	}
@@ -402,7 +397,6 @@ protected:
 	}
 
 private:
-	string catalog_name;
 	string schema_name;
 	string table_name;
 	vector<unique_ptr<DataChunkWrapper>> chunks;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -330,10 +330,12 @@ class SendDataRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::SEND_DATA_REQUEST;
 
-	explicit SendDataRequestMessage(string connection_id_p, string schema_name_p, string table_name_p,
-	                                vector<unique_ptr<DataChunkWrapper>> chunks_p, hugeint_t query_uuid_p)
-	    : QuackMessage(TYPE, std::move(connection_id_p)), schema_name(std::move(schema_name_p)),
-	      table_name(std::move(table_name_p)), chunks(std::move(chunks_p)), query_uuid(query_uuid_p) {
+	explicit SendDataRequestMessage(string connection_id_p, string catalog_name_p, string schema_name_p,
+	                                string table_name_p, vector<unique_ptr<DataChunkWrapper>> chunks_p,
+	                                hugeint_t query_uuid_p)
+	    : QuackMessage(TYPE, std::move(connection_id_p)), catalog_name(std::move(catalog_name_p)),
+	      schema_name(std::move(schema_name_p)), table_name(std::move(table_name_p)), chunks(std::move(chunks_p)),
+	      query_uuid(query_uuid_p) {
 	}
 
 	void Serialize(Serializer &serializer) const override;
@@ -368,6 +370,9 @@ public:
 	const string &SchemaName() const {
 		return schema_name;
 	}
+	const string &CatalogName() const {
+		return catalog_name;
+	}
 	const string &TableName() const {
 		return table_name;
 	}
@@ -392,6 +397,7 @@ protected:
 	}
 
 private:
+	string catalog_name;
 	string schema_name;
 	string table_name;
 	vector<unique_ptr<DataChunkWrapper>> chunks;

--- a/src/include/quack_message.hpp
+++ b/src/include/quack_message.hpp
@@ -9,7 +9,7 @@
 namespace duckdb {
 
 //! Quack wire-protocol version. Client and server agree on it during the connection handshake.
-static constexpr idx_t QUACK_VERSION = 2;
+static constexpr idx_t QUACK_VERSION = 3;
 
 enum class MessageType : uint8_t {
 	INVALID = 0,
@@ -211,7 +211,8 @@ class ConnectionRequestMessage : public QuackMessage {
 public:
 	static constexpr MessageType TYPE = MessageType::CONNECTION_REQUEST;
 
-	explicit ConnectionRequestMessage(const string &auth_string_p, string client_id_p = {});
+	explicit ConnectionRequestMessage(const string &auth_string_p, string client_id_p = {},
+	                                  string remote_catalog_p = {});
 
 public:
 	const string &AuthString() const {
@@ -219,6 +220,9 @@ public:
 	}
 	const string &ClientId() const {
 		return client_id;
+	}
+	const string &RemoteCatalog() const {
+		return remote_catalog;
 	}
 	const string &ClientVersion() const {
 		return client_duckdb_version;
@@ -242,6 +246,7 @@ protected:
 private:
 	string auth_string;
 	string client_id;
+	string remote_catalog;
 	string client_duckdb_version;
 	string client_platform;
 	idx_t min_supported_quack_version;

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -149,11 +149,6 @@
         "name": "dead_range_end",
         "type": "optional_idx",
         "default": "optional_idx()"
-      },
-      {
-        "id": 10,
-        "name": "catalog_name",
-        "type": "string"
       }
     ]
   },

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -149,6 +149,11 @@
         "name": "dead_range_end",
         "type": "optional_idx",
         "default": "optional_idx()"
+      },
+      {
+        "id": 10,
+        "name": "catalog_name",
+        "type": "string"
       }
     ]
   },

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -240,6 +240,11 @@
         "id": 6,
         "name": "client_id",
         "type": "string"
+      },
+      {
+        "id": 7,
+        "name": "remote_catalog",
+        "type": "string"
       }
     ]
   },

--- a/src/include/quack_message.json
+++ b/src/include/quack_message.json
@@ -260,6 +260,11 @@
         "id": 3,
         "name": "quack_version",
         "type": "idx_t"
+      },
+      {
+        "id": 4,
+        "name": "remote_catalog",
+        "type": "string"
       }
     ]
   },

--- a/src/include/quack_scan.hpp
+++ b/src/include/quack_scan.hpp
@@ -10,19 +10,24 @@ struct QuackScanBindData : FunctionData {
 		auto &other = other_p.Cast<QuackScanBindData>();
 		return other.client_connection->ConnectionId() == client_connection->ConnectionId() &&
 		       other.client_connection->ServerURI() == client_connection->ServerURI() &&
-		       other.table_name == table_name && other.column_names == column_names &&
+		       other.table_name == table_name && other.schema_name == schema_name &&
+		       other.catalog_name == catalog_name && other.column_names == column_names &&
 		       other.column_types == column_types;
 	}
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackScanBindData>();
 		result->client_connection = client_connection;
 		result->table_name = table_name;
+		result->schema_name = schema_name;
+		result->catalog_name = catalog_name;
 		result->column_names = column_names;
 		result->column_types = column_types;
 		return std::move(result);
 	}
 
 	string table_name;
+	string schema_name;
+	string catalog_name;
 	vector<string> column_names;
 	vector<LogicalType> column_types;
 	vector<unique_ptr<DataChunkWrapper>> results;

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -113,7 +113,8 @@ public:
 	virtual void Close() {};
 
 	shared_ptr<QuackConnection> GetConnection(const string &connection_id);
-	string CreateNewConnection(const string &session_id, const string &client_id_hash = {});
+	string CreateNewConnection(const string &session_id, const string &client_id_hash, const string &remote_catalog,
+	                           ErrorData &error);
 	bool DisconnectConnection(const string &session_id);
 	// TODO need something to destroy connections
 

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -73,6 +73,8 @@ struct QuackConnection {
 	//! Current query UUID
 	hugeint_t query_uuid;
 	string session_id;
+	//! Canonical remote catalog selected during the handshake. Empty for an unpinned connection.
+	string remote_catalog;
 
 	//! Stable per-client reconnect key: HMAC-SHA256(server_hmac_key, client_id). Intentionally excludes
 	//! session_id so it stays identical across (re)connections for the same client_id. Empty if no client_id.
@@ -89,6 +91,7 @@ struct QuackConnectionSnapshot {
 	string server_id;
 	string session_id;
 	string client_id_hash;
+	string remote_catalog;
 	string sql_query;
 	QuackQueryState query_state = QuackQueryState::IDLE;
 	timestamp_t query_started_at {0};

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -21,7 +21,7 @@ class QuackClientConnection;
 class QuackCatalog : public Catalog {
 public:
 	explicit QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p, ClientContext &context,
-	                      const string &token, string client_id = {});
+	                      const string &token, string client_id = {}, string remote_catalog = {});
 	~QuackCatalog() override;
 
 public:
@@ -75,6 +75,7 @@ public:
 	unique_ptr<ColumnDataCollection> ExecuteCommandInternal(ClientContext &context, const string &query);
 	const QuackUri &GetServerUri();
 	const string &GetConnectionId();
+	const string &GetRemoteCatalog() const;
 
 	shared_ptr<QuackClientConnection> GetClientConnection();
 
@@ -87,6 +88,7 @@ private:
 
 private:
 	shared_ptr<QuackClientConnection> client_connection;
+	string remote_catalog;
 	unique_ptr<QuackSchemaSet> schemas;
 };
 

--- a/src/include/storage/quack_schema.hpp
+++ b/src/include/storage/quack_schema.hpp
@@ -22,7 +22,7 @@ class QuackSchemaSet : public QuackCatalogSet {
 public:
 	QuackSchemaSet(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data);
 
-	static string GetLoadQuery();
+	static string GetLoadQuery(const string &remote_catalog);
 
 	void Reload(ClientContext &context, QuackCatalog &catalog, const QuackLoadCatalogData &load_data);
 };

--- a/src/include/storage/quack_table.hpp
+++ b/src/include/storage/quack_table.hpp
@@ -20,7 +20,7 @@ public:
 	QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &parent, const QuackLoadCatalogData &load_data);
 	explicit QuackTableSet(QuackSchemaCatalogEntry &parent);
 
-	static string GetLoadQuery();
+	static string GetLoadQuery(const string &remote_catalog);
 
 private:
 	QuackSchemaCatalogEntry &schema;

--- a/src/include/storage/quack_view.hpp
+++ b/src/include/storage/quack_view.hpp
@@ -23,7 +23,7 @@ public:
 	//! This SQL will always be "FROM {catalog}.query('FROM {view_name}');"
 	//! Ensuring the view is executed remotely
 	static string CreateViewSQL(const string &catalog_name, const string &schema_name, const string &view_name,
-	                            const string &remote_catalog = string());
+	                            const string &server_catalog = string());
 };
 
 } // namespace duckdb

--- a/src/include/storage/quack_view.hpp
+++ b/src/include/storage/quack_view.hpp
@@ -22,7 +22,8 @@ public:
 	//! Generate SQL for querying a view from quack
 	//! This SQL will always be "FROM {catalog}.query('FROM {view_name}');"
 	//! Ensuring the view is executed remotely
-	static string CreateViewSQL(const string &catalog_name, const string &schema_name, const string &view_name);
+	static string CreateViewSQL(const string &catalog_name, const string &schema_name, const string &view_name,
+	                            const string &remote_catalog = string());
 };
 
 } // namespace duckdb

--- a/src/quack_active_connections.cpp
+++ b/src/quack_active_connections.cpp
@@ -30,7 +30,7 @@ struct QuackActiveConnectionsData : FunctionData {
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<QuackActiveConnectionsData>();
 		result->finished = finished;
-		return result;
+		return std::move(result);
 	}
 	bool Equals(const FunctionData &) const override {
 		return false;
@@ -39,9 +39,10 @@ struct QuackActiveConnectionsData : FunctionData {
 
 static unique_ptr<FunctionData> QuackActiveConnectionsBind(ClientContext &, TableFunctionBindInput &,
                                                            vector<LogicalType> &return_types, vector<string> &names) {
-	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::TIMESTAMP};
-	names = {"server_id", "connection_id", "query", "state", "client_id_hash", "query_started_at"};
+	names = {"server_id", "connection_id", "query", "state", "client_id_hash", "remote_catalog",
+	         "query_started_at"};
 	return make_uniq<QuackActiveConnectionsData>();
 }
 
@@ -60,10 +61,11 @@ static void QuackActiveConnectionsScan(ClientContext &context, TableFunctionInpu
 		output.SetValue(2, row, snap.sql_query);
 		output.SetValue(3, row, Value(QueryStateToString(snap.query_state)));
 		output.SetValue(4, row, snap.client_id_hash.empty() ? Value(LogicalType::VARCHAR) : Value(snap.client_id_hash));
+		output.SetValue(5, row, snap.remote_catalog.empty() ? Value(LogicalType::VARCHAR) : Value(snap.remote_catalog));
 		if (snap.query_state == QuackQueryState::IDLE) {
-			output.SetValue(5, row, Value(LogicalType::TIMESTAMP));
+			output.SetValue(6, row, Value(LogicalType::TIMESTAMP));
 		} else {
-			output.SetValue(5, row, Value::TIMESTAMP(snap.query_started_at));
+			output.SetValue(6, row, Value::TIMESTAMP(snap.query_started_at));
 		}
 		row++;
 	}

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -204,7 +204,7 @@ string QuackClient::ResolveClientId(ClientContext &context, optional_ptr<const V
 }
 
 shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &context, const QuackUri &uri,
-                                                               string token, string client_id) {
+                                                               string token, string client_id, string remote_catalog) {
 	// Single choke point for every connection path (ATTACH + quack_query), so a malformed client_id is
 	// rejected here regardless of where it came from.
 	ValidateClientId(client_id);
@@ -227,7 +227,7 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 
 	// submit the connection request
 	auto connection_request_response = client->Request<ConnectionResponseMessage>(
-	    context, make_uniq<ConnectionRequestMessage>(token, std::move(client_id)));
+	    context, make_uniq<ConnectionRequestMessage>(token, std::move(client_id), std::move(remote_catalog)));
 	// Validate the server's selected protocol version before trusting the connection (client speaks QUACK_VERSION).
 	if (connection_request_response->QuackVersion() != QUACK_VERSION) {
 		throw IOException("Incompatible Quack protocol version: server uses %llu, client supports %llu",

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -161,9 +161,9 @@ unique_ptr<QuackClient> QuackClient::GetClient(ClientContext &context, const Qua
 }
 
 QuackClientConnection::QuackClientConnection(unique_ptr<QuackClient> client_p, QuackUri uri_p, string connection_id_p,
-                                             idx_t max_connections_cached_p)
+                                             idx_t max_connections_cached_p, string remote_catalog_p)
     : uri(std::move(uri_p)), connection_id(std::move(connection_id_p)),
-      max_connections_cached(max_connections_cached_p) {
+      remote_catalog(std::move(remote_catalog_p)), max_connections_cached(max_connections_cached_p) {
 	if (client_p) {
 		StoreClient(std::move(client_p));
 	}
@@ -238,7 +238,8 @@ shared_ptr<QuackClientConnection> QuackClient::ConnectToServer(ClientContext &co
 	// Cache at most one client per async send slot: pending SEND_DATA tasks can check out far more
 	// clients than ever POST concurrently, and each cached client pins a server connection slot.
 	idx_t pool_size = MaxValue<idx_t>(1, (idx_t)TaskScheduler::GetScheduler(context).NumberOfAsyncThreads());
-	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id), pool_size);
+	return make_shared_ptr<QuackClientConnection>(std::move(client), uri, std::move(connection_id), pool_size,
+	                                              connection_request_response->RemoteCatalog());
 }
 
 unique_ptr<QuackClientWrapper> QuackClientConnection::GetClient(ClientContext &context) const {

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -183,9 +183,9 @@ ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p, 
       max_supported_quack_version(QUACK_VERSION) {
 }
 
-ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p)
+ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p, string remote_catalog_p)
     : QuackMessage(TYPE, std::move(connection_id_p)), server_duckdb_version(DuckDB::LibraryVersion()),
-      server_platform(DuckDB::Platform()), quack_version(QUACK_VERSION) {
+      server_platform(DuckDB::Platform()), quack_version(QUACK_VERSION), remote_catalog(std::move(remote_catalog_p)) {
 }
 
 unique_ptr<QuackMessage> QuackMessage::FromMemoryStream(MemoryStream &read_stream) {

--- a/src/quack_message.cpp
+++ b/src/quack_message.cpp
@@ -175,10 +175,12 @@ unique_ptr<QuackMessage> QuackMessage::DeserializeMessage(BinaryDeserializer &de
 	return result;
 }
 
-ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p, string client_id_p)
+ConnectionRequestMessage::ConnectionRequestMessage(const string &auth_string_p, string client_id_p,
+                                                   string remote_catalog_p)
     : QuackMessage(TYPE), auth_string(auth_string_p), client_id(std::move(client_id_p)),
-      client_duckdb_version(DuckDB::LibraryVersion()), client_platform(DuckDB::Platform()),
-      min_supported_quack_version(QUACK_VERSION), max_supported_quack_version(QUACK_VERSION) {
+      remote_catalog(std::move(remote_catalog_p)), client_duckdb_version(DuckDB::LibraryVersion()),
+      client_platform(DuckDB::Platform()), min_supported_quack_version(QUACK_VERSION),
+      max_supported_quack_version(QUACK_VERSION) {
 }
 
 ConnectionResponseMessage::ConnectionResponseMessage(string connection_id_p)

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -219,10 +219,10 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 	// 		query = "SELECT " + StringUtil::Join(selected_columns, ", ") + " ";
 	// 	}
 	// }
-	auto table_name = StringUtil::Format("%s", SQLIdentifier(bind_data.table_name));
+	auto table_name =
+	    StringUtil::Format("%s.%s", SQLIdentifier(bind_data.schema_name), SQLIdentifier(bind_data.table_name));
 	if (!bind_data.catalog_name.empty()) {
-		table_name = StringUtil::Format("%s.%s.%s", SQLIdentifier(bind_data.catalog_name),
-		                                SQLIdentifier(bind_data.schema_name), table_name);
+		table_name = StringUtil::Format("%s.%s", SQLIdentifier(bind_data.catalog_name), table_name);
 	}
 	query += StringUtil::Format("FROM %s", table_name);
 	//

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -219,7 +219,12 @@ static string BuildPushdownQuery(const QuackScanBindData &bind_data, const Table
 	// 		query = "SELECT " + StringUtil::Join(selected_columns, ", ") + " ";
 	// 	}
 	// }
-	query += StringUtil::Format("FROM %s", SQLIdentifier(bind_data.table_name));
+	auto table_name = StringUtil::Format("%s", SQLIdentifier(bind_data.table_name));
+	if (!bind_data.catalog_name.empty()) {
+		table_name = StringUtil::Format("%s.%s.%s", SQLIdentifier(bind_data.catalog_name),
+		                                SQLIdentifier(bind_data.schema_name), table_name);
+	}
+	query += StringUtil::Format("FROM %s", table_name);
 	//
 	// // Filters: build WHERE clause from pushable filters
 	// if (input.filters) {

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -178,11 +178,8 @@ shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_
 	return nullptr;
 }
 
-string QuackServer::CreateNewConnection(const string &session_id, const string &client_id_hash) {
-	std::lock_guard<std::mutex> lock(active_connections_mutex);
-
-	D_ASSERT(active_connections.find(session_id) == active_connections.end());
-
+string QuackServer::CreateNewConnection(const string &session_id, const string &client_id_hash,
+                                        const string &remote_catalog, ErrorData &error) {
 	auto db = db_ptr.lock();
 	if (!db) {
 		throw InternalException("Database was closed");
@@ -191,8 +188,22 @@ string QuackServer::CreateNewConnection(const string &session_id, const string &
 	new_connection->client_id_hash = client_id_hash;
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
+	if (!remote_catalog.empty()) {
+		auto result = new_connection->duckdb_connection->Query("USE " + SQLIdentifier(remote_catalog));
+		if (result->HasError()) {
+			auto use_error = result->GetErrorObject();
+			error = ErrorData(use_error.Type(), StringUtil::Format("Failed to select remote catalog \"%s\": %s",
+			                                                       remote_catalog, use_error.RawMessage()));
+			return string();
+		}
+	}
 	// new_connection->duckdb_connection->context->config.streaming_buffer_size = 10 * 1000000; // 10 MB
-	active_connections[session_id] = std::move(new_connection);
+	std::lock_guard<std::mutex> lock(active_connections_mutex);
+	auto inserted = active_connections.emplace(session_id, std::move(new_connection));
+	if (!inserted.second) {
+		error = ErrorData(ExceptionType::INTERNAL, "Generated a duplicate Quack connection id");
+		return string();
+	}
 	return session_id;
 }
 
@@ -429,7 +440,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		if (!connection_request_message.ClientId().empty()) {
 			client_id_hash = ComputeClientHash(server_hmac_key, connection_request_message.ClientId());
 		}
-		return make_uniq<ConnectionResponseMessage>(CreateNewConnection(session_id, client_id_hash));
+		ErrorData connection_error;
+		auto connection_id = CreateNewConnection(session_id, client_id_hash, connection_request_message.RemoteCatalog(),
+		                                         connection_error);
+		if (connection_id.empty()) {
+			return make_uniq<ErrorResponse>(std::move(connection_error));
+		}
+		return make_uniq<ConnectionResponseMessage>(std::move(connection_id));
 	}
 	case MessageType::DISCONNECT_MESSAGE: {
 		auto &connection = *connection_p;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -106,11 +106,15 @@ QuackConnection::~QuackConnection() {
 //! Background thread: runs the INSERT that drains `stream` via scan_data_from_quack_client, holding
 //! the connection lock for the statement's duration (one transactional statement -> atomic).
 static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackDataStream> stream, string stream_id,
-                               string schema_name, string table_name) {
+                               string catalog_name, string schema_name, string table_name) {
 	try {
 		unique_lock<mutex> lock(connection.lock);
-		auto sql = StringUtil::Format("INSERT INTO %s.%s SELECT * FROM scan_data_from_quack_client(%s)",
-		                              SQLIdentifier(schema_name), SQLIdentifier(table_name), SQLString(stream_id));
+		auto target = StringUtil::Format("%s.%s", SQLIdentifier(schema_name), SQLIdentifier(table_name));
+		if (!catalog_name.empty()) {
+			target = StringUtil::Format("%s.%s", SQLIdentifier(catalog_name), target);
+		}
+		auto sql = StringUtil::Format("INSERT INTO %s SELECT * FROM scan_data_from_quack_client(%s)", target,
+		                              SQLString(stream_id));
 		auto result = connection.duckdb_connection->Query(sql);
 		if (result->HasError()) {
 			stream->SetError(result->GetErrorObject());
@@ -549,9 +553,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 
 		// we never execute this query, but throw it at the authorization function so it can check if this user gets to
 		// insert into this table
-		auto dummy_insert_query =
-		    StringUtil::Format("INSERT INTO %s.%s VALUES (NULL)", SQLIdentifier(send_data_message.SchemaName()),
-		                       SQLIdentifier(send_data_message.TableName()));
+		auto table_name = StringUtil::Format("%s.%s", SQLIdentifier(send_data_message.SchemaName()),
+		                                     SQLIdentifier(send_data_message.TableName()));
+		if (!send_data_message.CatalogName().empty()) {
+			table_name = StringUtil::Format("%s.%s", SQLIdentifier(send_data_message.CatalogName()), table_name);
+		}
+		auto dummy_insert_query = StringUtil::Format("INSERT INTO %s VALUES (NULL)", table_name);
 
 		// TODO do not do this if there is no fun set
 		{
@@ -597,7 +604,8 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				connection.insert.stream = stream;
 				connection.insert.stream_id = stream_id;
 				connection.insert.thread = std::thread(RunInsertStatement, std::ref(connection), stream, stream_id,
-				                                       send_data_message.SchemaName(), send_data_message.TableName());
+				                                       send_data_message.CatalogName(), send_data_message.SchemaName(),
+				                                       send_data_message.TableName());
 				// Apply any dead-range markers that arrived before the stream existed.
 				if (connection.insert.pending_marker_stream_id == stream_id) {
 					buffered_dead_ranges = std::move(connection.insert.pending_dead_ranges);

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -106,13 +106,10 @@ QuackConnection::~QuackConnection() {
 //! Background thread: runs the INSERT that drains `stream` via scan_data_from_quack_client, holding
 //! the connection lock for the statement's duration (one transactional statement -> atomic).
 static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackDataStream> stream, string stream_id,
-                               string catalog_name, string schema_name, string table_name) {
+                               string schema_name, string table_name) {
 	try {
 		unique_lock<mutex> lock(connection.lock);
 		auto target = StringUtil::Format("%s.%s", SQLIdentifier(schema_name), SQLIdentifier(table_name));
-		if (!catalog_name.empty()) {
-			target = StringUtil::Format("%s.%s", SQLIdentifier(catalog_name), target);
-		}
 		auto sql = StringUtil::Format("INSERT INTO %s SELECT * FROM scan_data_from_quack_client(%s)", target,
 		                              SQLString(stream_id));
 		auto result = connection.duckdb_connection->Query(sql);
@@ -572,9 +569,6 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		// insert into this table
 		auto table_name = StringUtil::Format("%s.%s", SQLIdentifier(send_data_message.SchemaName()),
 		                                     SQLIdentifier(send_data_message.TableName()));
-		if (!send_data_message.CatalogName().empty()) {
-			table_name = StringUtil::Format("%s.%s", SQLIdentifier(send_data_message.CatalogName()), table_name);
-		}
 		auto dummy_insert_query = StringUtil::Format("INSERT INTO %s VALUES (NULL)", table_name);
 
 		// TODO do not do this if there is no fun set
@@ -621,8 +615,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				connection.insert.stream = stream;
 				connection.insert.stream_id = stream_id;
 				connection.insert.thread = std::thread(RunInsertStatement, std::ref(connection), stream, stream_id,
-				                                       send_data_message.CatalogName(), send_data_message.SchemaName(),
-				                                       send_data_message.TableName());
+				                                       send_data_message.SchemaName(), send_data_message.TableName());
 				// Apply any dead-range markers that arrived before the stream existed.
 				if (connection.insert.pending_marker_stream_id == stream_id) {
 					buffered_dead_ranges = std::move(connection.insert.pending_dead_ranges);

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -3,8 +3,12 @@
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_data.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/catalog/catalog_search_path.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/storage/temporary_file_manager.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
@@ -103,12 +107,39 @@ QuackConnection::~QuackConnection() {
 	duckdb_query_result.reset();
 }
 
+//! Restore the connection's pinned catalog without parsing a USE statement. Looking the catalog up through
+//! DatabaseManager ensures a schema-only name cannot be mistaken for a catalog and preserves its stored casing.
+static bool RestoreRemoteCatalog(QuackConnection &connection, ErrorData &error) {
+	if (connection.remote_catalog.empty()) {
+		return true;
+	}
+	auto &context = *connection.duckdb_connection->context;
+	auto database = DatabaseManager::Get(context).GetDatabase(context, Identifier(connection.remote_catalog));
+	if (!database) {
+		error = ErrorData(ExceptionType::INVALID_INPUT,
+		                  StringUtil::Format("Failed to select remote catalog \"%s\": catalog is not attached",
+		                                     connection.remote_catalog));
+		return false;
+	}
+	connection.remote_catalog = database->GetName().GetIdentifierName();
+	ClientData::Get(context).catalog_search_path->Set(
+	    CatalogSearchEntry(database->GetName(), Identifier(database->GetCatalog().GetDefaultSchema())),
+	    CatalogSetPathType::SET_DIRECTLY);
+	return true;
+}
+
 //! Background thread: runs the INSERT that drains `stream` via scan_data_from_quack_client, holding
 //! the connection lock for the statement's duration (one transactional statement -> atomic).
 static void RunInsertStatement(QuackConnection &connection, shared_ptr<QuackDataStream> stream, string stream_id,
                                string schema_name, string table_name) {
 	try {
 		unique_lock<mutex> lock(connection.lock);
+		ErrorData catalog_error;
+		if (!RestoreRemoteCatalog(connection, catalog_error)) {
+			stream->SetError(std::move(catalog_error));
+			stream->Finish();
+			return;
+		}
 		auto target = StringUtil::Format("%s.%s", SQLIdentifier(schema_name), SQLIdentifier(table_name));
 		auto sql = StringUtil::Format("INSERT INTO %s SELECT * FROM scan_data_from_quack_client(%s)", target,
 		                              SQLString(stream_id));
@@ -158,6 +189,7 @@ vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
 		QuackConnectionSnapshot snapshot;
 		snapshot.session_id = conn->session_id;
 		snapshot.client_id_hash = conn->client_id_hash;
+		snapshot.remote_catalog = conn->remote_catalog;
 		snapshot.sql_query = conn->sql_query;
 		snapshot.query_state = conn->query_state;
 		snapshot.query_started_at = conn->query_started_at;
@@ -186,11 +218,8 @@ string QuackServer::CreateNewConnection(const string &session_id, const string &
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
 	if (!remote_catalog.empty()) {
-		auto result = new_connection->duckdb_connection->Query("USE " + SQLIdentifier(remote_catalog));
-		if (result->HasError()) {
-			auto use_error = result->GetErrorObject();
-			error = ErrorData(use_error.Type(), StringUtil::Format("Failed to select remote catalog \"%s\": %s",
-			                                                       remote_catalog, use_error.RawMessage()));
+		new_connection->remote_catalog = remote_catalog;
+		if (!RestoreRemoteCatalog(*new_connection, error)) {
 			return string();
 		}
 	}
@@ -443,7 +472,9 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		if (connection_id.empty()) {
 			return make_uniq<ErrorResponse>(std::move(connection_error));
 		}
-		return make_uniq<ConnectionResponseMessage>(std::move(connection_id));
+		auto connection = GetConnection(connection_id);
+		D_ASSERT(connection);
+		return make_uniq<ConnectionResponseMessage>(std::move(connection_id), connection->remote_catalog);
 	}
 	case MessageType::DISCONNECT_MESSAGE: {
 		auto &connection = *connection_p;
@@ -473,6 +504,12 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		unique_ptr<QueryResult> stale_result;
 		std::unique_lock<std::mutex> lock(connection.lock);
 		stale_result = std::move(connection.duckdb_query_result);
+		ErrorData catalog_error;
+		if (!RestoreRemoteCatalog(connection, catalog_error)) {
+			connection.sql_query = "";
+			connection.query_state = QuackQueryState::QUACK_ERROR;
+			return make_uniq<ErrorResponse>(std::move(catalog_error));
+		}
 		connection.sql_query = prepare_request_message.Query();
 		connection.query_state = QuackQueryState::ACTIVE;
 		connection.query_started_at = Timestamp::GetCurrentTimestamp();
@@ -484,7 +521,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				auto response = make_uniq<ErrorResponse>(query_result->GetErrorObject());
 				connection.duckdb_query_result.reset();
 				connection.query_state = QuackQueryState::CANCELLED;
-				return response;
+				return std::move(response);
 			}
 			if (query_result->names.empty()) {
 				connection.sql_query = "";

--- a/src/quack_storage.cpp
+++ b/src/quack_storage.cpp
@@ -103,7 +103,15 @@ static unique_ptr<Catalog> QuackAttach(optional_ptr<StorageExtensionInfo> storag
 	auto client_id_entry = attach_options.options.find("client_id");
 	auto client_id = QuackClient::ResolveClientId(
 	    context, client_id_entry != attach_options.options.end() ? &client_id_entry->second : nullptr);
-	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token, std::move(client_id));
+	string remote_catalog;
+	if (attach_options.options.find("remote_catalog") != attach_options.options.end()) {
+		remote_catalog = attach_options.options["remote_catalog"].GetValue<string>();
+		if (remote_catalog.empty()) {
+			throw InvalidInputException("REMOTE_CATALOG cannot be empty");
+		}
+	}
+	return make_uniq<QuackCatalog>(db, QuackUri(uri, enable_ssl), context, token, std::move(client_id),
+	                               std::move(remote_catalog));
 }
 
 static unique_ptr<TransactionManager> QuackCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -163,7 +163,6 @@ void SendDataRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(7, "is_last_in_batch", is_last_in_batch);
 	serializer.WritePropertyWithDefault<optional_idx>(8, "batch_watermark", batch_watermark, optional_idx());
 	serializer.WritePropertyWithDefault<optional_idx>(9, "dead_range_end", dead_range_end, optional_idx());
-	serializer.WritePropertyWithDefault<string>(10, "catalog_name", catalog_name);
 }
 
 unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -179,7 +178,6 @@ unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deseriali
 	                                                           optional_idx());
 	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(9, "dead_range_end", result->dead_range_end,
 	                                                           optional_idx());
-	deserializer.ReadPropertyWithDefault<string>(10, "catalog_name", result->catalog_name);
 	return result;
 }
 

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -45,6 +45,7 @@ void ConnectionResponseMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(1, "server_duckdb_version", server_duckdb_version);
 	serializer.WritePropertyWithDefault<string>(2, "server_platform", server_platform);
 	serializer.WritePropertyWithDefault<idx_t>(3, "quack_version", quack_version);
+	serializer.WritePropertyWithDefault<string>(4, "remote_catalog", remote_catalog);
 }
 
 unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Deserializer &deserializer) {
@@ -52,6 +53,7 @@ unique_ptr<ConnectionResponseMessage> ConnectionResponseMessage::Deserialize(Des
 	deserializer.ReadPropertyWithDefault<string>(1, "server_duckdb_version", result->server_duckdb_version);
 	deserializer.ReadPropertyWithDefault<string>(2, "server_platform", result->server_platform);
 	deserializer.ReadPropertyWithDefault<idx_t>(3, "quack_version", result->quack_version);
+	deserializer.ReadPropertyWithDefault<string>(4, "remote_catalog", result->remote_catalog);
 	return result;
 }
 

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -161,6 +161,7 @@ void SendDataRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(7, "is_last_in_batch", is_last_in_batch);
 	serializer.WritePropertyWithDefault<optional_idx>(8, "batch_watermark", batch_watermark, optional_idx());
 	serializer.WritePropertyWithDefault<optional_idx>(9, "dead_range_end", dead_range_end, optional_idx());
+	serializer.WritePropertyWithDefault<string>(10, "catalog_name", catalog_name);
 }
 
 unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -176,6 +177,7 @@ unique_ptr<SendDataRequestMessage> SendDataRequestMessage::Deserialize(Deseriali
 	                                                           optional_idx());
 	deserializer.ReadPropertyWithExplicitDefault<optional_idx>(9, "dead_range_end", result->dead_range_end,
 	                                                           optional_idx());
+	deserializer.ReadPropertyWithDefault<string>(10, "catalog_name", result->catalog_name);
 	return result;
 }
 

--- a/src/serialize_quack_message.cpp
+++ b/src/serialize_quack_message.cpp
@@ -26,6 +26,7 @@ void ConnectionRequestMessage::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<idx_t>(4, "min_supported_quack_version", min_supported_quack_version);
 	serializer.WritePropertyWithDefault<idx_t>(5, "max_supported_quack_version", max_supported_quack_version);
 	serializer.WritePropertyWithDefault<string>(6, "client_id", client_id);
+	serializer.WritePropertyWithDefault<string>(7, "remote_catalog", remote_catalog);
 }
 
 unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deserializer &deserializer) {
@@ -36,6 +37,7 @@ unique_ptr<ConnectionRequestMessage> ConnectionRequestMessage::Deserialize(Deser
 	deserializer.ReadPropertyWithDefault<idx_t>(4, "min_supported_quack_version", result->min_supported_quack_version);
 	deserializer.ReadPropertyWithDefault<idx_t>(5, "max_supported_quack_version", result->max_supported_quack_version);
 	deserializer.ReadPropertyWithDefault<string>(6, "client_id", result->client_id);
+	deserializer.ReadPropertyWithDefault<string>(7, "remote_catalog", result->remote_catalog);
 	return result;
 }
 

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -29,7 +29,7 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
                            const string &token, string client_id, string remote_catalog_p)
     : Catalog(db_p), remote_catalog(std::move(remote_catalog_p)) {
 	// connect to the server
-	client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id));
+	client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id), remote_catalog);
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -126,7 +126,13 @@ const string &QuackCatalog::GetRemoteCatalog() const {
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	// create schema remotely
-	quack_transaction.Query(info.ToString());
+	if (remote_catalog.empty()) {
+		quack_transaction.Query(info.ToString());
+	} else {
+		auto remote_info = info.Copy();
+		remote_info->SetCatalog(Identifier(remote_catalog));
+		quack_transaction.Query(remote_info->ToString());
+	}
 	// register schema locally
 	auto schema_entry = make_uniq<QuackSchemaCatalogEntry>(*this, info);
 	return schemas->CreateEntry(std::move(schema_entry), info.on_conflict);

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -39,9 +39,6 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
 QuackLoadCatalogData QuackCatalog::LoadCatalog(ClientContext &context) {
 	QuackLoadCatalogData result;
 	result.schemas = ExecuteCommandInternal(context, QuackSchemaSet::GetLoadQuery(remote_catalog));
-	if (!remote_catalog.empty() && result.schemas->Count() == 0) {
-		throw BinderException("Remote catalog \"%s\" not found", remote_catalog);
-	}
 	result.tables = ExecuteCommandInternal(context, QuackTableSet::GetLoadQuery(remote_catalog));
 	return result;
 }
@@ -127,7 +124,7 @@ optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transac
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	auto remote_info = info.Copy();
 	if (!remote_catalog.empty()) {
-		remote_info->SetCatalog(Identifier(remote_catalog));
+		remote_info->SetCatalog(Identifier());
 	}
 	// create schema remotely
 	quack_transaction.Query(remote_info->ToString());
@@ -189,9 +186,6 @@ void QuackCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 }
 
 bool QuackCatalog::SupportsPushdown(const TableRef &ref) {
-	if (!remote_catalog.empty()) {
-		return false;
-	}
 	if (ref.type != TableReferenceType::TABLE_FUNCTION) {
 		return true;
 	}

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -125,14 +125,12 @@ const string &QuackCatalog::GetRemoteCatalog() const {
 
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
 	auto &quack_transaction = QuackTransaction::Get(transaction);
-	// create schema remotely
-	if (remote_catalog.empty()) {
-		quack_transaction.Query(info.ToString());
-	} else {
-		auto remote_info = info.Copy();
+	auto remote_info = info.Copy();
+	if (!remote_catalog.empty()) {
 		remote_info->SetCatalog(Identifier(remote_catalog));
-		quack_transaction.Query(remote_info->ToString());
 	}
+	// create schema remotely
+	quack_transaction.Query(remote_info->ToString());
 	// register schema locally
 	auto schema_entry = make_uniq<QuackSchemaCatalogEntry>(*this, info);
 	return schemas->CreateEntry(std::move(schema_entry), info.on_conflict);

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -26,8 +26,8 @@
 namespace duckdb {
 
 QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, ClientContext &context,
-                           const string &token, string client_id)
-    : Catalog(db_p) {
+                           const string &token, string client_id, string remote_catalog_p)
+    : Catalog(db_p), remote_catalog(std::move(remote_catalog_p)) {
 	// connect to the server
 	client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id));
 
@@ -38,8 +38,11 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
 
 QuackLoadCatalogData QuackCatalog::LoadCatalog(ClientContext &context) {
 	QuackLoadCatalogData result;
-	result.schemas = ExecuteCommandInternal(context, QuackSchemaSet::GetLoadQuery());
-	result.tables = ExecuteCommandInternal(context, QuackTableSet::GetLoadQuery());
+	result.schemas = ExecuteCommandInternal(context, QuackSchemaSet::GetLoadQuery(remote_catalog));
+	if (!remote_catalog.empty() && result.schemas->Count() == 0) {
+		throw BinderException("Remote catalog \"%s\" not found", remote_catalog);
+	}
+	result.tables = ExecuteCommandInternal(context, QuackTableSet::GetLoadQuery(remote_catalog));
 	return result;
 }
 
@@ -116,6 +119,10 @@ QuackCatalog &QuackCatalog::GetQuackCatalog(ClientContext &context, Value &catal
 	return catalog.Cast<QuackCatalog>();
 }
 
+const string &QuackCatalog::GetRemoteCatalog() const {
+	return remote_catalog;
+}
+
 optional_ptr<CatalogEntry> QuackCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	// create schema remotely
@@ -178,6 +185,9 @@ void QuackCatalog::DropSchema(ClientContext &context, DropInfo &info) {
 }
 
 bool QuackCatalog::SupportsPushdown(const TableRef &ref) {
+	if (!remote_catalog.empty()) {
+		return false;
+	}
 	if (ref.type != TableReferenceType::TABLE_FUNCTION) {
 		return true;
 	}

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -30,6 +30,9 @@ QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, C
     : Catalog(db_p), remote_catalog(std::move(remote_catalog_p)) {
 	// connect to the server
 	client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id), remote_catalog);
+	// The server resolves identifiers case-insensitively and returns the stored spelling. Use that canonical
+	// value for system-catalog discovery, whose result strings retain their original case.
+	remote_catalog = client_connection->RemoteCatalog();
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -177,9 +177,9 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 		wrappers.push_back(make_uniq<DataChunkWrapper>(*chunk));
 	}
 
-	auto send_msg =
-	    make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name.GetIdentifierName(),
-	                                      tbl.name.GetIdentifierName(), std::move(wrappers), gstate.query_uuid);
+	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), quack_catalog.GetRemoteCatalog(),
+	                                                  tbl.schema.name.GetIdentifierName(), tbl.name.GetIdentifierName(),
+	                                                  std::move(wrappers), gstate.query_uuid);
 
 	switch (insert.order_mode) {
 	case AppendOrderMode::PARALLEL_ORDERED: {
@@ -222,7 +222,7 @@ static void SendDeadRange(ClientContext &context, QuackInsertGlobalState &gstate
 	auto &tbl = gstate.table;
 	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
 
-	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(),
+	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), quack_catalog.GetRemoteCatalog(),
 	                                                  tbl.schema.name.GetIdentifierName(), tbl.name.GetIdentifierName(),
 	                                                  vector<unique_ptr<DataChunkWrapper>>(), gstate.query_uuid);
 	send_msg->SetDeadRange(lo, hi);

--- a/src/storage/quack_insert.cpp
+++ b/src/storage/quack_insert.cpp
@@ -177,9 +177,9 @@ static void SendChunks(ClientContext &context, const QuackInsert &insert, QuackI
 		wrappers.push_back(make_uniq<DataChunkWrapper>(*chunk));
 	}
 
-	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), quack_catalog.GetRemoteCatalog(),
-	                                                  tbl.schema.name.GetIdentifierName(), tbl.name.GetIdentifierName(),
-	                                                  std::move(wrappers), gstate.query_uuid);
+	auto send_msg =
+	    make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), tbl.schema.name.GetIdentifierName(),
+	                                      tbl.name.GetIdentifierName(), std::move(wrappers), gstate.query_uuid);
 
 	switch (insert.order_mode) {
 	case AppendOrderMode::PARALLEL_ORDERED: {
@@ -222,7 +222,7 @@ static void SendDeadRange(ClientContext &context, QuackInsertGlobalState &gstate
 	auto &tbl = gstate.table;
 	auto &quack_catalog = tbl.catalog.Cast<QuackCatalog>();
 
-	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(), quack_catalog.GetRemoteCatalog(),
+	auto send_msg = make_uniq<SendDataRequestMessage>(quack_catalog.GetConnectionId(),
 	                                                  tbl.schema.name.GetIdentifierName(), tbl.name.GetIdentifierName(),
 	                                                  vector<unique_ptr<DataChunkWrapper>>(), gstate.query_uuid);
 	send_msg->SetDeadRange(lo, hi);

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -28,13 +28,16 @@ void QuackSchemaSet::Reload(ClientContext &context, QuackCatalog &catalog, const
 	}
 }
 
-string QuackSchemaSet::GetLoadQuery() {
-	return R"(
+string QuackSchemaSet::GetLoadQuery(const string &remote_catalog) {
+	return StringUtil::Format(R"(
 SELECT catalog_name, schema_name
 FROM information_schema.schemata
-WHERE catalog_name NOT IN ('system', 'temp')
+WHERE %s
 ORDER BY ALL
-	)";
+	)",
+	                          remote_catalog.empty()
+	                              ? "catalog_name NOT IN ('system', 'temp')"
+	                              : StringUtil::Format("catalog_name = %s", SQLString(remote_catalog)));
 }
 
 QuackSchemaCatalogEntry::QuackSchemaCatalogEntry(Catalog &catalog_p, CreateSchemaInfo &info_p)
@@ -87,7 +90,10 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransacti
                                                                 BoundCreateTableInfo &info) {
 	auto create_table_info = info.Base().Copy();
 	auto schema_info = GetInfo();
-	create_table_info->SetCatalog(schema_info->GetQualifiedName().Catalog());
+	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
+	create_table_info->SetCatalog(quack_catalog.GetRemoteCatalog().empty()
+	                                  ? schema_info->GetQualifiedName().Catalog()
+	                                  : Identifier(quack_catalog.GetRemoteCatalog()));
 	create_table_info->SetSchema(schema_info->GetQualifiedName().Schema());
 
 	auto &quack_transaction = QuackTransaction::Get(transaction);
@@ -99,7 +105,10 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransacti
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
 	auto create_view_info = info.Copy();
 	auto schema_info = GetInfo();
-	create_view_info->SetCatalog(schema_info->GetQualifiedName().Catalog());
+	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
+	create_view_info->SetCatalog(quack_catalog.GetRemoteCatalog().empty()
+	                                 ? schema_info->GetQualifiedName().Catalog()
+	                                 : Identifier(quack_catalog.GetRemoteCatalog()));
 	create_view_info->SetSchema(schema_info->GetQualifiedName().Schema());
 
 	// create the view verbatim in the serer
@@ -108,7 +117,8 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransactio
 
 	// locally, override the query with a remote procedure call to ensure the view is evaluated remotely
 	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName().GetIdentifierName(),
-	                                                name.GetIdentifierName(), info.GetViewName().GetIdentifierName());
+	                                                name.GetIdentifierName(), info.GetViewName().GetIdentifierName(),
+	                                                ParentCatalog().Cast<QuackCatalog>().GetRemoteCatalog());
 	info.query = CreateViewInfo::ParseSelect(info.sql);
 
 	auto quack_entry = make_uniq<QuackViewCatalogEntry>(catalog, *this, info);

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -151,7 +151,10 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateType(CatalogTransactio
 
 void QuackSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) {
 	auto drop_info = info_p.Copy();
-	drop_info->SetCatalog(GetInfo()->GetQualifiedName().Catalog());
+	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
+	auto &remote_catalog = quack_catalog.GetRemoteCatalog();
+	drop_info->SetCatalog(remote_catalog.empty() ? GetInfo()->GetQualifiedName().Catalog()
+	                                             : Identifier(remote_catalog));
 	drop_info->SetSchema(name);
 	switch (drop_info->type) {
 	case CatalogType::TABLE_ENTRY:

--- a/src/storage/quack_schema.cpp
+++ b/src/storage/quack_schema.cpp
@@ -20,8 +20,10 @@ void QuackSchemaSet::Reload(ClientContext &context, QuackCatalog &catalog, const
 	Clear();
 	for (auto &row : load_data.schemas->Rows()) {
 		CreateSchemaInfo info;
-		info.SetQualifiedName(QualifiedName(Identifier(row.GetValue(0).GetValue<string>()),
-		                                    Identifier(row.GetValue(1).GetValue<string>()), Identifier()));
+		auto catalog_name =
+		    catalog.GetRemoteCatalog().empty() ? Identifier(row.GetValue(0).GetValue<string>()) : catalog.GetName();
+		info.SetQualifiedName(
+		    QualifiedName(std::move(catalog_name), Identifier(row.GetValue(1).GetValue<string>()), Identifier()));
 		// TODO this will fail if there are two schemas with the same name in different catalogs :/
 		auto schema = make_uniq<QuackSchemaCatalogEntry>(context, catalog, info, load_data);
 		CreateEntry(std::move(schema), OnCreateConflict::REPLACE_ON_CONFLICT);
@@ -91,24 +93,25 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateTable(CatalogTransacti
 	auto create_table_info = info.Base().Copy();
 	auto schema_info = GetInfo();
 	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
-	create_table_info->SetCatalog(quack_catalog.GetRemoteCatalog().empty()
-	                                  ? schema_info->GetQualifiedName().Catalog()
-	                                  : Identifier(quack_catalog.GetRemoteCatalog()));
+	create_table_info->SetCatalog(quack_catalog.GetRemoteCatalog().empty() ? schema_info->GetQualifiedName().Catalog()
+	                                                                       : Identifier());
 	create_table_info->SetSchema(schema_info->GetQualifiedName().Schema());
 
 	auto &quack_transaction = QuackTransaction::Get(transaction);
 	quack_transaction.Query(create_table_info->ToString());
-	auto quack_entry = make_uniq<QuackTableCatalogEntry>(catalog, *this, create_table_info->Cast<CreateTableInfo>());
+	auto local_info = info.Base().Copy();
+	auto quack_entry = make_uniq<QuackTableCatalogEntry>(catalog, *this, local_info->Cast<CreateTableInfo>());
 	return tables->CreateEntry(std::move(quack_entry), info.Base().on_conflict);
 }
 
 optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
+	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
+	if (!quack_catalog.GetRemoteCatalog().empty()) {
+		throw NotImplementedException("CREATE VIEW is not supported with REMOTE_CATALOG");
+	}
 	auto create_view_info = info.Copy();
 	auto schema_info = GetInfo();
-	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
-	create_view_info->SetCatalog(quack_catalog.GetRemoteCatalog().empty()
-	                                 ? schema_info->GetQualifiedName().Catalog()
-	                                 : Identifier(quack_catalog.GetRemoteCatalog()));
+	create_view_info->SetCatalog(schema_info->GetQualifiedName().Catalog());
 	create_view_info->SetSchema(schema_info->GetQualifiedName().Schema());
 
 	// create the view verbatim in the serer
@@ -118,7 +121,7 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateView(CatalogTransactio
 	// locally, override the query with a remote procedure call to ensure the view is evaluated remotely
 	info.sql = QuackViewCatalogEntry::CreateViewSQL(ParentCatalog().GetName().GetIdentifierName(),
 	                                                name.GetIdentifierName(), info.GetViewName().GetIdentifierName(),
-	                                                ParentCatalog().Cast<QuackCatalog>().GetRemoteCatalog());
+	                                                schema_info->GetQualifiedName().Catalog().GetIdentifierName());
 	info.query = CreateViewInfo::ParseSelect(info.sql);
 
 	auto quack_entry = make_uniq<QuackViewCatalogEntry>(catalog, *this, info);
@@ -152,9 +155,8 @@ optional_ptr<CatalogEntry> QuackSchemaCatalogEntry::CreateType(CatalogTransactio
 void QuackSchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo &info_p) {
 	auto drop_info = info_p.Copy();
 	auto &quack_catalog = ParentCatalog().Cast<QuackCatalog>();
-	auto &remote_catalog = quack_catalog.GetRemoteCatalog();
-	drop_info->SetCatalog(remote_catalog.empty() ? GetInfo()->GetQualifiedName().Catalog()
-	                                             : Identifier(remote_catalog));
+	drop_info->SetCatalog(quack_catalog.GetRemoteCatalog().empty() ? GetInfo()->GetQualifiedName().Catalog()
+	                                                               : Identifier());
 	drop_info->SetSchema(name);
 	switch (drop_info->type) {
 	case CatalogType::TABLE_ENTRY:

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -51,7 +51,8 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			// query
 			CreateViewInfo info(schema, Identifier(view_name));
 			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName().GetIdentifierName(),
-			                                                schema.name.GetIdentifierName(), view_name);
+			                                                schema.name.GetIdentifierName(), view_name,
+			                                                catalog.GetRemoteCatalog());
 			info.query = CreateViewInfo::ParseSelect(info.sql);
 
 			// bind to resolve the types
@@ -66,14 +67,19 @@ QuackTableSet::QuackTableSet(QuackSchemaCatalogEntry &parent)
     : QuackCatalogSet(parent.ParentCatalog().Cast<QuackCatalog>()), schema(parent) {
 }
 
-string QuackTableSet::GetLoadQuery() {
-	return R"(
+string QuackTableSet::GetLoadQuery(const string &remote_catalog) {
+	auto filter =
+	    remote_catalog.empty() ? string() : StringUtil::Format("\nWHERE database_name = %s", SQLString(remote_catalog));
+	return StringUtil::Format(R"(
 SELECT schema_name, sql, 'table'
 FROM duckdb_tables()
+%s
 UNION ALL
 SELECT schema_name, view_name, 'view'
 FROM duckdb_views()
-	)";
+%s
+	)",
+	                          filter, filter);
 }
 
 TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data_p) {
@@ -81,6 +87,8 @@ TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, un
 	auto bind_data = make_uniq<QuackScanBindData>();
 	bind_data->client_connection = quack_catalog.GetClientConnection();
 	bind_data->table_name = name.GetIdentifierName();
+	bind_data->schema_name = schema.name.GetIdentifierName();
+	bind_data->catalog_name = quack_catalog.GetRemoteCatalog();
 	for (auto &col : GetColumns().Physical()) {
 		bind_data->column_names.emplace_back(col.Name());
 		bind_data->column_types.push_back(col.Type());

--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -39,6 +39,10 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			if (info->type != CatalogType::TABLE_ENTRY) {
 				throw InternalException("Expected a CREATE TABLE");
 			}
+			if (!catalog.GetRemoteCatalog().empty()) {
+				info->SetCatalog(catalog.GetName());
+				info->SetSchema(schema.name);
+			}
 			// bind to resolve the types
 			auto binder = Binder::CreateBinder(context);
 			auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
@@ -50,9 +54,11 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			// we don't actually care what the view contains server-side, we just treat it like an opaque object we can
 			// query
 			CreateViewInfo info(schema, Identifier(view_name));
+			auto server_catalog = catalog.GetRemoteCatalog().empty()
+			                          ? schema.GetInfo()->GetQualifiedName().Catalog().GetIdentifierName()
+			                          : string();
 			info.sql = QuackViewCatalogEntry::CreateViewSQL(catalog.GetName().GetIdentifierName(),
-			                                                schema.name.GetIdentifierName(), view_name,
-			                                                catalog.GetRemoteCatalog());
+			                                                schema.name.GetIdentifierName(), view_name, server_catalog);
 			info.query = CreateViewInfo::ParseSelect(info.sql);
 
 			// bind to resolve the types
@@ -88,7 +94,9 @@ TableFunction QuackTableCatalogEntry::GetScanFunction(ClientContext &context, un
 	bind_data->client_connection = quack_catalog.GetClientConnection();
 	bind_data->table_name = name.GetIdentifierName();
 	bind_data->schema_name = schema.name.GetIdentifierName();
-	bind_data->catalog_name = quack_catalog.GetRemoteCatalog();
+	if (quack_catalog.GetRemoteCatalog().empty()) {
+		bind_data->catalog_name = schema.GetInfo()->GetQualifiedName().Catalog().GetIdentifierName();
+	}
 	for (auto &col : GetColumns().Physical()) {
 		bind_data->column_names.emplace_back(col.Name());
 		bind_data->column_types.push_back(col.Type());

--- a/src/storage/quack_view.cpp
+++ b/src/storage/quack_view.cpp
@@ -8,11 +8,11 @@ QuackViewCatalogEntry::QuackViewCatalogEntry(Catalog &catalog_p, SchemaCatalogEn
 }
 
 string QuackViewCatalogEntry::CreateViewSQL(const string &catalog_name, const string &schema_name,
-                                            const string &view_name, const string &remote_catalog) {
+                                            const string &view_name, const string &server_catalog) {
 	//! This SQL will always be "FROM quack_query({catalog}, 'FROM {view_name}');"
 	auto remote_sql = StringUtil::Format("FROM %s.%s", SQLIdentifier(schema_name), SQLIdentifier(view_name));
-	if (!remote_catalog.empty()) {
-		remote_sql = StringUtil::Format("FROM %s.%s.%s", SQLIdentifier(remote_catalog), SQLIdentifier(schema_name),
+	if (!server_catalog.empty()) {
+		remote_sql = StringUtil::Format("FROM %s.%s.%s", SQLIdentifier(server_catalog), SQLIdentifier(schema_name),
 		                                SQLIdentifier(view_name));
 	}
 	return StringUtil::Format("FROM quack_query_by_name(%s, %s)", SQLString(catalog_name), SQLString(remote_sql));

--- a/src/storage/quack_view.cpp
+++ b/src/storage/quack_view.cpp
@@ -8,9 +8,13 @@ QuackViewCatalogEntry::QuackViewCatalogEntry(Catalog &catalog_p, SchemaCatalogEn
 }
 
 string QuackViewCatalogEntry::CreateViewSQL(const string &catalog_name, const string &schema_name,
-                                            const string &view_name) {
+                                            const string &view_name, const string &remote_catalog) {
 	//! This SQL will always be "FROM quack_query({catalog}, 'FROM {view_name}');"
 	auto remote_sql = StringUtil::Format("FROM %s.%s", SQLIdentifier(schema_name), SQLIdentifier(view_name));
+	if (!remote_catalog.empty()) {
+		remote_sql = StringUtil::Format("FROM %s.%s.%s", SQLIdentifier(remote_catalog), SQLIdentifier(schema_name),
+		                                SQLIdentifier(view_name));
+	}
 	return StringUtil::Format("FROM quack_query_by_name(%s, %s)", SQLString(catalog_name), SQLString(remote_sql));
 }
 

--- a/test/sql/attach_remote_catalog.test
+++ b/test/sql/attach_remote_catalog.test
@@ -61,6 +61,11 @@ from rpc_remote.shared.v1;
 ----
 46	47
 
+statement error
+create view rpc_remote.shared.created_view as from rpc_remote.shared.tbl;
+----
+CREATE VIEW is not supported with REMOTE_CATALOG
+
 statement ok
 create table rpc_remote.shared.created as select 48 as id;
 

--- a/test/sql/attach_remote_catalog.test
+++ b/test/sql/attach_remote_catalog.test
@@ -22,11 +22,25 @@ create table remote_db.shared.tbl as values(46, 47);
 statement ok quack_db:quack_server_con
 create view remote_db.shared.v1 as from remote_db.shared.tbl;
 
+statement ok quack_db:quack_server_con
+attach ':memory:' as catalog_a;
+
+statement ok quack_db:quack_server_con
+attach ':memory:' as catalog_b;
+
+statement ok quack_db:quack_server_con
+attach ':memory:' as "catalog-with-dash";
+
 statement ok
 create secret (type quack, token 'asdf')
 
 statement ok
 attach {server} as rpc_remote (remote_catalog 'remote_db')
+
+query T
+from rpc_remote.query('select current_catalog()');
+----
+remote_db
 
 statement ok
 create schema rpc_remote.new_schema;
@@ -60,7 +74,7 @@ from rpc_remote.shared.created order by id;
 49
 
 statement ok
-from rpc_remote.query('create table remote_db.shared.refreshed as select 50 as id');
+from rpc_remote.query('create table shared.refreshed as select 50 as id');
 
 statement ok
 call quack_clear_cache();
@@ -73,9 +87,51 @@ from rpc_remote.shared.refreshed;
 statement ok
 detach rpc_remote;
 
+statement ok
+attach {server} as a (remote_catalog 'catalog_a');
+
+statement ok
+attach {server} as b (remote_catalog 'catalog_b');
+
+query T
+from a.query('select current_catalog()');
+----
+catalog_a
+
+query T
+from b.query('select current_catalog()');
+----
+catalog_b
+
+query T
+from a.query('select current_catalog()');
+----
+catalog_a
+
+statement ok
+attach {server} as plain;
+
+query T
+from plain.query('select current_catalog()');
+----
+memory
+
+query T
+from a.query('select current_catalog()');
+----
+catalog_a
+
+statement ok
+attach {server} as quoted (remote_catalog 'catalog-with-dash');
+
+query T
+from quoted.query('select current_catalog()');
+----
+catalog-with-dash
+
 statement error
 attach {server} as missing (remote_catalog 'missing')
 ----
-Remote catalog "missing" not found
+Failed to select remote catalog "missing"
 
 include test/template/quack_teardown.test_template

--- a/test/sql/attach_remote_catalog.test
+++ b/test/sql/attach_remote_catalog.test
@@ -31,6 +31,12 @@ attach {server} as rpc_remote (remote_catalog 'remote_db')
 statement ok
 create schema rpc_remote.new_schema;
 
+statement ok
+create table rpc_remote.new_schema.tbl (id integer);
+
+statement ok
+drop table rpc_remote.new_schema.tbl;
+
 query II
 from rpc_remote.shared.tbl;
 ----

--- a/test/sql/attach_remote_catalog.test
+++ b/test/sql/attach_remote_catalog.test
@@ -28,6 +28,9 @@ create secret (type quack, token 'asdf')
 statement ok
 attach {server} as rpc_remote (remote_catalog 'remote_db')
 
+statement ok
+create schema rpc_remote.new_schema;
+
 query II
 from rpc_remote.shared.tbl;
 ----

--- a/test/sql/attach_remote_catalog.test
+++ b/test/sql/attach_remote_catalog.test
@@ -31,11 +31,43 @@ attach ':memory:' as catalog_b;
 statement ok quack_db:quack_server_con
 attach ':memory:' as "catalog-with-dash";
 
+# A schema name is not a valid REMOTE_CATALOG unless it also names an attached catalog.
+statement ok quack_db:quack_server_con
+create schema schema_only;
+
+# Catalog lookup is case-insensitive but must retain the catalog's stored spelling for discovery.
+statement ok quack_db:quack_server_con
+attach ':memory:' as "MixedCase";
+
+statement ok quack_db:quack_server_con
+create table "MixedCase".main.tbl as values(61);
+
+# A schema and an attached catalog can have the same identifier. REMOTE_CATALOG must choose the catalog.
+statement ok quack_db:quack_server_con
+create schema ambiguous;
+
+statement ok quack_db:quack_server_con
+attach ':memory:' as ambiguous;
+
+statement ok quack_db:quack_server_con
+create table ambiguous.main.tbl as values(71);
+
 statement ok
 create secret (type quack, token 'asdf')
 
 statement ok
 attach {server} as rpc_remote (remote_catalog 'remote_db')
+
+query T
+from rpc_remote.query('select current_catalog()');
+----
+remote_db
+
+# query() rejects commands without columns, but those commands must not permanently move the server session.
+statement error
+from rpc_remote.query('use catalog_b');
+----
+Query did not return any columns
 
 query T
 from rpc_remote.query('select current_catalog()');
@@ -135,8 +167,53 @@ from quoted.query('select current_catalog()');
 catalog-with-dash
 
 statement error
+attach {server} as schema_only_remote (remote_catalog 'schema_only')
+----
+Failed to select remote catalog "schema_only": catalog is not attached
+
+statement ok
+attach {server} as mixed_case (remote_catalog 'mixedcase');
+
+query I
+from mixed_case.main.tbl;
+----
+61
+
+statement ok
+attach {server} as ambiguous_remote (remote_catalog 'ambiguous');
+
+query I
+from ambiguous_remote.main.tbl;
+----
+71
+
+# Authorization callbacks retain their two-argument signature, but can now recover the pinned catalog by
+# connection id. The same SQL is allowed in catalog_a and denied in catalog_b.
+statement ok quack_db:quack_server_con
+create macro catalog_a_only(sid, sql) as (
+    select exists (
+        select 1 from quack_active_connections() connections
+        where connections.connection_id = sid and connections.remote_catalog = 'catalog_a'
+    )
+);
+
+statement ok quack_db:quack_server_con
+set quack_authorization_function = 'catalog_a_only';
+
+statement ok
+attach {server} as authorized_a (remote_catalog 'catalog_a');
+
+statement error
+attach {server} as denied_b (remote_catalog 'catalog_b');
+----
+Authorization failed
+
+statement ok quack_db:quack_server_con
+reset global quack_authorization_function;
+
+statement error
 attach {server} as missing (remote_catalog 'missing')
 ----
-Failed to select remote catalog "missing"
+Failed to select remote catalog "missing": catalog is not attached
 
 include test/template/quack_teardown.test_template

--- a/test/sql/attach_remote_catalog.test
+++ b/test/sql/attach_remote_catalog.test
@@ -1,0 +1,72 @@
+# name: test/sql/attach_remote_catalog.test
+# description: attach a specific remote catalog
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok quack_db:quack_server_con
+create schema shared;
+
+statement ok quack_db:quack_server_con
+create table shared.tbl as values(99, 100);
+
+statement ok quack_db:quack_server_con
+attach ':memory:' as remote_db;
+
+statement ok quack_db:quack_server_con
+create schema remote_db.shared;
+
+statement ok quack_db:quack_server_con
+create table remote_db.shared.tbl as values(46, 47);
+
+statement ok quack_db:quack_server_con
+create view remote_db.shared.v1 as from remote_db.shared.tbl;
+
+statement ok
+create secret (type quack, token 'asdf')
+
+statement ok
+attach {server} as rpc_remote (remote_catalog 'remote_db')
+
+query II
+from rpc_remote.shared.tbl;
+----
+46	47
+
+query II
+from rpc_remote.shared.v1;
+----
+46	47
+
+statement ok
+create table rpc_remote.shared.created as select 48 as id;
+
+statement ok
+insert into rpc_remote.shared.created values (49);
+
+query I
+from rpc_remote.shared.created order by id;
+----
+48
+49
+
+statement ok
+from rpc_remote.query('create table remote_db.shared.refreshed as select 50 as id');
+
+statement ok
+call quack_clear_cache();
+
+query I
+from rpc_remote.shared.refreshed;
+----
+50
+
+statement ok
+detach rpc_remote;
+
+statement error
+attach {server} as missing (remote_catalog 'missing')
+----
+Remote catalog "missing" not found
+
+include test/template/quack_teardown.test_template


### PR DESCRIPTION
## Summary

- resolve and retain the canonical remote catalog during the handshake
- restore the pinned catalog before remote prepares and asynchronous inserts
- make the selected catalog available to authorization callbacks
- add regressions for session mutation, casing, ambiguous names, and catalog-aware authorization

## Validation

- `git diff --check`
- compiled the modified Quack translation units directly

The full Debug suite remains blocked by existing `unique_ptr` conversion failures in `quack_scan.cpp`; the Release configuration is blocked by a missing `roaring` dependency.