### PR TITLE
Bound the teardown DisconnectMessage timeout so a dead peer cannot hang the destructor

### DIFF
--- a/src/include/quack_client.hpp
+++ b/src/include/quack_client.hpp
@@ -38,6 +38,13 @@ public:
 	//! pass context=nullptr when called off the execution thread (parameters fall back to the database).
 	virtual string PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) = 0;
 
+	//! Best-effort teardown hint: bound the transport for subsequent (final DisconnectMessage) requests so a
+	//! gone/half-open peer cannot block the destructor for the full, possibly hour-long, request timeout.
+	//! Default no-op; the HTTPS client caps the timeout and skips retries. Not thread-safe — call on a client
+	//! that is being torn down and will issue at most one more request.
+	virtual void PrepareTeardownRequest() {
+	}
+
 	//! Encode a request (inject client_query_id when a query is active, then serialize) into `out`.
 	//! Protocol-level and lock-free; the caller owns `out` and any locking around it.
 	static void EncodeRequest(optional_ptr<ClientContext> context, QuackMessage &message, MemoryStream &out);
@@ -130,6 +137,7 @@ public:
 	~HttpsQuackClient() override;
 
 	string PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) override;
+	void PrepareTeardownRequest() override;
 
 private:
 	unique_ptr<QuackMessage> RequestInternal(optional_ptr<ClientContext> context,
@@ -144,6 +152,9 @@ private:
 	//! Persistent keep-alive HTTP client: reused across requests so the TCP connection (and its
 	//! warm congestion window) survives between POSTs; replaced by the retry path on dead sockets.
 	unique_ptr<HTTPClient> http_client;
+	//! Set by PrepareTeardownRequest(): cap the transport timeout and drop retries so the final
+	//! best-effort DisconnectMessage cannot hang the destructor on a dead peer.
+	bool teardown_request = false;
 };
 
 } // namespace duckdb

--- a/src/quack_client.cpp
+++ b/src/quack_client.cpp
@@ -115,6 +115,19 @@ void HttpsQuackClient::EnsureHttpParams(optional_ptr<ClientContext> context) {
 	} else if (!context) {
 		http_params->logger.reset();
 	}
+	if (teardown_request) {
+		// The final DisconnectMessage is best-effort. The transport derives its timeout from
+		// http_params->timeout, which a caller may have set very high (e.g. an hour) for long-running
+		// task dispatch. Against a gone or half-open peer at teardown that would block the destructor for
+		// the whole timeout, so cap it hard and drop retries — a couple of seconds, then give up.
+		http_params->timeout = 2;
+		http_params->timeout_usec = 0;
+		http_params->retries = 0;
+	}
+}
+
+void HttpsQuackClient::PrepareTeardownRequest() {
+	teardown_request = true;
 }
 
 string HttpsQuackClient::PostRaw(optional_ptr<ClientContext> context, const_data_ptr_t data, idx_t size) {
@@ -173,6 +186,9 @@ QuackClientConnection::~QuackClientConnection() {
 	if (!cached_clients.empty()) {
 		try {
 			auto &client = cached_clients.back();
+			// A dead peer at teardown must not block the destructor for the full request timeout (which
+			// task dispatch may have set to an hour). Bound the transport first.
+			client->PrepareTeardownRequest();
 			client->Request<SuccessResponse>(nullptr, make_uniq<DisconnectMessage>(connection_id));
 		} catch (...) {
 		}


### PR DESCRIPTION
### Problem
`QuackClientConnection::~QuackClientConnection()` sends a final best-effort `DisconnectMessage`. The transport derives its timeout from `http_params->timeout`, which a caller may set very high (e.g. an hour) for long-running task dispatch. So when the peer is gone or half-open at teardown — for example an attached worker whose server instance was already destroyed — the destructor blocks for the whole timeout. The surrounding `try/catch` doesn't help: the call doesn't throw, it *hangs* waiting for a response that never comes. Symptom: a process finishes its work but never exits (hangs during DB/static teardown).

### Fix
Add `PrepareTeardownRequest()`:
- default no-op on `QuackClient`;
- `HttpsQuackClient` overrides it to cap `http_params->timeout` to 2s and drop retries for the next request (applied in `EnsureHttpParams`).

`~QuackClientConnection` calls it before the `DisconnectMessage`, so that final request is bounded to a couple of seconds; the existing `catch (...)` swallows the resulting transport error, and the destructor returns promptly whether or not the peer answers. Normal requests are unaffected.
