### PR TITLE
Track latest duckdb main: bump bundled duckdb and adapt to API changes

### DIFF
--- a/.github/duckdb-version
+++ b/.github/duckdb-version
@@ -1,1 +1,1 @@
-26063e4ca7c7cda17af1231de7fdddfcdbde12a2
+89772dbeeba6c8ea89080f75dc418da8e057adca

--- a/src/quack_fetch_ahead.cpp
+++ b/src/quack_fetch_ahead.cpp
@@ -53,7 +53,7 @@ shared_ptr<ReadAheadJobCompletion> QuackFetchBuffer::RegisterWaiter(idx_t claim)
 	if (entry != waiters.end()) {
 		return entry->second;
 	}
-	auto completion = make_shared_ptr<ReadAheadJobCompletion>(1);
+	auto completion = make_shared_ptr<ReadAheadJobCompletion>(nullptr, 1);
 	waiters.emplace(claim, completion);
 	return completion;
 }

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -468,7 +468,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 				connection.query_state = QuackQueryState::CANCELLED;
 				return response;
 			}
-			if (query_result->names.empty()) {
+			if (query_result->GetNames().empty()) {
 				connection.sql_query = "";
 				auto response = make_uniq<ErrorResponse>(query_result->GetErrorObject());
 				connection.duckdb_query_result.reset();
@@ -487,8 +487,14 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		DBConfig::GetConfig(db).TryGetCurrentSetting("quack_fetch_batch_rows", max_rows_val);
 		auto max_rows_per_batch = max_rows_val.GetValue<uint64_t>();
 
-		auto names = connection.duckdb_query_result->names;
-		auto types = connection.duckdb_query_result->types;
+		// BaseQueryResult::names is now vector<Identifier>; the wire message carries plain strings, so
+		// convert each identifier to its raw name.
+		vector<string> names;
+		names.reserve(connection.duckdb_query_result->GetNames().size());
+		for (auto &col_name : connection.duckdb_query_result->GetNames()) {
+			names.push_back(col_name.GetIdentifierName());
+		}
+		auto types = connection.duckdb_query_result->GetTypes();
 
 		auto results = CreateBatch(Allocator::Get(db), connection.duckdb_query_result, max_rows_per_batch);
 		if (connection.duckdb_query_result && connection.duckdb_query_result->HasError()) {


### PR DESCRIPTION
Bumps the bundled duckdb submodule to latest `main` and adapts the source to the duckdb API changes since the previous pin:

- **`ReadAheadJobCompletion`** now takes `(shared_ptr<TaskExecutor>, idx_t)`. The fetch-ahead bridge passes a null executor — it only ever calls `FinishIOTask`/`TryPark` on the completion, never `WaitForIO` (the sole method that uses the executor), so a null executor is safe.
- **`BaseQueryResult::names`/`types` are now private** — switched to `GetNames()`/`GetTypes()`.
- **Result column names are now `vector<Identifier>`** — converted to plain strings via `GetIdentifierName()` for the wire `PrepareResponseMessage` (which carries `vector<string>`).

Builds cleanly against latest duckdb `main` (verified by compiling the extension in a downstream build — `libquack_extension.a` links). CI here validates the standalone build.