### PR TITLE
Reclaim sessions on socket close + give each by_name scan its own session

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>
 #include <thread>
 
 #include "duckdb/common/atomic.hpp"
@@ -83,6 +84,15 @@ struct QuackConnection {
 
 	//! The INSERT this connection is currently driving via a client SEND_DATA stream (one at a time).
 	QuackInsertState insert;
+
+	//! Server-side connection reclamation. socket_refs = number of live HTTP connection tasks (sockets)
+	//! currently serving this session; last_active_ms = steady-clock ms of the last request/activity. A
+	//! background reaper frees a session once no socket serves it (socket_refs == 0) and it has been idle
+	//! past a grace period, reclaiming resources for a client that vanished (crash / dropped socket)
+	//! without sending a DisconnectMessage. A long-running request keeps its socket — and thus a ref — so
+	//! it is never reaped mid-flight, and a quick reconnect re-claims the session within the grace window.
+	atomic<uint32_t> socket_refs {0};
+	atomic<int64_t> last_active_ms {0};
 };
 
 struct QuackConnectionSnapshot {
@@ -161,7 +171,23 @@ private:
 	string token;
 	//! Per-server random key that seeds the HMAC for client_id_hash.
 	string server_hmac_key;
+
+	//! Background reaper that frees sessions whose serving sockets have all closed (see
+	//! QuackConnection::socket_refs). Started in the constructor, stopped/joined in the destructor.
+	void ReaperLoop();
+	std::thread reaper_thread;
+	std::mutex reaper_mutex;
+	std::condition_variable reaper_cv;
+	bool reaper_stop = false;
 };
+
+//! Connection-reclamation hooks. Each accepted HTTP socket runs as one connection task on a single
+//! worker thread for its whole keep-alive lifetime (see ElasticThreadPool), so per-socket state lives in
+//! a thread_local. ClaimSessionForCurrentSocket records that the current task is serving `conn` (adding a
+//! socket ref); ReleaseCurrentSocketSessions is called when that task ends (its socket closed) to drop
+//! the refs this socket held, making the sessions eligible for reaping if no other socket serves them.
+void ClaimSessionForCurrentSocket(const shared_ptr<QuackConnection> &conn);
+void ReleaseCurrentSocketSessions();
 
 class HttpQuackServer : public QuackServer {
 public:

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -123,6 +123,10 @@ public:
 	virtual void Close() {};
 
 	shared_ptr<QuackConnection> GetConnection(const string &connection_id);
+	//! Look up a session AND claim a socket ref for the current socket task in one step, under the
+	//! active_connections lock — so the reaper (which erases only under that lock, only when
+	//! socket_refs == 0) can never reclaim the session between the lookup and the claim.
+	shared_ptr<QuackConnection> GetConnectionForCurrentSocket(const string &connection_id);
 	string CreateNewConnection(const string &session_id, const string &client_id_hash = {});
 	bool DisconnectConnection(const string &session_id);
 	// TODO need something to destroy connections

--- a/src/include/storage/quack_catalog.hpp
+++ b/src/include/storage/quack_catalog.hpp
@@ -77,6 +77,12 @@ public:
 	const string &GetConnectionId();
 
 	shared_ptr<QuackClientConnection> GetClientConnection();
+	//! Open a FRESH server session (its own connection_id) using this catalog's server URI + credentials.
+	//! Each concurrent scan must get its own session: the server keeps a single result per connection_id,
+	//! so sharing GetClientConnection() across concurrent scans lets one scan's PREPARE clobber another's
+	//! in-flight result ("Result has been closed" / short reads).  The extra sessions are reclaimed by the
+	//! server's socket-close reaper once the scan's client sockets go away.
+	shared_ptr<QuackClientConnection> CreateClientConnection(ClientContext &context);
 
 	void Refresh(ClientContext &context);
 
@@ -87,6 +93,10 @@ private:
 
 private:
 	shared_ptr<QuackClientConnection> client_connection;
+	//! Server URI + credentials retained so CreateClientConnection() can mint fresh per-scan sessions.
+	QuackUri server_uri;
+	string token;
+	string client_id;
 	unique_ptr<QuackSchemaSet> schemas;
 };
 

--- a/src/quack_http_server.cpp
+++ b/src/quack_http_server.cpp
@@ -78,7 +78,18 @@ private:
 				auto fn = std::move(jobs.front());
 				jobs.pop_front();
 				guard.unlock();
-				fn();
+				{
+					// fn() runs one accepted socket's whole keep-alive lifetime.  When it returns (the
+					// socket closed), drop the socket refs this connection task claimed on its session(s)
+					// so the reaper can reclaim any no longer served by a live socket.  RAII so the refs
+					// are released even if fn() throws.
+					struct SocketSessionGuard {
+						~SocketSessionGuard() {
+							ReleaseCurrentSocketSessions();
+						}
+					} socket_session_guard;
+					fn();
+				}
 				guard.lock();
 				continue;
 			}

--- a/src/quack_scan.cpp
+++ b/src/quack_scan.cpp
@@ -89,7 +89,10 @@ static unique_ptr<FunctionData> QuackScanBindCatalogName(ClientContext &context,
 	// TODO some of this stuff below is duplicated af
 	auto query = input.inputs[1].GetValue<string>();
 	auto bind_data = make_uniq<QuackScanBindData>();
-	bind_data->client_connection = catalog.GetClientConnection();
+	// Own session per scan (not the shared catalog connection): the server keeps a single result per
+	// connection_id, so a concurrent scan reusing the catalog's connection would clobber this one's
+	// in-flight result.  The reaper reclaims the session once this scan's client sockets close.
+	bind_data->client_connection = catalog.CreateClientConnection(context);
 	auto client_wrapper = bind_data->client_connection->GetClient(context);
 	auto &client = client_wrapper->GetClient();
 	bind_data->query_uuid = UUID::GenerateRandomUUID();

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -252,6 +252,23 @@ shared_ptr<QuackConnection> QuackServer::GetConnection(const string &connection_
 	return nullptr;
 }
 
+shared_ptr<QuackConnection> QuackServer::GetConnectionForCurrentSocket(const string &connection_id) {
+	std::lock_guard<std::mutex> lock(active_connections_mutex);
+	auto it = active_connections.find(connection_id);
+	if (it == active_connections.end()) {
+		return nullptr;
+	}
+	// Claim the socket ref + refresh activity WHILE holding active_connections_mutex.  The reaper erases
+	// a session only under this same lock and only when socket_refs == 0, so bumping the ref here — rather
+	// than after GetConnection has released the lock — closes the TOCTOU where the reaper could reclaim the
+	// session in the gap and orphan the in-flight request (its next call would fail with "Invalid
+	// connection id").  ClaimSessionForCurrentSocket only touches the connection's atomics and a
+	// thread_local, so it is safe to call under the lock.
+	ClaimSessionForCurrentSocket(it->second);
+	it->second->last_active_ms = QuackSteadyNowMs();
+	return it->second;
+}
+
 string QuackServer::CreateNewConnection(const string &session_id, const string &client_id_hash) {
 	std::lock_guard<std::mutex> lock(active_connections_mutex);
 
@@ -425,14 +442,13 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 	// these are basically all messages aside from connect request
 	shared_ptr<QuackConnection> connection;
 	if (MessageRequiresConnection(header.type)) {
-		connection = GetConnection(header.connection_id);
+		// Look up the session AND claim a socket ref for this task atomically (under the map lock), so the
+		// reaper can never reclaim it in the gap between lookup and claim while a request — including a
+		// long-running one — is in flight.  Also refreshes the session's activity time.
+		connection = GetConnectionForCurrentSocket(header.connection_id);
 		if (!connection) {
 			return make_uniq<ErrorResponse>("Invalid connection id");
 		}
-		// This socket task is serving the session: hold a socket ref (so the reaper never reclaims it
-		// while a request — including a long-running one — is in flight) and refresh its activity time.
-		ClaimSessionForCurrentSocket(connection);
-		connection->last_active_ms = QuackSteadyNowMs();
 	}
 
 	// now deserialize the actual message

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -17,7 +17,41 @@
 
 #include "mbedtls_wrapper.hpp"
 
+#include <chrono>
+
 namespace duckdb {
+
+// Sessions the current HTTP connection task holds a socket ref on. Each accepted socket runs as one
+// connection task on a single worker thread for its whole keep-alive lifetime (see ElasticThreadPool),
+// so this per-socket set lives in a thread_local; it is released when the task ends (socket closed).
+static thread_local vector<shared_ptr<QuackConnection>> tls_socket_sessions;
+
+static int64_t QuackSteadyNowMs() {
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+	    .count();
+}
+
+void ClaimSessionForCurrentSocket(const shared_ptr<QuackConnection> &conn) {
+	if (!conn) {
+		return;
+	}
+	for (auto &s : tls_socket_sessions) {
+		if (s == conn) {
+			return; // this socket task already holds a ref on the session
+		}
+	}
+	conn->socket_refs++;
+	tls_socket_sessions.push_back(conn);
+}
+
+void ReleaseCurrentSocketSessions() {
+	auto now = QuackSteadyNowMs();
+	for (auto &s : tls_socket_sessions) {
+		s->socket_refs--;
+		s->last_active_ms = now;
+	}
+	tls_socket_sessions.clear();
+}
 QuackConnection::QuackConnection(string session_id_p) : session_id(std::move(session_id_p)) {
 }
 
@@ -145,9 +179,53 @@ QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const 
     : db_ptr(context_p.db), uri(uri_p), token(token_p) {
 	ValidateToken(token);
 	server_hmac_key = GenerateRandomToken(*context_p.db);
+	reaper_thread = std::thread(&QuackServer::ReaperLoop, this);
 }
 
 QuackServer::~QuackServer() {
+	{
+		std::lock_guard<std::mutex> lk(reaper_mutex);
+		reaper_stop = true;
+	}
+	reaper_cv.notify_all();
+	if (reaper_thread.joinable()) {
+		reaper_thread.join();
+	}
+}
+
+void QuackServer::ReaperLoop() {
+	// Sweep interval, and the grace a session gets after its last serving socket closes before it is
+	// reclaimed — long enough for a client whose socket dropped to reconnect (retry) with the same
+	// connection id and re-claim it first.
+	static constexpr int64_t REAP_INTERVAL_MS = 5000;
+	static constexpr int64_t REAP_GRACE_MS = 30000;
+	std::unique_lock<std::mutex> lk(reaper_mutex);
+	while (!reaper_stop) {
+		reaper_cv.wait_for(lk, std::chrono::milliseconds(REAP_INTERVAL_MS), [&] { return reaper_stop; });
+		if (reaper_stop) {
+			return;
+		}
+		lk.unlock();
+		auto now = QuackSteadyNowMs();
+		// Reclaim sessions no socket is serving that have been idle past the grace.  Hold the removed
+		// connections in a local vector so their destructors (which close a DuckDB connection) run after
+		// the map lock is released, and never with reaper_mutex held.
+		vector<shared_ptr<QuackConnection>> reaped;
+		{
+			std::lock_guard<std::mutex> clk(active_connections_mutex);
+			for (auto it = active_connections.begin(); it != active_connections.end();) {
+				auto &conn = it->second;
+				if (conn->socket_refs.load() == 0 && now - conn->last_active_ms.load() > REAP_GRACE_MS) {
+					reaped.push_back(conn);
+					it = active_connections.erase(it);
+				} else {
+					++it;
+				}
+			}
+		}
+		reaped.clear();
+		lk.lock();
+	}
 }
 
 vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
@@ -185,9 +263,14 @@ string QuackServer::CreateNewConnection(const string &session_id, const string &
 	}
 	auto new_connection = make_shared_ptr<QuackConnection>(session_id);
 	new_connection->client_id_hash = client_id_hash;
+	new_connection->last_active_ms = QuackSteadyNowMs();
 	new_connection->duckdb_connection = make_uniq<Connection>(*db);
 	new_connection->duckdb_connection->context->config.enable_progress_bar = false;
 	// new_connection->duckdb_connection->context->config.streaming_buffer_size = 10 * 1000000; // 10 MB
+	// The socket task handling this CONNECTION_REQUEST will carry the session's subsequent requests, so
+	// claim a socket ref now — otherwise the session sits unclaimed (socket_refs == 0) from creation until
+	// its first follow-up request and could be reaped in between.
+	ClaimSessionForCurrentSocket(new_connection);
 	active_connections[session_id] = std::move(new_connection);
 	return session_id;
 }
@@ -346,6 +429,10 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 		if (!connection) {
 			return make_uniq<ErrorResponse>("Invalid connection id");
 		}
+		// This socket task is serving the session: hold a socket ref (so the reaper never reclaims it
+		// while a request — including a long-running one — is in flight) and refresh its activity time.
+		ClaimSessionForCurrentSocket(connection);
+		connection->last_active_ms = QuackSteadyNowMs();
 	}
 
 	// now deserialize the actual message
@@ -353,6 +440,10 @@ unique_ptr<QuackMessage> QuackServer::HandleMessage(MemoryStream &read_stream) {
 
 	// process the message
 	auto response = HandleMessageInternal(*db, *received_message, connection);
+
+	if (connection) {
+		connection->last_active_ms = QuackSteadyNowMs();
+	}
 
 	if (should_log) {
 		auto duration_ms = QuackNowMillis() - start_time;

--- a/src/storage/quack_catalog.cpp
+++ b/src/storage/quack_catalog.cpp
@@ -25,15 +25,20 @@
 
 namespace duckdb {
 
-QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri, ClientContext &context,
-                           const string &token, string client_id)
-    : Catalog(db_p) {
-	// connect to the server
-	client_connection = QuackClient::ConnectToServer(context, server_uri, token, std::move(client_id));
+QuackCatalog::QuackCatalog(AttachedDatabase &db_p, const QuackUri &server_uri_p, ClientContext &context,
+                           const string &token_p, string client_id_p)
+    : Catalog(db_p), server_uri(server_uri_p), token(token_p), client_id(std::move(client_id_p)) {
+	// connect to the server (this connection loads the catalog and serves metadata/DDL); per-scan reads
+	// get their OWN sessions via CreateClientConnection so concurrent scans never share one result slot.
+	client_connection = QuackClient::ConnectToServer(context, server_uri, token, client_id);
 
 	// load the entire catalog up-front
 	auto load_info = LoadCatalog(context);
 	schemas = make_uniq<QuackSchemaSet>(context, *this, load_info);
+}
+
+shared_ptr<QuackClientConnection> QuackCatalog::CreateClientConnection(ClientContext &context) {
+	return QuackClient::ConnectToServer(context, server_uri, token, client_id);
 }
 
 QuackLoadCatalogData QuackCatalog::LoadCatalog(ClientContext &context) {


### PR DESCRIPTION
Three related fixes to server-side session handling, motivated by "random behaviour when quack nodes read many S3 files concurrently."

### 1. Reclaim server-side sessions when their client sockets close (original PR)
`active_connections` sessions were only freed on an explicit `DISCONNECT`; a client that just drops its socket leaked its session (and the DuckDB connection it pins). Adds a reaper that reclaims sessions whose sockets are gone (`socket_refs == 0`) once idle past a grace, plus per-socket ref-counting (`ClaimSessionForCurrentSocket`/`ReleaseCurrentSocketSessions`). Careful with long-running requests: the serving socket holds a ref for the request's whole duration, and reconnects re-claim within the grace.

### 2. Reaper TOCTOU fix
`HandleMessage` looked a session up with `GetConnection` (which releases the map lock) and only *then* bumped `socket_refs` — so the reaper could observe `socket_refs == 0` in the gap, erase the session, and orphan the in-flight request (next request → "Invalid connection id"). New `GetConnectionForCurrentSocket` looks up **and** claims the ref while still holding `active_connections_mutex`, closing the window.

### 3. `quack_query_by_name`: own session per scan
The attached-catalog path reused the catalog's **single** `client_connection` (one `connection_id`) for every scan. The server keeps exactly **one** `duckdb_query_result` per `connection_id`, so two concurrent scans to the same attached database clobber each other — the second's `PREPARE` discards the first's in-flight result and resets `query_uuid`, and the first's next `FETCH` fails the uuid check (**"Result has been closed"**) or returns short/partial rows. A big many-file read holds its result open longer → wider clobber window → **"random behaviour reading many files at once."**

`QuackCatalog::CreateClientConnection()` now opens a fresh `connection_id` per scan (mirroring the direct `quack_query` path), which the socket-close reaper (fix #1) reclaims — so it fixes the correctness bug without reintroducing the session leak. The single catalog connection is still used for metadata/DDL.
