### PR TITLE
Bump httpfs to post-restructure main (fafb14f)

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -11,9 +11,9 @@ duckdb_extension_load(autocomplete)
 
 duckdb_extension_load(httpfs
     GIT_URL https://github.com/duckdb/duckdb-httpfs
-    # Includes the curl per-read timeout fix (duckdb-httpfs#336): stalled transfers abort via
-    # CURLOPT_LOW_SPEED_* instead of hanging forever / requiring a huge total-transfer timeout.
-    # Newest commit before the 2026-07-30 directory restructure. No APPLY_PATCHES: the carried
-    # patches (prefetch network cost model etc.) were absorbed upstream on 2026-07-03.
-    GIT_TAG a6352ca0a4bec678008133cd41edb13e6465fa88
+    # httpfs main including the large 2026-07-30 directory restructure/reimplementation and the curl
+    # per-read timeout fix (duckdb-httpfs#336: stalled transfers abort via CURLOPT_LOW_SPEED_* instead of
+    # hanging). No APPLY_PATCHES: the carried patches were absorbed upstream. Builds against the bundled
+    # duckdb (.github/duckdb-version), which is current main and has SecretPersistType::TRANSACTION.
+    GIT_TAG fafb14f2c899ddfd1998f8adf2e07fbbfd28b3fd
 )


### PR DESCRIPTION
Moves the httpfs pin to main including the 2026-07-30 directory restructure/reimplementation: `a6352ca0` → `fafb14f`.

This is the httpfs bump from **#238**, but **without** #238's accompanying duckdb downgrade. #238's `linux_amd64` build failed with:

```
httpfs/src/create_secret_functions.cpp:147: 'TRANSACTION' is not a member of 'duckdb::SecretPersistType'
```

— because #238 paired the post-restructure httpfs with an *old* bundled duckdb that predates `SecretPersistType::TRANSACTION`. Now that **#243** has landed (bundled duckdb = current main `8ca23ac`, which has `TRANSACTION`), the post-restructure httpfs compiles. This PR therefore keeps **only** the httpfs tag change on top of current main.

Supersedes #238 — that PR can be closed once this is green.