### PR TITLE
Allow attaching catalogs with foreign keys

### DIFF
--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -39,7 +39,16 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			if (info->type != CatalogType::TABLE_ENTRY) {
 				throw InternalException("Expected a CREATE TABLE");
 			}
-			// bind to resolve the types
+			auto &table_info = info->Cast<CreateTableInfo>();
+			vector<unique_ptr<Constraint>> constraints;
+			for (auto &constraint : table_info.constraints) {
+				if (constraint->type != ConstraintType::FOREIGN_KEY) {
+					constraints.push_back(std::move(constraint));
+				}
+			}
+			table_info.constraints = std::move(constraints);
+
+			// The server enforces foreign keys. Binding them here would resolve them in the client catalog.
 			auto binder = Binder::CreateBinder(context);
 			auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
 			auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());

--- a/test/sql/attach_foreign_keys.test
+++ b/test/sql/attach_foreign_keys.test
@@ -1,0 +1,58 @@
+# name: test/sql/attach_foreign_keys.test
+# description: attach a catalog with foreign keys
+# group: [sql]
+
+require quack
+
+require httpfs
+
+statement ok con1
+create table parent(id integer primary key);
+
+statement ok con1
+create table child(id integer primary key, parent_id integer references parent(id));
+
+statement ok con1
+insert into parent values (1);
+
+statement ok con1
+insert into child values (1, 1);
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+statement ok con2
+attach {server} as rpc (token 'asdf');
+
+query I con2
+select id from rpc.child;
+----
+1
+
+query I con2
+select id from rpc.parent;
+----
+1
+
+statement ok con2
+insert into rpc.child values (2, 1);
+
+statement error con2
+insert into rpc.child values (3, 99);
+----
+Violates foreign key constraint
+
+query I con2
+select count(*) from rpc.child;
+----
+2
+
+statement ok con2
+detach rpc;
+
+statement ok con1
+call quack_stop({server});
+
+endloop


### PR DESCRIPTION
Quack binds remote table DDL while building the attached catalog. Foreign-key binding looks for referenced tables in the client catalog, so `ATTACH` fails.

Skip foreign keys when binding remote table metadata. They remain server-side constraints and are still enforced on remote inserts.

Adds coverage for attach, reads, and valid and invalid remote inserts.

Checks:
- `make format-check`
- `make test` (34 tests, 635 assertions)
- debug regression test (13 assertions)