### PR TITLE
Skip the authorization callback when none is configured

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -30,6 +30,11 @@ class EncryptionState;
 class QuackDataStream;
 class ErrorData;
 
+//! Default of the `quack_authorization_function` setting: a no-op callback that accepts every statement and
+//! hands the query back unchanged. quack_extension.cpp registers it and the server compares against it to
+//! detect that no callback of its own has been set, so both sites use this.
+static constexpr const char *QUACK_DEFAULT_AUTHORIZATION_FUNCTION = "quack_nop_authorization";
+
 enum class QuackQueryState : uint8_t { IDLE, ACTIVE, FINISHED, CANCELLED, QUACK_ERROR };
 
 //! An insert stream + its driver thread, taken off a connection so finish/join can run unlocked.

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -153,7 +153,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	quack_check_token.SetVolatile();
 	loader.RegisterFunction(quack_check_token);
 
-	ScalarFunction rpc_authorization("quack_nop_authorization",
+	ScalarFunction rpc_authorization(QUACK_DEFAULT_AUTHORIZATION_FUNCTION,
 	                                 {/* session id */ LogicalType::VARCHAR, /* query string */ LogicalType::VARCHAR},
 	                                 LogicalType::VARCHAR, QuackDummyAuthorization);
 	rpc_authorization.SetVolatile();
@@ -180,7 +180,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_authentication_function", "Name of a callback function for authentication",
 	                          LogicalType::VARCHAR, Value("quack_check_token"), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("quack_authorization_function", "Name of a callback function for authorization",
-	                          LogicalType::VARCHAR, Value("quack_nop_authorization"), nullptr, SetScope::GLOBAL);
+	                          LogicalType::VARCHAR, Value(QUACK_DEFAULT_AUTHORIZATION_FUNCTION), nullptr,
+	                          SetScope::GLOBAL);
 
 	config.AddExtensionOption("quack_prepare_inline_rows",
 	                          "Rows returned inline in the PREPARE response before the remainder is left to "

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -519,6 +519,17 @@ static Value EvaluateAuthQuery(DatabaseInstance &db, const string &sql, ARGS... 
 	return auth_result_chunk->GetValue(0, 0);
 }
 
+//! Name of the configured authorization callback, or empty while the default no-op is still in place. That
+//! default accepts every statement and returns the query unchanged, so calling it buys nothing and costs a
+//! Connection plus a full parse/bind/execute - per statement, and once per batch on the append path.
+static string GetAuthorizationFunction(DatabaseInstance &db) {
+	auto function_name = GetSettingString(db, "quack_authorization_function");
+	if (function_name == QUACK_DEFAULT_AUTHORIZATION_FUNCTION) {
+		return string();
+	}
+	return function_name;
+}
+
 static constexpr idx_t kTokenBytes = 16; // 128 bits
 
 static string HexEncode(const data_t *bytes, idx_t n) {
@@ -717,16 +728,20 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &prepare_request_message = received_message.Cast<PrepareRequestMessage>();
 		auto &connection = *connection_p;
 
-		// TODO do not do this if there is no fun set
-		auto auth_result = EvaluateAuthQuery(
-		    db, StringUtil::Format("SELECT %s(?, ?)", GetSettingString(db, "quack_authorization_function")),
-		    Value(prepare_request_message.ConnectionId()), Value(prepare_request_message.Query()));
-		if (auth_result.IsNull() ||
-		    (auth_result.type().id() == LogicalTypeId::BOOLEAN && !auth_result.GetValue<bool>())) {
-			return make_uniq<ErrorResponse>("Authorization failed");
+		auto effective_sql = prepare_request_message.Query();
+		auto authorization_function = GetAuthorizationFunction(db);
+		if (!authorization_function.empty()) {
+			auto auth_result = EvaluateAuthQuery(db, StringUtil::Format("SELECT %s(?, ?)", authorization_function),
+			                                     Value(prepare_request_message.ConnectionId()),
+			                                     Value(prepare_request_message.Query()));
+			if (auth_result.IsNull() ||
+			    (auth_result.type().id() == LogicalTypeId::BOOLEAN && !auth_result.GetValue<bool>())) {
+				return make_uniq<ErrorResponse>("Authorization failed");
+			}
+			if (auth_result.type().id() == LogicalTypeId::VARCHAR) {
+				effective_sql = auth_result.GetValue<string>();
+			}
 		}
-		auto effective_sql = (auth_result.type().id() == LogicalTypeId::VARCHAR) ? auth_result.GetValue<string>()
-		                                                                         : prepare_request_message.Query();
 
 		// Stop the previous producer first. This joins its thread, so it frees the statement lock.
 		AbortFetchStream(connection, "superseded by a new query");
@@ -938,17 +953,15 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 		auto &send_data_message = received_message.Cast<SendDataRequestMessage>();
 		auto &connection = *connection_p;
 
-		// we never execute this query, but throw it at the authorization function so it can check if this user gets to
-		// insert into this table
-		auto dummy_insert_query =
-		    StringUtil::Format("INSERT INTO %s.%s VALUES (NULL)", SQLIdentifier(send_data_message.SchemaName()),
-		                       SQLIdentifier(send_data_message.TableName()));
-
-		// TODO do not do this if there is no fun set
-		{
-			auto auth_result = EvaluateAuthQuery(
-			    db, StringUtil::Format("SELECT %s(?, ?)", GetSettingString(db, "quack_authorization_function")),
-			    Value(send_data_message.ConnectionId()), Value(dummy_insert_query));
+		auto authorization_function = GetAuthorizationFunction(db);
+		if (!authorization_function.empty()) {
+			// we never execute this query, but throw it at the authorization function so it can check if this user
+			// gets to insert into this table
+			auto dummy_insert_query =
+			    StringUtil::Format("INSERT INTO %s.%s VALUES (NULL)", SQLIdentifier(send_data_message.SchemaName()),
+			                       SQLIdentifier(send_data_message.TableName()));
+			auto auth_result = EvaluateAuthQuery(db, StringUtil::Format("SELECT %s(?, ?)", authorization_function),
+			                                     Value(send_data_message.ConnectionId()), Value(dummy_insert_query));
 			if (auth_result.IsNull() ||
 			    (auth_result.type().id() == LogicalTypeId::BOOLEAN && !auth_result.GetValue<bool>())) {
 				return make_uniq<ErrorResponse>("Authorization failed");

--- a/test/sql/authz_append.test
+++ b/test/sql/authz_append.test
@@ -1,0 +1,67 @@
+# name: test/sql/authz_append.test
+# description: the authorization callback still gates the append (SEND_DATA) path
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table rpc.t(i bigint);
+
+# The source has to be local. A remote-executable source (range(), a remote table) is pushed down to one
+# server-side statement instead, which authorizes through PREPARE and never reaches the append path.
+statement ok
+create table local_src(i bigint);
+
+statement ok
+insert into local_src select * from range(1000);
+
+# The default callback (quack_nop_authorization) accepts everything, so the server skips it here.
+statement ok
+insert into rpc.t select * from local_src;
+
+query I
+select count(*) from rpc.t;
+----
+1000
+
+# The append path never shows the callback the statement the client ran - it probes with a synthetic
+# "INSERT INTO <schema>.<table> VALUES (NULL)" instead. Rejecting that probe must stop the append.
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_no_append(sid, query) AS NOT (query LIKE 'INSERT INTO %VALUES (NULL)');
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_no_append';
+
+statement error
+insert into rpc.t select * from local_src;
+----
+Authorization failed
+
+# The rejected append is atomic: no rows leaked through.
+query I
+select count(*) from rpc.t;
+----
+1000
+
+# Reads are untouched by this callback, so the connection is still usable.
+query I
+select max(i) from rpc.t;
+----
+999
+
+# Back on the default the callback is skipped again and appends resume.
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_authorization_function;
+
+statement ok
+insert into rpc.t select * from local_src;
+
+query I
+select count(*) from rpc.t;
+----
+2000
+
+include test/template/quack_teardown.test_template


### PR DESCRIPTION
### What

Skip the authorization callback while the default `quack_nop_authorization` is still configured, which is
what the two `// TODO do not do this if there is no fun set` comments in `quack_server.cpp` ask for.

### Why

`quack_nop_authorization` accepts every statement and hands the query straight back:

```cpp
static void QuackDummyAuthorization(const DataChunk &args, ExpressionState &, Vector &result) {
	result.SetValue(0, args.GetValue(1, 0)); // choose life
}
```

Reaching that one `SetValue` costs, per request, inside `EvaluateAuthQuery`:

* a `StringUtil::Format` for the `SELECT <fun>(?, ?)` wrapper,
* a `Connection`, whose constructor allocates a `ClientContext` and then takes `ConnectionManager`'s
  global `connections_lock` to run every extension's `OnConnectionOpened`,
* a full parse / bind / plan / execute of that statement,
* the same global lock again on destruction, for `OnConnectionClosed`.

`PREPARE_REQUEST` pays this once per remote statement, which is where it shows up.

### Numbers

Release build, arm64 macOS, loopback, server and clients on one machine. Measured by building this branch
twice — once as-is, once with `quack_server.cpp` reverted — so only the branch differs.

| Workload | before | after | |
|---|---|---|---|
| 500 × `quack_query('SELECT 42')`, one process | 0.338 s | 0.283 s | **-16%** (~0.11 ms/statement) |
| 8 client processes × 200 statements | 0.404 s | 0.331 s | **-18%** |
| 4 M-row append from a local source | 0.132 s | 0.132 s | no change |

Medians of 5 and 3 runs; the per-run spreads did not overlap for the first two rows.

The append row deserves the honesty: `SEND_DATA_REQUEST` also authorized on every request, and I expected
that to dominate a bulk append. Counting the log says otherwise - a 4 M-row insert issues **45**
`SEND_DATA_REQUEST`s (~89 k rows each, and the count does not move with `quack_target_batch_bytes`), so the
saving there is a few ms inside the noise. The change still removes the pointless work on that path, but
the measurable win is the statement path, not the append path.

### Behaviour

Unchanged whenever a callback is configured: same call, same arguments, same `Authorization failed` on a
false or NULL result, same VARCHAR rewrite of the effective SQL. Unchanged on the default too, since
skipping a callback that returns its own argument leaves `effective_sql` equal to the query the client sent.

One deliberate difference: if `quack_nop_authorization` were not resolvable at all (a broken install), the
old code failed closed on the resulting error, whereas the new code never asks. That did not seem worth
paying for on every request, but say the word and I will keep it.

### Alternative considered

Keying on the setting value means someone who shadowed the built-in with a macro of the same name would be
skipped too. Registering a `set_callback` on `quack_authorization_function` and tracking whether anyone has
set it would be exact rather than name-based - happy to switch if you prefer that.

### Test

`test/sql/authz_append.test` covers the append path, which `authn_swap.test` does not reach. Two things it
pins down: the callback sees a synthetic `INSERT INTO <schema>.<table> VALUES (NULL)` probe rather than the
client's statement, and the source table has to be local, because a remote-executable source (`range()`, a
remote table) is pushed down to a single server-side statement that authorizes through PREPARE and never
touches the append path at all.

`make test` passes: 68 test cases, 2679 assertions.
