### PR TITLE
docs+test: pin how the authorization callback's return value is interpreted

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -247,11 +247,57 @@ All settings are regular DuckDB session/global options. Set with
 | Setting                         | Type    | Default                   | Description                                                             |
 |---------------------------------|---------|---------------------------|-------------------------------------------------------------------------|
 | `rpc_authentication_function`   | VARCHAR | `rpc_auth_token`          | Name of a 2-arg scalar function `(sid, token) -> BOOLEAN` used by the server to authenticate clients. |
-| `rpc_authorization_function`    | VARCHAR | `rpc_dummy_authorization` | Name of a 2-arg scalar function `(sid, query) -> BOOLEAN` used by the server to authorize each query. |
+| `rpc_authorization_function`    | VARCHAR | `rpc_dummy_authorization` | Name of a 2-arg scalar function `(sid, query)` used by the server to authorize each query. See [Return values](#authorization-callback-return-values). |
 | `rpc_default_token`             | VARCHAR | *(unset)*                 | Shared secret. The server generates one on `rpc_start`; clients must set it before connecting. |
 
 You can plug in your own auth by creating any scalar function with the
 expected signature and pointing the setting at it.
+
+#### Authorization callback return values
+
+The server interprets the callback's return value as follows
+(`test/sql/authz_return_value.test` pins each case):
+
+| Return | Effect |
+|--------|--------|
+| `true` | Run the client's query unchanged |
+| `false` | Reject with `Authorization failed` |
+| `NULL` | Reject with `Authorization failed` |
+| `VARCHAR` | **Run the returned SQL instead of the client's query** |
+| any other type | Run the client's query unchanged (no rejection) |
+
+The `VARCHAR` form lets a policy *narrow* a query rather than reject it — returning a
+more restrictive statement in place of the one the client sent. That is the only way to
+filter **rows**, which a `BOOLEAN` cannot do.
+
+```sql
+-- illustrative only: see the warnings below before using this shape
+CREATE MACRO authz_narrow(sid, query) AS 'SELECT id, grp FROM t WHERE grp = ''a''';
+SET GLOBAL rpc_authorization_function = 'authz_narrow';
+```
+
+Three things to know before relying on it:
+
+- **A `VARCHAR` return can never deny.** The guard checks only `NULL` and a false
+  `BOOLEAN`, so a policy that always returns SQL cannot reject anything — it can only
+  substitute. To reject, return SQL that errors, or a `BOOLEAN`.
+- **The rewrite applies to query execution only.** `SEND_DATA_REQUEST` (client-side
+  inserts) invokes the same callback with a synthesized `INSERT INTO <schema>.<table>
+  VALUES (NULL)` and applies the deny guard alone. A `VARCHAR` return is ignored there and
+  the insert proceeds — so a policy built entirely on rewriting does not gate writes.
+- **Deciding what to rewrite by matching on the query text is not a security boundary.**
+  Aliases, whitespace, comments and qualified names all defeat substring matching. If the
+  decision matters, parse the query — `json_serialize_sql()` is available inside the
+  callback — rather than matching on the raw string.
+
+Note also that `quack_active_connections()` and the server log report the query **as the
+client sent it**, not the rewritten statement that ran — so a rewrite is invisible to the
+audit trail.
+
+If you rewrite the catalogue queries a client issues on `ATTACH` (`duckdb_tables()`,
+`duckdb_views()`, `information_schema.schemata`), preserve their column list and order:
+the client reads those results positionally and a different projection breaks the
+`ATTACH` with an unrelated-looking error.
 
 ### FETCH batching (server-side)
 

--- a/test/sql/authz_return_value.test
+++ b/test/sql/authz_return_value.test
@@ -1,0 +1,163 @@
+# name: test/sql/authz_return_value.test
+# description: pins how the server interprets quack_authorization_function's return value
+# group: [sql]
+
+# The callback is documented as `(sid, query) -> BOOLEAN`, but quack_server.cpp treats a
+# VARCHAR return as the SQL to execute. These cases pin what the server does today so the
+# behaviour cannot change silently, whichever way it is meant to go.
+
+include test/template/quack_setup.test_template
+
+# --- BOOLEAN: allow / deny, the documented contract ---
+
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_true(sid, query) AS true;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_true';
+
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
+----
+42
+
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_false(sid, query) AS false;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_false';
+
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
+----
+
+# --- NULL: fails closed ---
+
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_null(sid, query) AS CAST(NULL AS VARCHAR);
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_null';
+
+statement error
+FROM quack_query({server}, 'select 42', token='asdf');
+----
+
+# --- VARCHAR: the returned string is executed in place of the client's query ---
+
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_rewrite(sid, query) AS 'SELECT 99';
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_rewrite';
+
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
+----
+99
+
+# Returning the query unchanged is a passthrough.
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_passthrough(sid, query) AS CAST(query AS VARCHAR);
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_passthrough';
+
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
+----
+42
+
+# A rewrite can narrow the result: the client asks for every row, the server returns a
+# subset. This is the property that makes the VARCHAR form interesting.
+statement ok quack_db:quack_server_con
+CREATE TABLE t(id INTEGER, grp VARCHAR);
+
+statement ok quack_db:quack_server_con
+INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'a');
+
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_narrow(sid, query) AS
+    'SELECT id, grp FROM t WHERE grp = ''a'' ORDER BY id';
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_narrow';
+
+query II
+FROM quack_query({server}, 'SELECT id, grp FROM t ORDER BY id', token='asdf');
+----
+1	a
+3	a
+
+# --- Fail-open cases. Both currently ALLOW; pinned so a change is deliberate. ---
+
+# 1. A VARCHAR return can never deny. quack_server.cpp checks IsNull() or a false BOOLEAN,
+#    so a policy that always returns SQL has no way to reject a query -- it can only
+#    substitute one. Rejecting means returning SQL that itself errors.
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_varchar_deny_attempt(sid, query) AS 'SELECT 1';
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_varchar_deny_attempt';
+
+query I
+FROM quack_query({server}, 'DROP TABLE t', token='asdf');
+----
+1
+
+# ...and t is still there: the substitution ran instead of the drop.
+query I quack_db:quack_server_con
+SELECT count(*) FROM t;
+----
+3
+
+# 2. Any other return type is allowed. The guard tests only IsNull() and BOOLEAN, so an
+#    INTEGER return falls through to the client's own query.
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_integer(sid, query) AS 0;
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_integer';
+
+query I
+FROM quack_query({server}, 'select 42', token='asdf');
+----
+42
+
+# 3. The rewrite applies to PREPARE_REQUEST only. SEND_DATA_REQUEST calls the same callback
+#    with a synthesized INSERT and applies the deny guard alone, so a VARCHAR return neither
+#    rewrites nor denies there: the insert proceeds.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'quack_nop_authorization';
+
+statement ok
+attach {server} as rpc (token 'asdf')
+
+statement ok
+create table rpc.sink(i bigint);
+
+statement ok quack_db:quack_server_con
+CREATE MACRO authz_deny_via_varchar(sid, query) AS 'SELECT error(''denied'')';
+
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'authz_deny_via_varchar';
+
+statement ok
+insert into rpc.sink select * from range(3) t(i);
+
+# The rows landed even though the callback returned a query that errors.
+statement ok quack_db:quack_server_con
+SET GLOBAL quack_authorization_function = 'quack_nop_authorization';
+
+query I quack_db:quack_server_con
+SELECT count(*) FROM sink;
+----
+3
+
+statement ok quack_db:quack_server_con
+RESET GLOBAL quack_authorization_function;
+
+statement ok
+detach rpc;
+
+include test/template/quack_teardown.test_template


### PR DESCRIPTION
## What

`quack_authorization_function` is documented as `(sid, query) -> BOOLEAN`, but `quack_server.cpp:728` treats a `VARCHAR` return as the SQL to execute, and line 772 runs that instead of the client's query:

```cpp
auto effective_sql = (auth_result.type().id() == LogicalTypeId::VARCHAR)
                     ? auth_result.GetValue<string>()
                     : prepare_request_message.Query();
```

Nothing tests it, so it can disappear in a refactor without anyone noticing.

**No functional change** — a test pinning current behaviour, and a docs section describing it accurately.

## Why the VARCHAR form is worth keeping

`BOOLEAN` can only allow or deny a *whole query*, so it cannot filter **rows**.

That matters for the catalogue queries a client issues on `ATTACH` (`storage/quack_schema.cpp:34`, `storage/quack_table.cpp:72`). Their response carries every schema name and `CREATE TABLE` DDL on the server, so on a server hosting more than one tenant, a client that runs nothing but `ATTACH` learns every other tenant's schemas and table definitions. Returning `false` does not help — it aborts the `ATTACH` and the client gets no connection.

Rewriting those two queries to add a filter is the only way to scope that response today.

## What the test covers

`test/sql/authz_return_value.test` — in each case, what the server does *now*:

- `BOOLEAN` true / false, and `NULL` failing closed
- `VARCHAR` replacing the executed query
- `VARCHAR` returning the query unchanged (passthrough)
- a rewrite narrowing a result the client asked for in full

…and three fail-open behaviours:

- **a `VARCHAR` return can never deny** — the guard checks only `NULL` and a false `BOOLEAN`, so `DROP TABLE t` is answered by the substituted query rather than rejected
- **any other return type allows** — an `INTEGER` return falls through to the client's own query
- **the rewrite does not reach `SEND_DATA_REQUEST`** — line 949 invokes the same callback with a synthesized `INSERT` and applies the deny guard alone, so with a callback returning `SELECT error(...)` an insert through an attached client still lands its rows

I pinned those three rather than changing them, so closing them is a separate deliberate commit. **Happy to write that** if you'd like — making the `VARCHAR` branch apply at 949 and rejecting unexpected return types both seem right to me, but they change behaviour and that's your call.

## Docs

`docs/usage.md` gains a return-value table including the fail-open row, and states plainly that a rewrite cannot deny, that it does not reach the insert path, and that **deciding what to rewrite by matching on raw query text is not a security boundary** — aliases, whitespace and qualified names all defeat it; `json_serialize_sql()` is available inside the callback if the decision matters.

It also notes that a catalogue rewrite must preserve column order, since the client reads those results positionally.

## Note

`docs/usage.md` uses `rpc_*` setting names throughout while the code registers `quack_*` (`src/quack_extension.cpp:149-183`). I followed the file's existing convention rather than mixing the two — happy to fix the file-wide rename here or leave it separate.
