### PR TITLE
Add quack_query_timeout to interrupt queries that run past a deadline

### DIFF
--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
 
+#include "quack_periodic_worker.hpp"
 #include "quack_result_cache.hpp"
 #include "quack_uri.hpp"
 
@@ -130,6 +131,9 @@ struct QuackConnection {
 	//! Read unlocked by the cache sweep and the connection listing, so it must be atomic.
 	atomic<QuackQueryState> query_state {QuackQueryState::IDLE};
 	timestamp_t query_started_at {0};
+	//! Monotonic start time for the query-timeout deadline. Wall-clock query_started_at is for
+	//! display only — a clock jump must not interrupt a running query or defer its timeout.
+	time_point<steady_clock> query_started_steady;
 
 	//! The INSERT this connection is currently driving via a client SEND_DATA stream (one at a time).
 	QuackInsertState insert;
@@ -235,25 +239,23 @@ private:
 	//! Destroys reaped caches on a one-shot detached thread so no response waits on their teardown
 	void DestroyCachesDetached(vector<unique_ptr<QuackResultCache>> doomed);
 
-	//! Background thread: interrupts any query that has run past quack_query_timeout. This also
+	//! One reaper pass: interrupt any query that has run past quack_query_timeout. This also
 	//! reclaims a query whose client has disconnected — the server keeps running it otherwise,
 	//! because the heartbeat lease is only evaluated when a fresh message arrives on the connection.
-	void StartReaper();
-	void StopReaper();
-	void ReaperLoop();
-	//! Interrupt `connection`'s running query if it started more than `deadline_us` before `now`.
-	//! A no-op unless the connection has an ACTIVE query old enough; identity-checked so a query
-	//! started since the deadline was computed is never touched.
-	static void ReapConnectionIfOverdue(QuackConnection &connection, timestamp_t now, int64_t deadline_us);
-
-	std::thread reaper_thread;
-	std::mutex reaper_mutex;
-	std::condition_variable reaper_cv;
-	bool reaper_stop = false;
+	void ReaperTick();
+	//! Interrupt `connection`'s running query if it has run for at least `timeout_seconds`.
+	//! A no-op unless the connection has an ACTIVE, non-sentinel query old enough; identity-checked
+	//! so a query started since the decision is never touched.
+	static void ReapConnectionIfOverdue(QuackConnection &connection, time_point<steady_clock> now,
+	                                    idx_t timeout_seconds);
 
 	string token;
 	//! Per-server random key that seeds the HMAC for client_id_hash.
 	string server_hmac_key;
+
+	//! Enforces quack_query_timeout. Declared last so it is torn down (its dtor joins the thread)
+	//! before active_connections; ~QuackServer also stops it explicitly before any teardown.
+	QuackPeriodicWorker reaper;
 };
 
 class HttpQuackServer : public QuackServer {

--- a/src/include/quack_server.hpp
+++ b/src/include/quack_server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <condition_variable>
 #include <queue>
 #include <thread>
 
@@ -233,6 +234,22 @@ private:
 	static void CleanupExpiredConnection(QuackConnection &connection);
 	//! Destroys reaped caches on a one-shot detached thread so no response waits on their teardown
 	void DestroyCachesDetached(vector<unique_ptr<QuackResultCache>> doomed);
+
+	//! Background thread: interrupts any query that has run past quack_query_timeout. This also
+	//! reclaims a query whose client has disconnected — the server keeps running it otherwise,
+	//! because the heartbeat lease is only evaluated when a fresh message arrives on the connection.
+	void StartReaper();
+	void StopReaper();
+	void ReaperLoop();
+	//! Interrupt `connection`'s running query if it started more than `deadline_us` before `now`.
+	//! A no-op unless the connection has an ACTIVE query old enough; identity-checked so a query
+	//! started since the deadline was computed is never touched.
+	static void ReapConnectionIfOverdue(QuackConnection &connection, timestamp_t now, int64_t deadline_us);
+
+	std::thread reaper_thread;
+	std::mutex reaper_mutex;
+	std::condition_variable reaper_cv;
+	bool reaper_stop = false;
 
 	string token;
 	//! Per-server random key that seeds the HMAC for client_id_hash.

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -228,9 +228,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Seconds an idle keep-alive connection is kept open by the RPC server",
 	                          LogicalType::UBIGINT, Value::UBIGINT(300), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("quack_query_timeout",
-	                          "Seconds a single query may run on the server before it is interrupted (0 = no limit). "
-	                          "Also reclaims a query whose client has disconnected, which the server keeps running "
-	                          "otherwise",
+	                          "Seconds a SELECT-style query may run on the server before it is interrupted (0 = no "
+	                          "limit), enforced within about a second. Also reclaims such a query whose client has "
+	                          "disconnected, which the server keeps running otherwise. Does not cover INSERT streams",
 	                          LogicalType::UBIGINT, Value::UBIGINT(0), nullptr, SetScope::GLOBAL);
 
 	// Default client_id handed to any ATTACH / quack_query that doesn't pass one explicitly

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -228,9 +228,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Seconds an idle keep-alive connection is kept open by the RPC server",
 	                          LogicalType::UBIGINT, Value::UBIGINT(300), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("quack_query_timeout",
-	                          "Seconds a SELECT-style query may run on the server before it is interrupted (0 = no "
-	                          "limit), enforced within about a second. Also reclaims such a query whose client has "
-	                          "disconnected, which the server keeps running otherwise. Does not cover INSERT streams",
+	                          "Seconds a SELECT-style query may run on the server, measured from query start to its "
+	                          "final fetch, before it is interrupted (0 = no limit), enforced within about a second. "
+	                          "Also reclaims such a query whose client has disconnected, which the server keeps "
+	                          "running otherwise. Does not cover INSERT streams",
 	                          LogicalType::UBIGINT, Value::UBIGINT(0), nullptr, SetScope::GLOBAL);
 
 	// Default client_id handed to any ATTACH / quack_query that doesn't pass one explicitly

--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -227,6 +227,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("quack_server_keep_alive_timeout",
 	                          "Seconds an idle keep-alive connection is kept open by the RPC server",
 	                          LogicalType::UBIGINT, Value::UBIGINT(300), nullptr, SetScope::GLOBAL);
+	config.AddExtensionOption("quack_query_timeout",
+	                          "Seconds a single query may run on the server before it is interrupted (0 = no limit). "
+	                          "Also reclaims a query whose client has disconnected, which the server keeps running "
+	                          "otherwise",
+	                          LogicalType::UBIGINT, Value::UBIGINT(0), nullptr, SetScope::GLOBAL);
 
 	// Default client_id handed to any ATTACH / quack_query that doesn't pass one explicitly
 	string default_client_id;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -367,6 +367,14 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, timestamp
 		if (connection.query_state != QuackQueryState::ACTIVE || connection.query_started_at.value == 0) {
 			return;
 		}
+		// The abort below only fires if the connection's current fetch stream still carries this
+		// uuid, which makes reaping safe — but ONLY for a unique uuid. Uuid {0,0} is the shared
+		// sentinel for internal catalogue traffic (quack_catalog.cpp) and is reused across queries,
+		// so a decision made for one {0,0} query could abort the next. Skip it: every real client
+		// query carries a random uuid, so the timeout still covers all of them.
+		if (connection.query_uuid == hugeint_t {0, 0}) {
+			return;
+		}
 		if (now.value - connection.query_started_at.value <= deadline_us) {
 			return;
 		}
@@ -378,7 +386,8 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, timestamp
 	}
 	std::unique_lock<std::mutex> lock(connection.lock);
 	if (connection.query_state == QuackQueryState::ACTIVE && connection.query_uuid == uuid) {
-		connection.query_state = QuackQueryState::QUACK_ERROR;
+		// A timeout is a server-initiated cancel, so mirror the CANCEL_REQUEST terminal state.
+		connection.query_state = QuackQueryState::CANCELLED;
 		connection.ClearResultCache();
 	}
 }
@@ -412,7 +421,9 @@ void QuackServer::ReaperLoop() {
 			}
 		}
 		auto now = Timestamp::GetCurrentTimestamp();
-		auto deadline_us = static_cast<int64_t>(timeout_seconds) * 1000000LL; // query_started_at is micros
+		// Clamp before converting to microseconds so the multiply cannot overflow int64. A timeout
+		// this large is effectively "never" anyway (~292,000 years). query_started_at is micros.
+		auto deadline_us = static_cast<int64_t>(MinValue<idx_t>(timeout_seconds, 9223372036854ULL)) * 1000000LL;
 		for (auto &connection : connections) {
 			ReapConnectionIfOverdue(*connection, now, deadline_us);
 		}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -172,24 +172,38 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 }
 
 //! Like AbortFetchStream, but only aborts if the connection's current fetch stream is still the one
-//! identified by `uuid`. Returns false (touching nothing) if a newer query has since taken the slot,
-//! so a timeout decision made for one query can never abort a query started after it. Call WITHOUT
-//! the statement lock.
+//! identified by `uuid`. Returns false (touching nothing) if a newer query has since taken the slot.
+//!
+//! Unlike AbortFetchStream, the wake (SetError) and Interrupt() happen WHILE fetch.lock is held. A
+//! new PREPARE cannot install a producer until fetch.lock is released, so the connection's running
+//! statement is provably this `uuid` at the moment we interrupt it — never a newer query that raced
+//! in behind us. (The generic AbortFetchStream is called on the same thread that then installs the
+//! next producer, so it has no such race; the reaper fires asynchronously against a live connection,
+//! so it must interrupt under the lock.) The producer join runs after the lock is released. Call
+//! WITHOUT the statement lock.
 static bool AbortFetchStreamIfUuid(QuackConnection &connection, hugeint_t uuid, const string &reason) {
-	DetachedFetchStream detached;
+	std::thread producer;
 	{
 		lock_guard<mutex> guard(connection.fetch.lock);
 		if (connection.fetch.uuid != uuid || !connection.fetch.stream) {
 			return false;
 		}
-		detached.stream = std::move(connection.fetch.stream);
-		detached.thread = std::move(connection.fetch.thread);
+		auto stream = std::move(connection.fetch.stream);
+		producer = std::move(connection.fetch.thread);
 		// the abort reason must not hide a real failure
-		connection.fetch.abort_error = detached.stream->buffer.HasError()
-		                                   ? detached.stream->buffer.GetError()
-		                                   : ErrorData(ExceptionType::INTERRUPT, reason);
+		connection.fetch.abort_error =
+		    stream->buffer.HasError() ? stream->buffer.GetError() : ErrorData(ExceptionType::INTERRUPT, reason);
+		auto was_finished = stream->buffer.Finished();
+		// SetError releases a producer parked on buffer capacity; Interrupt() stops one that is
+		// executing. Both under fetch.lock, so the running statement is still `uuid`.
+		stream->buffer.SetError(ErrorData(ExceptionType::INTERRUPT, reason));
+		if (!was_finished && connection.duckdb_connection) {
+			connection.duckdb_connection->Interrupt();
+		}
 	}
-	AbortDetachedFetch(connection, std::move(detached), reason);
+	if (producer.joinable()) {
+		producer.join();
+	}
 	return true;
 }
 
@@ -334,37 +348,24 @@ QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const 
     : db_ptr(context_p.db), uri(uri_p), token(token_p) {
 	ValidateToken(token);
 	server_hmac_key = GenerateRandomToken(*context_p.db);
-	StartReaper();
+	reaper.Start([] { return milliseconds(1000); }, [this] { ReaperTick(); });
 }
 
 QuackServer::~QuackServer() {
-	StopReaper();
-}
-
-void QuackServer::StartReaper() {
-	reaper_thread = std::thread([this] { ReaperLoop(); });
-}
-
-void QuackServer::StopReaper() {
-	{
-		std::lock_guard<std::mutex> lock(reaper_mutex);
-		reaper_stop = true;
-	}
-	reaper_cv.notify_all();
-	if (reaper_thread.joinable()) {
-		reaper_thread.join();
-	}
+	// Stop the reaper before any member is torn down, so its tick cannot touch a half-destroyed server.
+	reaper.Stop();
 }
 
 //! One query is reaped if its ACTIVE query is older than the deadline. Decision and abort are split
 //! so the abort (which joins the producer thread) never runs under connection.lock, and the abort is
 //! uuid-guarded so it cannot touch a query started since the decision. Internal catalogue traffic
 //! (uuid {0,0}) is sub-millisecond and so never reaches a multi-second deadline.
-void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, timestamp_t now, int64_t deadline_us) {
+void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, time_point<steady_clock> now,
+                                          idx_t timeout_seconds) {
 	hugeint_t uuid {0, 0};
 	{
 		std::unique_lock<std::mutex> lock(connection.lock);
-		if (connection.query_state != QuackQueryState::ACTIVE || connection.query_started_at.value == 0) {
+		if (connection.query_state != QuackQueryState::ACTIVE) {
 			return;
 		}
 		// The abort below only fires if the connection's current fetch stream still carries this
@@ -375,7 +376,9 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, timestamp
 		if (connection.query_uuid == hugeint_t {0, 0}) {
 			return;
 		}
-		if (now.value - connection.query_started_at.value <= deadline_us) {
+		// Whole seconds off a monotonic clock: no overflow, and a backward step just reads as young.
+		auto age = duration_cast<std::chrono::seconds>(now - connection.query_started_steady).count();
+		if (age < 0 || static_cast<idx_t>(age) < timeout_seconds) {
 			return;
 		}
 		uuid = connection.query_uuid;
@@ -392,41 +395,28 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, timestamp
 	}
 }
 
-void QuackServer::ReaperLoop() {
-	while (true) {
-		{
-			std::unique_lock<std::mutex> lock(reaper_mutex);
-			// Wake once a second, or immediately on shutdown.
-			reaper_cv.wait_for(lock, std::chrono::seconds(1), [this] { return reaper_stop; });
-			if (reaper_stop) {
-				return;
-			}
+void QuackServer::ReaperTick() {
+	auto db = db_ptr.lock();
+	if (!db) {
+		return;
+	}
+	idx_t timeout_seconds = QuackGetUBigintSetting(*db, "quack_query_timeout", 0);
+	if (timeout_seconds == 0) {
+		return;
+	}
+	// Copy the shared_ptrs out under the lock, then work unlocked: an abort joins a producer
+	// thread and must not run while active_connections_mutex is held.
+	vector<shared_ptr<QuackConnection>> connections;
+	{
+		std::lock_guard<std::mutex> lock(active_connections_mutex);
+		connections.reserve(active_connections.size());
+		for (auto &entry : active_connections) {
+			connections.push_back(entry.second);
 		}
-		auto db = db_ptr.lock();
-		if (!db) {
-			continue;
-		}
-		idx_t timeout_seconds = QuackGetUBigintSetting(*db, "quack_query_timeout", 0);
-		if (timeout_seconds == 0) {
-			continue;
-		}
-		// Copy the shared_ptrs out under the lock, then work unlocked: an abort joins a producer
-		// thread and must not run while active_connections_mutex is held.
-		vector<shared_ptr<QuackConnection>> connections;
-		{
-			std::lock_guard<std::mutex> lock(active_connections_mutex);
-			connections.reserve(active_connections.size());
-			for (auto &entry : active_connections) {
-				connections.push_back(entry.second);
-			}
-		}
-		auto now = Timestamp::GetCurrentTimestamp();
-		// Clamp before converting to microseconds so the multiply cannot overflow int64. A timeout
-		// this large is effectively "never" anyway (~292,000 years). query_started_at is micros.
-		auto deadline_us = static_cast<int64_t>(MinValue<idx_t>(timeout_seconds, 9223372036854ULL)) * 1000000LL;
-		for (auto &connection : connections) {
-			ReapConnectionIfOverdue(*connection, now, deadline_us);
-		}
+	}
+	auto now = steady_clock::now();
+	for (auto &connection : connections) {
+		ReapConnectionIfOverdue(*connection, now, timeout_seconds);
 	}
 }
 
@@ -852,6 +842,7 @@ unique_ptr<QuackMessage> QuackServer::HandleMessageInternal(DatabaseInstance &db
 			connection.sql_query = prepare_request_message.Query();
 			connection.query_state = QuackQueryState::ACTIVE;
 			connection.query_started_at = Timestamp::GetCurrentTimestamp();
+			connection.query_started_steady = steady_clock::now();
 			connection.query_uuid = prepare_request_message.QueryUUID();
 		}
 

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -186,7 +186,9 @@ static bool AbortFetchStreamIfUuid(QuackConnection &connection, hugeint_t uuid, 
 	std::thread producer;
 	{
 		lock_guard<mutex> guard(connection.fetch.lock);
-		if (connection.fetch.uuid != uuid || !connection.fetch.stream) {
+		// A newer query took the slot (or it already finished) since the reaper's decision — leave it.
+		bool still_the_reaped_query = connection.fetch.stream && connection.fetch.uuid == uuid;
+		if (!still_the_reaped_query) {
 			return false;
 		}
 		stream = std::move(connection.fetch.stream);
@@ -196,7 +198,8 @@ static bool AbortFetchStreamIfUuid(QuackConnection &connection, hugeint_t uuid, 
 		    stream->buffer.HasError() ? stream->buffer.GetError() : ErrorData(ExceptionType::INTERRUPT, reason);
 		// Interrupt() stays under fetch.lock — that is what proves the running statement is still
 		// `uuid`. It is a non-blocking atomic CAS, safe to hold the lock across.
-		if (!stream->buffer.Finished() && connection.duckdb_connection) {
+		bool still_executing = !stream->buffer.Finished() && connection.duckdb_connection;
+		if (still_executing) {
 			connection.duckdb_connection->Interrupt();
 		}
 	}
@@ -381,7 +384,8 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, time_poin
 		}
 		// Whole seconds off a monotonic clock: no overflow, and a backward step just reads as young.
 		auto age = duration_cast<std::chrono::seconds>(now - connection.query_started_steady).count();
-		if (age < 0 || static_cast<idx_t>(age) < timeout_seconds) {
+		bool within_deadline = age < 0 || static_cast<idx_t>(age) < timeout_seconds;
+		if (within_deadline) {
 			return;
 		}
 		uuid = connection.query_uuid;
@@ -391,7 +395,9 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, time_poin
 		return;
 	}
 	std::unique_lock<std::mutex> lock(connection.lock);
-	if (connection.query_state == QuackQueryState::ACTIVE && connection.query_uuid == uuid) {
+	// Skip if a new query took the slot while we were aborting — leave its state alone.
+	bool still_the_reaped_query = connection.query_state == QuackQueryState::ACTIVE && connection.query_uuid == uuid;
+	if (still_the_reaped_query) {
 		// A timeout is a server-initiated cancel, so mirror the CANCEL_REQUEST terminal state.
 		connection.query_state = QuackQueryState::CANCELLED;
 		connection.ClearResultCache();

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -174,33 +174,36 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 //! Like AbortFetchStream, but only aborts if the connection's current fetch stream is still the one
 //! identified by `uuid`. Returns false (touching nothing) if a newer query has since taken the slot.
 //!
-//! Unlike AbortFetchStream, the wake (SetError) and Interrupt() happen WHILE fetch.lock is held. A
-//! new PREPARE cannot install a producer until fetch.lock is released, so the connection's running
-//! statement is provably this `uuid` at the moment we interrupt it — never a newer query that raced
-//! in behind us. (The generic AbortFetchStream is called on the same thread that then installs the
-//! next producer, so it has no such race; the reaper fires asynchronously against a live connection,
-//! so it must interrupt under the lock.) The producer join runs after the lock is released. Call
-//! WITHOUT the statement lock.
+//! Unlike AbortFetchStream, Interrupt() happens WHILE fetch.lock is held. A new PREPARE cannot
+//! install a producer until fetch.lock is released, so the connection's running statement is provably
+//! this `uuid` at the moment we interrupt it — never a newer query that raced in behind us. (The
+//! generic AbortFetchStream is called on the same thread that then installs the next producer, so it
+//! has no such race; the reaper fires asynchronously against a live connection, so it must interrupt
+//! under the lock.) SetError and the producer join run after the lock is released. Call WITHOUT the
+//! statement lock.
 static bool AbortFetchStreamIfUuid(QuackConnection &connection, hugeint_t uuid, const string &reason) {
+	shared_ptr<QuackFetchStream> stream;
 	std::thread producer;
 	{
 		lock_guard<mutex> guard(connection.fetch.lock);
 		if (connection.fetch.uuid != uuid || !connection.fetch.stream) {
 			return false;
 		}
-		auto stream = std::move(connection.fetch.stream);
+		stream = std::move(connection.fetch.stream);
 		producer = std::move(connection.fetch.thread);
 		// the abort reason must not hide a real failure
 		connection.fetch.abort_error =
 		    stream->buffer.HasError() ? stream->buffer.GetError() : ErrorData(ExceptionType::INTERRUPT, reason);
-		auto was_finished = stream->buffer.Finished();
-		// SetError releases a producer parked on buffer capacity; Interrupt() stops one that is
-		// executing. Both under fetch.lock, so the running statement is still `uuid`.
-		stream->buffer.SetError(ErrorData(ExceptionType::INTERRUPT, reason));
-		if (!was_finished && connection.duckdb_connection) {
+		// Interrupt() stays under fetch.lock — that is what proves the running statement is still
+		// `uuid`. It is a non-blocking atomic CAS, safe to hold the lock across.
+		if (!stream->buffer.Finished() && connection.duckdb_connection) {
 			connection.duckdb_connection->Interrupt();
 		}
 	}
+	// SetError releases a producer parked on buffer capacity. It targets the captured `stream`, which
+	// a new PREPARE can never re-install, so it stays uuid-safe outside the lock — and is kept out so
+	// the executor reschedule it can trigger does not run under fetch.lock.
+	stream->buffer.SetError(ErrorData(ExceptionType::INTERRUPT, reason));
 	if (producer.joinable()) {
 		producer.join();
 	}

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -379,7 +379,8 @@ void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, time_poin
 		// sentinel for internal catalogue traffic (quack_catalog.cpp) and is reused across queries,
 		// so a decision made for one {0,0} query could abort the next. Skip it: every real client
 		// query carries a random uuid, so the timeout still covers all of them.
-		if (connection.query_uuid == hugeint_t {0, 0}) {
+		bool is_internal_catalogue_query = connection.query_uuid == hugeint_t {0, 0};
+		if (is_internal_catalogue_query) {
 			return;
 		}
 		// Whole seconds off a monotonic clock: no overflow, and a backward step just reads as young.

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -171,6 +171,28 @@ static void AbortFetchStream(QuackConnection &connection, const string &reason) 
 	AbortDetachedFetch(connection, std::move(detached), reason);
 }
 
+//! Like AbortFetchStream, but only aborts if the connection's current fetch stream is still the one
+//! identified by `uuid`. Returns false (touching nothing) if a newer query has since taken the slot,
+//! so a timeout decision made for one query can never abort a query started after it. Call WITHOUT
+//! the statement lock.
+static bool AbortFetchStreamIfUuid(QuackConnection &connection, hugeint_t uuid, const string &reason) {
+	DetachedFetchStream detached;
+	{
+		lock_guard<mutex> guard(connection.fetch.lock);
+		if (connection.fetch.uuid != uuid || !connection.fetch.stream) {
+			return false;
+		}
+		detached.stream = std::move(connection.fetch.stream);
+		detached.thread = std::move(connection.fetch.thread);
+		// the abort reason must not hide a real failure
+		connection.fetch.abort_error = detached.stream->buffer.HasError()
+		                                   ? detached.stream->buffer.GetError()
+		                                   : ErrorData(ExceptionType::INTERRUPT, reason);
+	}
+	AbortDetachedFetch(connection, std::move(detached), reason);
+	return true;
+}
+
 //! Update the cache with what its stream holds. Drops the cache when the result grows past
 //! quack_cache_max_rows, because it is then too large to keep for a reconnect.
 static void SyncFetchCache(QuackConnection &connection, QuackFetchStream &stream, DatabaseInstance &db) {
@@ -312,9 +334,89 @@ QuackServer::QuackServer(ClientContext &context_p, const QuackUri &uri_p, const 
     : db_ptr(context_p.db), uri(uri_p), token(token_p) {
 	ValidateToken(token);
 	server_hmac_key = GenerateRandomToken(*context_p.db);
+	StartReaper();
 }
 
 QuackServer::~QuackServer() {
+	StopReaper();
+}
+
+void QuackServer::StartReaper() {
+	reaper_thread = std::thread([this] { ReaperLoop(); });
+}
+
+void QuackServer::StopReaper() {
+	{
+		std::lock_guard<std::mutex> lock(reaper_mutex);
+		reaper_stop = true;
+	}
+	reaper_cv.notify_all();
+	if (reaper_thread.joinable()) {
+		reaper_thread.join();
+	}
+}
+
+//! One query is reaped if its ACTIVE query is older than the deadline. Decision and abort are split
+//! so the abort (which joins the producer thread) never runs under connection.lock, and the abort is
+//! uuid-guarded so it cannot touch a query started since the decision. Internal catalogue traffic
+//! (uuid {0,0}) is sub-millisecond and so never reaches a multi-second deadline.
+void QuackServer::ReapConnectionIfOverdue(QuackConnection &connection, timestamp_t now, int64_t deadline_us) {
+	hugeint_t uuid {0, 0};
+	{
+		std::unique_lock<std::mutex> lock(connection.lock);
+		if (connection.query_state != QuackQueryState::ACTIVE || connection.query_started_at.value == 0) {
+			return;
+		}
+		if (now.value - connection.query_started_at.value <= deadline_us) {
+			return;
+		}
+		uuid = connection.query_uuid;
+	}
+	// Interrupt() lives inside the abort; guarded so a superseding query is never aborted.
+	if (!AbortFetchStreamIfUuid(connection, uuid, "Interrupted: query exceeded quack_query_timeout")) {
+		return;
+	}
+	std::unique_lock<std::mutex> lock(connection.lock);
+	if (connection.query_state == QuackQueryState::ACTIVE && connection.query_uuid == uuid) {
+		connection.query_state = QuackQueryState::QUACK_ERROR;
+		connection.ClearResultCache();
+	}
+}
+
+void QuackServer::ReaperLoop() {
+	while (true) {
+		{
+			std::unique_lock<std::mutex> lock(reaper_mutex);
+			// Wake once a second, or immediately on shutdown.
+			reaper_cv.wait_for(lock, std::chrono::seconds(1), [this] { return reaper_stop; });
+			if (reaper_stop) {
+				return;
+			}
+		}
+		auto db = db_ptr.lock();
+		if (!db) {
+			continue;
+		}
+		idx_t timeout_seconds = QuackGetUBigintSetting(*db, "quack_query_timeout", 0);
+		if (timeout_seconds == 0) {
+			continue;
+		}
+		// Copy the shared_ptrs out under the lock, then work unlocked: an abort joins a producer
+		// thread and must not run while active_connections_mutex is held.
+		vector<shared_ptr<QuackConnection>> connections;
+		{
+			std::lock_guard<std::mutex> lock(active_connections_mutex);
+			connections.reserve(active_connections.size());
+			for (auto &entry : active_connections) {
+				connections.push_back(entry.second);
+			}
+		}
+		auto now = Timestamp::GetCurrentTimestamp();
+		auto deadline_us = static_cast<int64_t>(timeout_seconds) * 1000000LL; // query_started_at is micros
+		for (auto &connection : connections) {
+			ReapConnectionIfOverdue(*connection, now, deadline_us);
+		}
+	}
 }
 
 void QuackServer::CleanupExpiredConnection(QuackConnection &connection) {

--- a/test/sql/query_timeout.test
+++ b/test/sql/query_timeout.test
@@ -1,16 +1,27 @@
 # name: test/sql/query_timeout.test
-# description: quack_query_timeout interrupts a query that runs past the deadline
+# description: quack_query_timeout interrupts a query that runs past the deadline, and only then
 # group: [sql]
 
 include test/template/quack_setup.test_template
+
+statement ok
+ATTACH {server} AS remote (TOKEN 'asdf');
+
+# Off by default: a query that outlives a reaper tick still completes untouched.
+query I
+SELECT current_setting('quack_query_timeout');
+----
+0
+
+query I
+FROM quack_query_by_name('remote', 'SELECT sleep_ms(1500)');
+----
+NULL
 
 # Arm a 2-second timeout on the SERVER database — the reaper reads the server's config.
 # GLOBAL scope + a live read each tick means it applies without restarting the server.
 statement ok quack_db:quack_server_con
 SET quack_query_timeout=2;
-
-statement ok
-ATTACH {server} AS remote (TOKEN 'asdf');
 
 # A query that would run for 8s server-side is interrupted by the reaper within a few seconds.
 statement error
@@ -18,9 +29,29 @@ FROM quack_query_by_name('remote', 'SELECT sleep_ms(8000)');
 ----
 Interrupt
 
-# The same connection is reusable, and a query that finishes inside the deadline is untouched.
+# The same connection is reusable afterwards.
 query I
 FROM quack_query_by_name('remote', 'SELECT sleep_ms(200)');
+----
+NULL
+
+# Legitimate queries that finish inside the deadline are never reaped, even in a rapid burst
+# while the timeout is armed — this is the identity guard holding under churn.
+loop i 0 8
+
+query I
+FROM quack_query_by_name('remote', 'SELECT sleep_ms(150)');
+----
+NULL
+
+endloop
+
+# Disabling it live (back to 0) takes effect on the next tick: the same long query now completes.
+statement ok quack_db:quack_server_con
+SET quack_query_timeout=0;
+
+query I
+FROM quack_query_by_name('remote', 'SELECT sleep_ms(3000)');
 ----
 NULL
 

--- a/test/sql/query_timeout.test
+++ b/test/sql/query_timeout.test
@@ -1,0 +1,27 @@
+# name: test/sql/query_timeout.test
+# description: quack_query_timeout interrupts a query that runs past the deadline
+# group: [sql]
+
+include test/template/quack_setup.test_template
+
+# Arm a 2-second timeout on the SERVER database — the reaper reads the server's config.
+# GLOBAL scope + a live read each tick means it applies without restarting the server.
+statement ok quack_db:quack_server_con
+SET quack_query_timeout=2;
+
+statement ok
+ATTACH {server} AS remote (TOKEN 'asdf');
+
+# A query that would run for 8s server-side is interrupted by the reaper within a few seconds.
+statement error
+FROM quack_query_by_name('remote', 'SELECT sleep_ms(8000)');
+----
+Interrupt
+
+# The same connection is reusable, and a query that finishes inside the deadline is untouched.
+query I
+FROM quack_query_by_name('remote', 'SELECT sleep_ms(200)');
+----
+NULL
+
+include test/template/quack_teardown.test_template

--- a/test/sql/query_timeout.test
+++ b/test/sql/query_timeout.test
@@ -35,7 +35,7 @@ Interrupt
 # ...and the interrupt must arrive well before the 8s it would otherwise run: proof it was reaped
 # at the ~2s deadline (+ up to a 1s tick), not merely that some Interrupt error surfaced.
 query I
-SELECT (SELECT epoch_ms(current_timestamp::TIMESTAMP)) - getvariable('t0') < 6000;
+SELECT (SELECT epoch_ms(current_timestamp::TIMESTAMP)) - getvariable('t0') < 7500;
 ----
 true
 

--- a/test/sql/query_timeout.test
+++ b/test/sql/query_timeout.test
@@ -24,10 +24,20 @@ statement ok quack_db:quack_server_con
 SET quack_query_timeout=2;
 
 # A query that would run for 8s server-side is interrupted by the reaper within a few seconds.
+statement ok
+SET VARIABLE t0 = (SELECT epoch_ms(current_timestamp::TIMESTAMP));
+
 statement error
 FROM quack_query_by_name('remote', 'SELECT sleep_ms(8000)');
 ----
 Interrupt
+
+# ...and the interrupt must arrive well before the 8s it would otherwise run: proof it was reaped
+# at the ~2s deadline (+ up to a 1s tick), not merely that some Interrupt error surfaced.
+query I
+SELECT (SELECT epoch_ms(current_timestamp::TIMESTAMP)) - getvariable('t0') < 6000;
+----
+true
 
 # The same connection is reusable afterwards.
 query I


### PR DESCRIPTION
Closes #257.

## What

Adds a `quack_query_timeout` global setting (seconds, `0` = off, the default) and a per-server background **reaper** that interrupts any SELECT-style query that has run past the deadline.

This addresses both halves of #257:

1. **No query-execution timeout existed** — a single expensive query could pin the server's CPU with no bound.
2. **A disconnected client's running query was never reclaimed** — the heartbeat lease is only re-evaluated when a *fresh* message arrives on the connection, which a dead client never sends. An orphaned running query is just an `ACTIVE` query no one will cancel, so the same reaper catches it.

## How

The reaper reuses the existing `QuackPeriodicWorker` (as the client heartbeat does). Each tick (~1s) it reads `quack_query_timeout`; if non-zero, it snapshots `active_connections` and, for any connection whose `ACTIVE` query started more than the timeout ago, fires the existing abort + `Interrupt()` machinery from the `CANCEL_REQUEST` path.

Design points that keep it correct:

- **Interrupt under `fetch.lock`.** `duckdb_connection->Interrupt()` is connection-global, so it must fire while the reaper can prove the running statement is the query it decided to reap. Holding `fetch.lock` across the `Interrupt()` guarantees that — a new PREPARE cannot install a producer until the lock is released. `SetError` and the producer `join()` run after the lock is released, so the executor reschedule stays off the lock.
- **Identity guard.** The decision captures the query's uuid under `connection.lock`; the abort only fires if the connection's current fetch stream still carries it. Client queries always carry a random uuid, so this is unique per install.
- **`{0,0}` sentinel skipped.** Internal catalogue traffic reuses uuid `{0,0}`, so it is excluded from reaping (reaping a reused sentinel could target the wrong query). Every real client query has a random uuid and is covered.
- **Monotonic deadline.** The deadline is measured off `steady_clock`, so an NTP/DST jump can neither interrupt a young query nor defer the timeout. Wall-clock `query_started_at` is kept for `quack_active_connections` display only.

DuckDB deliberately ships no built-in statement timeout ([duckdb/duckdb#8564](https://github.com/duckdb/duckdb/issues/8564)) and points to `interrupt()` from another thread as the supported path — which is exactly what this uses.

## Scope / trade-offs

- **SELECT-style queries only.** INSERT/`SEND_DATA` streams are not reaped. An abandoned INSERT blocks waiting for client data rather than burning CPU, so it is bounded by the heartbeat-lease reclaim (#225 territory), not this CPU timeout.
- **Granularity ~1s.** A `timeout=1` query can run up to ~2s (deadline + one tick).
- The timeout bounds query-start → final-fetch, i.e. total server-side streaming time, not pure execution.

## Test

`test/sql/query_timeout.test`: off-by-default is a true no-op; an over-deadline query is interrupted and the connection stays reusable; a rapid burst of sub-deadline queries is never spuriously reaped; disabling the setting live takes effect on the next tick. A wall-time assertion confirms the interrupt arrives well under the query's full runtime (proof it was reaped, not merely that an Interrupt surfaced). Adjacent concurrency tests (`cancellations`, `heartbeat_lifecycle`, `heartbeat_config`, `attach`, `fetch_cancel_insert`) still pass.

## Open questions for maintainers

1. `{0,0}` catalogue queries are skipped by the reaper (the exclusion is what makes the uuid guard sound). Fine to leave, or add a generation counter so they can be covered too?
2. The `FINISHED` transition in the PREPARE/FETCH paths isn't under `connection.lock`; a query finishing exactly on a tick boundary can have its result-cache dropped by the reaper (cosmetic, only observable with `quack_enable_reconnects`). Move those writes under the lock, or leave it?
3. Want a socket-close → `interrupt()` hook for *prompt* disconnect reclaim on top of the deadline-based reclaim, here or as a follow-up?
