### PR TITLE
Fix data race when snapshotting active connection query state

### DIFF
--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -359,15 +359,32 @@ void QuackServer::DestroyCachesDetached(vector<unique_ptr<QuackResultCache>> doo
 }
 
 vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
+	// The session fields (sql_query, query_state, query_started_at) are written under
+	// QuackConnection::lock, so reading them under active_connections_mutex alone is a data race —
+	// and sql_query is a std::string, so a concurrent write can free the storage we copy. Copy the
+	// connection handles out under active_connections_mutex, release it, then read each connection's
+	// fields under its own lock (never holding both mutex classes at once).
+	vector<shared_ptr<QuackConnection>> connections;
+	{
+		std::lock_guard<std::mutex> lock(active_connections_mutex);
+		connections.reserve(active_connections.size());
+		for (auto &[id, conn] : active_connections) {
+			connections.push_back(conn);
+		}
+	}
 	vector<QuackConnectionSnapshot> result;
-	std::lock_guard<std::mutex> lock(active_connections_mutex);
-	for (auto &[id, conn] : active_connections) {
+	result.reserve(connections.size());
+	for (auto &conn : connections) {
 		QuackConnectionSnapshot snapshot;
+		// session_id and client_id_hash are set at construction and never rewritten.
 		snapshot.session_id = conn->session_id;
 		snapshot.client_id_hash = conn->client_id_hash;
-		snapshot.sql_query = conn->sql_query;
-		snapshot.query_state = conn->query_state;
-		snapshot.query_started_at = conn->query_started_at;
+		{
+			std::lock_guard<std::mutex> lock(conn->lock);
+			snapshot.sql_query = conn->sql_query;
+			snapshot.query_state = conn->query_state;
+			snapshot.query_started_at = conn->query_started_at;
+		}
 		auto cached_rows = conn->cached_rows.load();
 		if (cached_rows != DConstants::INVALID_INDEX) {
 			snapshot.cached_rows = cached_rows;

--- a/src/quack_server.cpp
+++ b/src/quack_server.cpp
@@ -359,9 +359,10 @@ void QuackServer::DestroyCachesDetached(vector<unique_ptr<QuackResultCache>> doo
 }
 
 vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
-	// The session fields (sql_query, query_state, query_started_at) are written under
-	// QuackConnection::lock, so reading them under active_connections_mutex alone is a data race —
-	// and sql_query is a std::string, so a concurrent write can free the storage we copy. Copy the
+	// sql_query and query_started_at are written under QuackConnection::lock, so reading them under
+	// active_connections_mutex alone is a data race — and sql_query is a std::string, so a concurrent
+	// write can free the storage we copy. (query_state is atomic and would be safe unlocked, but we
+	// read it in the same critical section for a snapshot consistent with the other two.) Copy the
 	// connection handles out under active_connections_mutex, release it, then read each connection's
 	// fields under its own lock (never holding both mutex classes at once).
 	vector<shared_ptr<QuackConnection>> connections;
@@ -376,7 +377,8 @@ vector<QuackConnectionSnapshot> QuackServer::GetActiveConnectionSnap() {
 	result.reserve(connections.size());
 	for (auto &conn : connections) {
 		QuackConnectionSnapshot snapshot;
-		// session_id and client_id_hash are set at construction and never rewritten.
+		// session_id and client_id_hash are set once when the connection is created, before it is
+		// published to active_connections, and never rewritten — so they need no lock here.
 		snapshot.session_id = conn->session_id;
 		snapshot.client_id_hash = conn->client_id_hash;
 		{


### PR DESCRIPTION
Closes #223.

## Problem

`QuackServer::GetActiveConnectionSnap()` read `sql_query`, `query_state` and `query_started_at` under `active_connections_mutex`, while `HandleMessageInternal()` (the PREPARE path) writes those same fields under `QuackConnection::lock`. The two mutexes don't synchronize those accesses, so it is a C++ data race. `sql_query` is a `std::string`, so a concurrent reassignment can free the storage the snapshot is copying from.

## Fix

The exact shape the issue suggested, and the same pattern the server already uses elsewhere for per-connection work:

1. Under `active_connections_mutex`, copy the `shared_ptr<QuackConnection>` handles into a local vector.
2. Release `active_connections_mutex`.
3. For each connection, take its own `lock` and copy the session fields.

Never holds both mutex classes at once, so there is no lock-ordering inversion. `session_id`/`client_id_hash` are set at construction and never rewritten, so they stay outside the lock; `cached_rows` is atomic.

## Test

Existing coverage exercises `quack_active_connections()` under concurrency (`cancellations.test` queries it from one thread while a slow query runs on another); it and the adjacent connection/heartbeat tests still pass.
