### PR TITLE
Add support for creating a secret to quack_serve if there is no secret yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ CALL quack_serve();                -- default secret, listens on quack:localhost
 ```
 
 If no secret matches and no `token` is given, `quack_serve` generates a random token and
-returns it in the `auth_token` column.
+returns it in the `auth_token` column. To keep that token across restarts, ask for it to be
+persisted:
+
+```sql
+CALL quack_serve(create_secret_if_not_exists = true);
+```
+
+This writes the token to a persistent default secret (`__default_quack`, scoped to `quack:`), so
+the next `quack_serve` - and any client on the machine - reuses the same token. It only does so
+when there is nothing to reuse yet: if a secret was named with `secret =`, or a default secret
+already matches, nothing is written.
 
 ### Connecting through a secret
 

--- a/src/include/quack_secret.hpp
+++ b/src/include/quack_secret.hpp
@@ -18,6 +18,8 @@ class QuackSecret {
 public:
 	//! The name of the quack secret type
 	static constexpr const char *TYPE = "quack";
+	//! The name DuckDB gives an unnamed `CREATE SECRET (TYPE quack, ...)`, i.e. the default quack secret
+	static constexpr const char *DEFAULT_NAME = "__default_quack";
 
 	//! How far an unnamed lookup may go. A secret scope is a match prefix, so a path that carries no endpoint
 	//! of its own (`quack_serve()`, `ATTACH 'quack:'`) only ever matches the catch-all `quack:` scope. There
@@ -36,6 +38,9 @@ public:
 	static bool TryGetEndpoint(const SecretEntry &entry, string &result);
 	//! The token stored in the secret - throws when the secret does not carry one
 	static string GetToken(const SecretEntry &entry);
+	//! Persist `token` as the default quack secret, so later sessions and clients pick it up without being
+	//! told the token. Does nothing when a secret of that name already exists.
+	static void CreateDefault(ClientContext &context, const string &token);
 };
 
 } // namespace duckdb

--- a/src/quack_secret.cpp
+++ b/src/quack_secret.cpp
@@ -78,6 +78,18 @@ bool QuackSecret::TryGetEndpoint(const SecretEntry &entry, string &result) {
 	return found;
 }
 
+void QuackSecret::CreateDefault(ClientContext &context, const string &token) {
+	CreateSecretInput input;
+	input.type = Identifier(TYPE);
+	input.name = Identifier(DEFAULT_NAME);
+	// an empty scope leaves the catch-all `quack:` default in place, exactly like an unnamed CREATE SECRET
+	input.options["token"] = Value(token);
+	input.persist_type = SecretPersistType::PERSISTENT;
+	// the secret is a convenience, so a name that is already taken is not worth failing the server over
+	input.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+	SecretManager::Get(context).CreateSecret(context, input);
+}
+
 string QuackSecret::GetToken(const SecretEntry &entry) {
 	auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*entry.secret);
 	Value token_value;

--- a/src/quack_start_stop.cpp
+++ b/src/quack_start_stop.cpp
@@ -15,6 +15,8 @@ struct QuackStartStopFunctionData : public TableFunctionData {
 	bool finished = false;
 	QuackUri listen_uri;
 	string token;
+	//! Persist the token as the default quack secret once the server is up
+	bool create_secret = false;
 };
 
 static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunctionBindInput &input,
@@ -49,14 +51,17 @@ static unique_ptr<FunctionData> QuackServeBind(ClientContext &context, TableFunc
 		throw InvalidInputException("Cannot specify both token and secret - the secret supplies the token");
 	}
 
-	unique_ptr<SecretEntry> secret;
-	if (!has_token) {
-		// An explicit name selects the secret; without one we use the default secret for this endpoint (if any).
-		// Without a URI the secret decides where we listen, so a lone secret counts as the default one.
-		secret = QuackSecret::Find(context, has_secret_name ? &secret_entry->second : nullptr, listen_uri,
-		                           explicit_uri ? QuackSecret::DefaultLookup::SCOPE_MATCH_ONLY
-		                                        : QuackSecret::DefaultLookup::ALLOW_SINGLE_SECRET);
-	}
+	// An explicit name selects the secret; without one we use the default secret for this endpoint (if any).
+	// Without a URI the secret decides where we listen, so a lone secret counts as the default one.
+	auto secret = QuackSecret::Find(context, has_secret_name ? &secret_entry->second : nullptr, listen_uri,
+	                                explicit_uri ? QuackSecret::DefaultLookup::SCOPE_MATCH_ONLY
+	                                             : QuackSecret::DefaultLookup::ALLOW_SINGLE_SECRET);
+
+	// Nothing to fall back on next time: persist the token we are about to use, if we are asked to.
+	auto create_secret_entry = input.named_parameters.find("create_secret_if_not_exists");
+	bind_data->create_secret = create_secret_entry != input.named_parameters.end() &&
+	                           !create_secret_entry->second.IsNull() && create_secret_entry->second.GetValue<bool>() &&
+	                           !has_secret_name && !secret;
 	if (secret && !explicit_uri) {
 		// No URI was given: a fully-qualified secret scope tells us where to listen.
 		string secret_endpoint;
@@ -101,6 +106,10 @@ static void QuackServe(ClientContext &context, TableFunctionInput &data_p, DataC
 
 	auto &server =
 	    QuackStorageExtensionInfo::GetState(*context.db).CreateServer(context, bind_data.listen_uri, bind_data.token);
+	if (bind_data.create_secret) {
+		// only once the server is actually up: a token that never made it onto a socket is not worth persisting
+		QuackSecret::CreateDefault(context, bind_data.token);
+	}
 	auto &actual_uri = server.ListenUri();
 	output.data[0].SetValue(0, actual_uri.Uri());
 	output.data[1].SetValue(0, actual_uri.Http());
@@ -117,6 +126,7 @@ TableFunctionSet QuackServeFunction::GetFunction() {
 	fun.named_parameters["allow_other_hostname"] = LogicalType::BOOLEAN;
 	fun.named_parameters["token"] = LogicalType::VARCHAR;
 	fun.named_parameters["secret"] = LogicalType::VARCHAR;
+	fun.named_parameters["create_secret_if_not_exists"] = LogicalType::BOOLEAN;
 	set.AddFunction(fun);
 	fun.arguments.clear();
 	set.AddFunction(fun);

--- a/test/sql/serve_create_secret.test
+++ b/test/sql/serve_create_secret.test
@@ -1,0 +1,156 @@
+# name: test/sql/serve_create_secret.test
+# description: quack_serve(create_secret_if_not_exists=true) persists its token as the default quack secret
+# group: [sql]
+
+require quack
+
+require httpfs
+
+statement ok
+SET quack_default_client_id='';
+
+statement ok
+set secret_directory='{TEST_DIR}/quack_serve_create_secret';
+
+# a persistent secret outlives the test run, so start from a known state
+statement ok
+drop secret if exists __default_quack;
+
+# --- 1. The option defaults to false: nothing is created ---
+
+statement ok
+set variable srv = (select {'uri': listen_uri, 'token': auth_token} from quack_serve('quack:localhost:0'));
+
+query I
+select count(*) from duckdb_secrets() where type='quack';
+----
+0
+
+statement ok
+call quack_stop(getvariable('srv').uri);
+
+# --- 2. No secret yet: the token we generated is persisted as the default secret ---
+
+statement ok
+set variable srv = (select {'uri': listen_uri, 'token': auth_token} from quack_serve('quack:localhost:0', create_secret_if_not_exists=true));
+
+query IIII
+select name, type, persistent, scope from duckdb_secrets() where type='quack';
+----
+__default_quack	quack	1	['quack:']
+
+# the secret carries the server token, so a client picks it up without being told
+statement ok
+attach getvariable('srv').uri as r (type quack);
+
+query II
+from r.query('select 1, 2');
+----
+1	2
+
+statement ok
+detach r;
+
+# --- 3. The default secret now exists: the next server reuses its token and creates nothing ---
+
+statement ok
+set variable srv2 = (select {'uri': listen_uri, 'token': auth_token} from quack_serve('quack:localhost:0', create_secret_if_not_exists=true));
+
+query I
+select getvariable('srv2').token = getvariable('srv').token;
+----
+true
+
+query I
+select count(*) from duckdb_secrets() where type='quack';
+----
+1
+
+statement ok
+call quack_stop(getvariable('srv2').uri);
+
+statement ok
+call quack_stop(getvariable('srv').uri);
+
+statement ok
+drop secret __default_quack;
+
+# --- 4. A named secret means we were told which one to use: nothing is created ---
+
+statement ok
+create secret s1 (type quack, token 'token_s1', scope 'quack:localhost:9489');
+
+statement ok
+set variable srv = (select {'uri': listen_uri, 'token': auth_token} from quack_serve('quack:localhost:0', secret='s1', create_secret_if_not_exists=true));
+
+query I
+select getvariable('srv').token;
+----
+token_s1
+
+query I
+select name from duckdb_secrets() where type='quack';
+----
+s1
+
+statement ok
+call quack_stop(getvariable('srv').uri);
+
+statement ok
+drop secret s1;
+
+# --- 5. A default secret already covers us, even a temporary one: nothing is created ---
+
+statement ok
+create secret (type quack, token 'defaulttoken');
+
+statement ok
+set variable srv = (select {'uri': listen_uri, 'token': auth_token} from quack_serve('quack:localhost:0', create_secret_if_not_exists=true));
+
+query I
+select getvariable('srv').token;
+----
+defaulttoken
+
+query II
+select name, persistent from duckdb_secrets() where type='quack';
+----
+__default_quack	0
+
+statement ok
+call quack_stop(getvariable('srv').uri);
+
+statement ok
+drop secret __default_quack;
+
+# --- 6. An explicit token is persisted just the same ---
+
+statement ok
+set variable srv = (select {'uri': listen_uri, 'token': auth_token} from quack_serve('quack:localhost:0', token='explicittoken', create_secret_if_not_exists=true));
+
+query II
+select name, persistent from duckdb_secrets() where type='quack';
+----
+__default_quack	1
+
+statement ok
+attach getvariable('srv').uri as r (type quack);
+
+query II
+from r.query('select 1, 2');
+----
+1	2
+
+statement ok
+detach r;
+
+statement ok
+call quack_stop(getvariable('srv').uri);
+
+statement ok
+drop secret __default_quack;
+
+query I
+select count(*) from quack_server_list();
+----
+0


### PR DESCRIPTION
This PR adds the `create_secret_if_not_exists` setting to `quack_serve`, e.g.:

```sql
CALL quack_serve(create_secret_if_not_exists=true);
```

What this effectively does is it creates a persistent secret with the auto-generated token if no such secret yet exists. This allows following connect statements to use that token, and following `quack_serve` calls to always use the same (still randomly generated) token.