### PR TITLE
Fix ATTACH when remote tables have computed DEFAULTs (#132)

### DIFF
--- a/src/storage/quack_table.cpp
+++ b/src/storage/quack_table.cpp
@@ -4,6 +4,7 @@
 #include "quack_scan.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/parsed_data/alter_info.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "storage/quack_view.hpp"
@@ -15,8 +16,7 @@ unique_ptr<CreateInfo> ParseCreateTable(const string &sql) {
 	parser.ParseQuery(sql);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::CREATE_STATEMENT) {
 		throw BinderException(
-		    "Failed to create view from SQL string - \"%s\" - statement did not contain a single SELECT statement",
-		    sql);
+		    "Failed to parse CREATE TABLE from the remote catalog - \"%s\" - expected a single CREATE statement", sql);
 	}
 	auto &create = parser.statements[0]->Cast<CreateStatement>();
 	return std::move(create.info);
@@ -41,9 +41,20 @@ QuackTableSet::QuackTableSet(ClientContext &context, QuackSchemaCatalogEntry &pa
 			if (info->type != CatalogType::TABLE_ENTRY) {
 				throw InternalException("Expected a CREATE TABLE");
 			}
-			// bind to resolve the types
+			// Bind to resolve the types. SKIP_BINDING leaves the column DEFAULT expressions unbound:
+			// binding them here would resolve functions through the catalog we are still constructing,
+			// which is not registered yet - a computed DEFAULT (now(), 1 + 0, nextval(...)) then aborts
+			// the entire ATTACH with a misleading "Catalog \"...\" does not exist" (issue #132).
+			// The parsed DEFAULT stays on the column and binds on first use, once the catalog exists.
 			auto binder = Binder::CreateBinder(context);
-			auto bound_info = binder->BindCreateTableInfo(std::move(info), schema);
+			unique_ptr<BoundCreateTableInfo> bound_info;
+			try {
+				bound_info = binder->BindCreateTableInfo(std::move(info), schema, AlterBindMode::SKIP_BINDING);
+			} catch (std::exception &ex) {
+				throw BinderException(
+				    "Failed to bind remote table while attaching quack catalog \"%s\" (schema \"%s\"): %s\nSQL: %s",
+				    catalog.GetName().GetIdentifierName(), schema.name.GetIdentifierName(), ex.what(), sql);
+			}
 			auto table = make_uniq<QuackTableCatalogEntry>(catalog, parent, bound_info->Base());
 			entry = std::move(table);
 		} else {

--- a/test/sql/attach_computed_default.test
+++ b/test/sql/attach_computed_default.test
@@ -1,0 +1,66 @@
+# name: test/sql/attach_computed_default.test
+# description: ATTACH must not fail when remote tables have computed DEFAULT expressions (issue #132)
+# group: [sql]
+
+require quack
+
+require httpfs
+
+set ignore_error_messages __none__
+
+foreach server 'quack:localhost'
+
+statement ok con1
+call quack_serve({server}, token='asdf');
+
+# constant default (always worked)
+statement ok con1
+create table t_const (x integer not null default 1);
+
+# computed defaults — previously aborted client ATTACH with "Catalog does not exist"
+statement ok con1
+create table t_expr (x integer not null default 1 + 0);
+
+statement ok con1
+create table t_ts (ts timestamptz default current_timestamp, v integer);
+
+statement ok con1
+insert into t_const default values;
+insert into t_expr default values;
+insert into t_ts (v) values (42);
+
+statement ok con2
+attach {server} as r (token 'asdf')
+
+# catalog must expose all three tables
+query I con2
+select count(*) from r.t_const
+----
+1
+
+query I con2
+select count(*) from r.t_expr
+----
+1
+
+query I con2
+select v from r.t_ts
+----
+42
+
+# remote INSERT DEFAULT still runs server-side
+statement ok con2
+insert into r.t_expr default values
+
+query I con2
+select count(*) from r.t_expr
+----
+2
+
+statement ok con2
+detach r
+
+statement ok con1
+call quack_stop({server})
+
+endloop


### PR DESCRIPTION
Fixes #132.

`ATTACH 'quack://…'` aborts with `Binder Error: Catalog "<alias>" does not exist!` when **any** table in the served database has a DEFAULT that needs catalog resolution (`now()`, `1 + 0`, `nextval(…)`). One such table poisons the ATTACH for the whole catalog.

### Mechanism

`QuackTableSet::LoadEntries` parses each remote `CREATE TABLE` and calls `BindCreateTableInfo`, which rebinds column DEFAULTs client-side. `Binder::BindDefaultValues` builds a binder over `schema.ParentCatalog().GetName()` — the attach alias, which is not registered in the `DatabaseManager` yet, because we are still constructing it. Constant defaults are literals and need no lookup, so they bind; anything requiring function resolution throws.

### Fix

Pass `AlterBindMode::SKIP_BINDING` — the escape hatch `bind_create_table.cpp` already provides. `BindDefaultValues` binds a *copy* (the original is kept for serialization), so the parsed DEFAULT survives on the column and binds on first use, once the catalog exists.

Also included: a real error message when a remote table fails to bind (previously a `CREATE TABLE` failure reported itself as a view-parsing error), naming the catalog, schema and SQL.

### Verified

Against quack `main` + duckdb submodule `f1c54da7` (2026-08-25):

```
INSERT INTO r.t_expr DEFAULT VALUES  ->  x = 1        (NOT NULL satisfied, 1 + 0 applied)
INSERT INTO r.t_ts (v) VALUES (42)   ->  ts NOT NULL  (current_timestamp applied)
```

Full suite: 78 tests, 0 failures. `clang-format`: 0 replacements.

### Why this supersedes #231

#231 stripped defaults with `SetDefaultValue(nullptr)`. That makes the attached table forget the DEFAULT entirely, so `INSERT … DEFAULT VALUES` fails the NOT NULL constraint — it breaks #231's own test at line 52, contradicting that PR's claim that remote `DEFAULT VALUES` still executes. #231 also targeted `v1.5-variegata`; this targets `main`.
